### PR TITLE
Add support for custom filters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,13 +47,6 @@ set_package_properties(Qt6Widgets PROPERTIES TYPE REQUIRED)
 set_package_properties(Qt6Gui PROPERTIES TYPE REQUIRED)
 set_package_properties(Qt6Sql PROPERTIES TYPE REQUIRED)
 
-find_package(
-    Qt6
-    COMPONENTS
-    Test
-)
-set_package_properties(Qt6Test PROPERTIES TYPE OPTIONAL)
-
 find_package(Taglib REQUIRED taglib>=1.12)
 find_package(Libmpv)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 fooyin_option(FOOYIN_STATIC "Build fooyin libraries as static." OFF)
+fooyin_option(BUILD_TESTS "Build fooyin tests." OFF)
 
 find_package(
     Qt6
@@ -46,11 +47,20 @@ set_package_properties(Qt6Widgets PROPERTIES TYPE REQUIRED)
 set_package_properties(Qt6Gui PROPERTIES TYPE REQUIRED)
 set_package_properties(Qt6Sql PROPERTIES TYPE REQUIRED)
 
+find_package(
+    Qt6
+    COMPONENTS
+    Test
+)
+set_package_properties(Qt6Test PROPERTIES TYPE OPTIONAL)
+
 find_package(Taglib REQUIRED taglib>=1.12)
 find_package(Libmpv)
 
 set_package_properties(Taglib PROPERTIES TYPE REQUIRED)
 set_package_properties(Libmpv PROPERTIES TYPE REQUIRED)
+
+find_package(GTest)
 
 #find_package(FFmpeg
 #                COMPONENTS
@@ -102,6 +112,12 @@ target_link_libraries(fooyin_lib
 
 target_compile_features(fooyin_lib PUBLIC cxx_std_17)
 target_compile_options(fooyin_lib PRIVATE -Werror -Wall -Wextra -Wpedantic)
+
+# ---- Fooyin testing ----
+
+if(BUILD_TESTS)
+    add_subdirectory(tests)
+endif()
 
 # ---- Fooyin executable ----
 

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -92,7 +92,7 @@ void Application::startup()
 
     m_mainWindow->setupUi();
 
-    if(m_settingsManager->value<Core::Settings::WaitForTracks>()) {
+    if(m_libraryManager->hasLibrary() && m_settingsManager->value<Core::Settings::WaitForTracks>()) {
         connect(m_library, &Core::Library::MusicLibrary::allTracksLoaded, m_mainWindow.get(), &Gui::MainWindow::show);
     }
     else {
@@ -124,8 +124,8 @@ void Application::registerWidgets()
     });
 
     m_widgetFactory.registerClass<Gui::Widgets::PlaylistWidget>("Playlist", [this]() {
-        return new Gui::Widgets::PlaylistWidget(m_libraryManager, m_playlistHandler, m_playerManager,
-                                                m_settingsManager);
+        return new Gui::Widgets::PlaylistWidget(
+            m_libraryManager, m_playlistHandler, m_playerManager, m_settingsManager);
     });
 
     m_widgetFactory.registerClass<Gui::Widgets::Spacer>("Spacer", []() {

--- a/src/core/constants.h
+++ b/src/core/constants.h
@@ -24,4 +24,30 @@ constexpr auto AppName     = "fooyin";
 constexpr auto DisplayName = "Fooyin";
 
 constexpr auto Separator = "\037"; // ASCII Code 31 - ␟
+
+namespace MetaData {
+constexpr auto Title        = "title";
+constexpr auto Artist       = "artist";
+constexpr auto Album        = "album";
+constexpr auto AlbumArtist  = "albumartist";
+constexpr auto Track        = "track";
+constexpr auto TrackTotal   = "tracktotal";
+constexpr auto Disc         = "disc";
+constexpr auto DiscTotal    = "disctotal";
+constexpr auto Genre        = "genre";
+constexpr auto Composer     = "composer";
+constexpr auto Performer    = "performer";
+constexpr auto Duration     = "duration";
+constexpr auto Lyrics       = "lyrics";
+constexpr auto Comment      = "comment";
+constexpr auto Date         = "date";
+constexpr auto Year         = "year";
+constexpr auto Cover        = "cover";
+constexpr auto FileSize     = "filesize";
+constexpr auto Bitrate      = "bitrate";
+constexpr auto SampleRate   = "samplerate";
+constexpr auto PlayCount    = "playcount";
+constexpr auto AddedTime    = "addedtime";
+constexpr auto ModifiedTime = "modifiedtime";
+} // namespace MetaData
 } // namespace Fy::Core::Constants

--- a/src/core/database/librarydatabase.cpp
+++ b/src/core/database/librarydatabase.cpp
@@ -32,30 +32,30 @@ namespace Fy::Core::DB {
 QMap<QString, QVariant> getTrackBindings(const Track& track)
 {
     return QMap<QString, QVariant>{
-        {QStringLiteral("FilePath"), Utils::File::cleanPath(track.filepath())},
-        {QStringLiteral("Title"), track.title()},
-        {QStringLiteral("TrackNumber"), track.trackNumber()},
-        {QStringLiteral("TrackTotal"), track.trackTotal()},
-        {QStringLiteral("Artists"), track.artists().join(Constants::Separator)},
-        {QStringLiteral("AlbumArtist"), track.albumArtist()},
-        {QStringLiteral("Album"), track.album()},
-        {QStringLiteral("CoverPath"), track.coverPath()},
-        {QStringLiteral("DiscNumber"), track.discNumber()},
-        {QStringLiteral("DiscTotal"), track.discTotal()},
-        {QStringLiteral("Date"), track.date()},
-        {QStringLiteral("Composer"), track.composer()},
-        {QStringLiteral("Performer"), track.performer()},
-        {QStringLiteral("Genres"), track.genres().join(Constants::Separator)},
-        {QStringLiteral("Lyrics"), track.lyrics()},
-        {QStringLiteral("Comment"), track.comment()},
-        {QStringLiteral("Duration"), QVariant::fromValue(track.duration())},
-        {QStringLiteral("FileSize"), QVariant::fromValue(track.fileSize())},
-        {QStringLiteral("BitRate"), track.bitrate()},
-        {QStringLiteral("SampleRate"), track.sampleRate()},
-        {QStringLiteral("ExtraTags"), track.extraTagsToJson()},
-        {QStringLiteral("AddedDate"), QVariant::fromValue(track.addedTime())},
-        {QStringLiteral("ModifiedDate"), QVariant::fromValue(track.modifiedTime())},
-        {QStringLiteral("LibraryID"), track.libraryId()},
+        {QStringLiteral("FilePath"),     Utils::File::cleanPath(track.filepath())  },
+        {QStringLiteral("Title"),        track.title()                             },
+        {QStringLiteral("TrackNumber"),  track.trackNumber()                       },
+        {QStringLiteral("TrackTotal"),   track.trackTotal()                        },
+        {QStringLiteral("Artists"),      track.artists().join(Constants::Separator)},
+        {QStringLiteral("AlbumArtist"),  track.albumArtist()                       },
+        {QStringLiteral("Album"),        track.album()                             },
+        {QStringLiteral("CoverPath"),    track.coverPath()                         },
+        {QStringLiteral("DiscNumber"),   track.discNumber()                        },
+        {QStringLiteral("DiscTotal"),    track.discTotal()                         },
+        {QStringLiteral("Date"),         track.date()                              },
+        {QStringLiteral("Composer"),     track.composer()                          },
+        {QStringLiteral("Performer"),    track.performer()                         },
+        {QStringLiteral("Genres"),       track.genres().join(Constants::Separator) },
+        {QStringLiteral("Lyrics"),       track.lyrics()                            },
+        {QStringLiteral("Comment"),      track.comment()                           },
+        {QStringLiteral("Duration"),     QVariant::fromValue(track.duration())     },
+        {QStringLiteral("FileSize"),     QVariant::fromValue(track.fileSize())     },
+        {QStringLiteral("BitRate"),      track.bitrate()                           },
+        {QStringLiteral("SampleRate"),   track.sampleRate()                        },
+        {QStringLiteral("ExtraTags"),    track.extraTagsToJson()                   },
+        {QStringLiteral("AddedDate"),    QVariant::fromValue(track.addedTime())    },
+        {QStringLiteral("ModifiedDate"), QVariant::fromValue(track.modifiedTime()) },
+        {QStringLiteral("LibraryID"),    track.libraryId()                         },
     };
 }
 
@@ -185,7 +185,10 @@ QString LibraryDatabase::fetchQueryTracks(const QString& where, const QString& j
     const auto joinedFields = fields.join(", ");
 
     return QString("SELECT %1 FROM Tracks %2 WHERE %3 ORDER BY %4 %5;")
-        .arg(joinedFields, join.isEmpty() ? "" : join, where.isEmpty() ? "1" : where, order.isEmpty() ? "1" : order,
+        .arg(joinedFields,
+             join.isEmpty() ? "" : join,
+             where.isEmpty() ? "1" : where,
+             order.isEmpty() ? "1" : order,
              offsetLimit);
 }
 
@@ -205,7 +208,7 @@ bool LibraryDatabase::dbFetchTracks(Query& q, TrackList& result)
         track.setTitle(q.value(2).toString());
         track.setTrackNumber(q.value(3).toInt());
         track.setTrackTotal(q.value(4).toInt());
-        track.setArtists(q.value(5).toString().split(Constants::Separator));
+        track.setArtists(q.value(5).toString().split(Constants::Separator, Qt::SkipEmptyParts));
         track.setAlbumArtist(q.value(6).toString());
         track.setAlbum(q.value(7).toString());
         track.setCoverPath(q.value(8).toString());
@@ -214,7 +217,7 @@ bool LibraryDatabase::dbFetchTracks(Query& q, TrackList& result)
         track.setDate(q.value(11).toString());
         track.setComposer(q.value(12).toString());
         track.setPerformer(q.value(13).toString());
-        track.setGenres(q.value(14).toString().split(Constants::Separator));
+        track.setGenres(q.value(14).toString().split(Constants::Separator, Qt::SkipEmptyParts));
         track.setLyrics(q.value(15).toString());
         track.setComment(q.value(16).toString());
         track.setDuration(q.value(17).value<uint64_t>());
@@ -245,8 +248,8 @@ bool LibraryDatabase::updateTrack(const Track& track)
 
     auto bindings = getTrackBindings(track);
 
-    const auto q = module()->update("Tracks", bindings, {"TrackID", track.id()},
-                                    QString("Cannot update track %1").arg(track.filepath()));
+    const auto q = module()->update(
+        "Tracks", bindings, {"TrackID", track.id()}, QString("Cannot update track %1").arg(track.filepath()));
 
     return !q.hasError();
 }

--- a/src/core/models/track.cpp
+++ b/src/core/models/track.cpp
@@ -19,34 +19,43 @@
 
 #include "track.h"
 
+#include "core/constants.h"
+
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 
 namespace Fy::Core {
+Track::Track()
+    : Track("")
+{ }
+
 Track::Track(QString filepath)
-    : MusicItem()
-    , m_enabled{true}
+    : m_enabled{true}
     , m_libraryId{-1}
     , m_id{-1}
     , m_filepath{std::move(filepath)}
-    , m_trackNumber{0}
-    , m_trackTotal{0}
-    , m_discNumber{0}
-    , m_discTotal{0}
+    , m_trackNumber{-1}
+    , m_trackTotal{-1}
+    , m_discNumber{-1}
+    , m_discTotal{-1}
     , m_duration{0}
     , m_filesize{0}
-    , m_bitrate{0}
-    , m_sampleRate{0}
+    , m_bitrate{-1}
+    , m_sampleRate{-1}
     , m_playcount{0}
+    , m_addedTime{0}
     , m_modifiedTime{0}
 { }
 
 QString Track::generateHash()
 {
-    m_hash = QString{"%1|%2|%3|%4.%5|%6"}.arg(
-        m_artists.join(","), m_album, QString::number(m_year), QString::number(m_discNumber),
-        QStringLiteral("%1").arg(m_trackNumber, 2, 10, QLatin1Char('0')), QString::number(m_duration));
+    m_hash = QString{"%1|%2|%3|%4.%5|%6"}.arg(m_artists.join(","),
+                                              m_album,
+                                              QString::number(m_year),
+                                              QString::number(m_discNumber),
+                                              QStringLiteral("%1").arg(m_trackNumber, 2, 10, QLatin1Char('0')),
+                                              QString::number(m_duration));
     return m_hash;
 }
 
@@ -85,6 +94,11 @@ QStringList Track::artists() const
     return m_artists;
 }
 
+QString Track::artist() const
+{
+    return m_artists.join(Constants::Separator);
+}
+
 QString Track::album() const
 {
     return m_album;
@@ -118,6 +132,11 @@ int Track::discTotal() const
 QStringList Track::genres() const
 {
     return m_genres;
+}
+
+QString Track::genre() const
+{
+    return m_genres.join(Constants::Separator);
 }
 
 QString Track::composer() const

--- a/src/core/models/track.h
+++ b/src/core/models/track.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include "core/typedefs.h"
 #include "musicitem.h"
 
 #include <QList>
@@ -32,7 +31,7 @@ using ExtraTags = std::map<QString, QList<QString>>;
 class Track : public MusicItem
 {
 public:
-    Track() = default;
+    Track();
     explicit Track(QString filepath);
 
     QString generateHash();
@@ -46,6 +45,7 @@ public:
     [[nodiscard]] QString filepath() const;
     [[nodiscard]] QString title() const;
     [[nodiscard]] QStringList artists() const;
+    [[nodiscard]] QString artist() const;
     [[nodiscard]] QString album() const;
     [[nodiscard]] QString albumArtist() const;
     [[nodiscard]] int trackNumber() const;
@@ -53,6 +53,7 @@ public:
     [[nodiscard]] int discNumber() const;
     [[nodiscard]] int discTotal() const;
     [[nodiscard]] QStringList genres() const;
+    [[nodiscard]] QString genre() const;
     [[nodiscard]] QString composer() const;
     [[nodiscard]] QString performer() const;
     [[nodiscard]] uint64_t duration() const;
@@ -128,7 +129,6 @@ private:
     int m_trackTotal;
     int m_discNumber;
     int m_discTotal;
-    IdSet m_genreIds;
     QStringList m_genres;
     QString m_composer;
     QString m_performer;

--- a/src/core/models/trackfwd.h
+++ b/src/core/models/trackfwd.h
@@ -23,6 +23,7 @@
 #include "artist.h"
 #include "track.h"
 
+#include <set>
 #include <unordered_map>
 
 namespace Fy::Core {

--- a/src/core/scripting/expression.h
+++ b/src/core/scripting/expression.h
@@ -1,6 +1,6 @@
 /*
  * Fooyin
- * Copyright 2022, Luke Taylor <LukeT1@proton.me>
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
  *
  * Fooyin is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,11 +19,34 @@
 
 #pragma once
 
-#include "core/scripting/scriptvalue.h"
+#include <QString>
 
 namespace Fy::Core::Scripting {
-ScriptResult cif(const ValueList& vec);
-ScriptResult ifequal(const ValueList& vec);
-ScriptResult ifgreater(const ValueList& vec);
-ScriptResult iflonger(const ValueList& vec);
-}
+enum ExprType : int
+{
+    Literal     = 0,
+    Variable    = 1,
+    Function    = 2,
+    FunctionArg = 3,
+    Conditional = 4,
+    Null        = 5
+};
+
+struct Expression;
+
+struct FuncValue
+{
+    QString name;
+    std::vector<Expression> args;
+};
+
+using ExpressionList = std::vector<Expression>;
+
+using ExpressionValue = std::variant<QString, FuncValue, ExpressionList>;
+
+struct Expression
+{
+    ExprType type{Null};
+    ExpressionValue value{""};
+};
+} // namespace Fy::Core::Scripting

--- a/src/core/scripting/functions/controlfuncs.cpp
+++ b/src/core/scripting/functions/controlfuncs.cpp
@@ -20,7 +20,7 @@
 #include "controlfuncs.h"
 
 namespace Fy::Core::Scripting {
-Value cif(const ValueList& vec)
+ScriptResult cif(const ValueList& vec)
 {
     const auto size = vec.size();
     if(size < 2 || size > 3) {
@@ -34,4 +34,41 @@ Value cif(const ValueList& vec)
     }
     return {};
 }
+
+ScriptResult ifequal(const ValueList& vec)
+{
+    const auto size = vec.size();
+    if(size != 4) {
+        return {};
+    }
+    if(vec[0].value.toDouble() == vec[1].value.toDouble()) {
+        return vec[2];
+    }
+    return vec[3];
+}
+
+ScriptResult ifgreater(const ValueList& vec)
+{
+    const auto size = vec.size();
+    if(size != 4) {
+        return {};
+    }
+    if(vec[0].value.toDouble() > vec[1].value.toDouble()) {
+        return vec[2];
+    }
+    return vec[3];
+}
+
+ScriptResult iflonger(const ValueList& vec)
+{
+    const auto size = vec.size();
+    if(size != 4) {
+        return {};
+    }
+    if(vec[0].value.size() > vec[1].value.size()) {
+        return vec[2];
+    }
+    return vec[3];
+}
+
 } // namespace Fy::Core::Scripting

--- a/src/core/scripting/functions/mathfuncs.cpp
+++ b/src/core/scripting/functions/mathfuncs.cpp
@@ -20,24 +20,18 @@
 #include "mathfuncs.h"
 
 namespace Fy::Core::Scripting {
-QString baseOperation(const StringList& vec, const QChar op)
+QString baseOperation(const QStringList& vec, const QChar op)
 {
     if(vec.size() < 2) {
         return {};
     }
-    bool success;
-    const double num = vec.front().toDouble(&success);
-    if(!success) {
-        return {};
-    }
-    double total = num;
+    double total = vec.front().toDouble();
     for(int i = 1; i < static_cast<int>(vec.size()); ++i) {
-        bool success;
-        const double num = vec[i].toDouble(&success);
-        if(!success) {
-            return {};
-        }
+        const double num = vec[i].toDouble();
         switch(op.cell()) {
+            case '+':
+                total += num;
+                break;
             case '-':
                 total -= num;
                 break;
@@ -51,39 +45,27 @@ QString baseOperation(const StringList& vec, const QChar op)
     }
     return QString::number(total);
 }
-QString add(const StringList& vec)
+QString add(const QStringList& vec)
 {
-    if(vec.size() < 2) {
-        return {};
-    }
-    double total = 0;
-    for(const auto& numStr : vec) {
-        bool success;
-        const double num = numStr.toDouble(&success);
-        if(!success) {
-            return {};
-        }
-        total += num;
-    }
-    return QString::number(total);
+    return baseOperation(vec, '+');
 }
 
-QString sub(const StringList& vec)
+QString sub(const QStringList& vec)
 {
     return baseOperation(vec, '-');
 }
 
-QString mul(const StringList& vec)
+QString mul(const QStringList& vec)
 {
     return baseOperation(vec, '*');
 }
 
-QString div(const StringList& vec)
+QString div(const QStringList& vec)
 {
     return baseOperation(vec, '/');
 }
 
-QString min(const StringList& vec)
+QString min(const QStringList& vec)
 {
     if(vec.size() < 2) {
         return {};
@@ -94,7 +76,7 @@ QString min(const StringList& vec)
     return *result;
 }
 
-QString max(const StringList& vec)
+QString max(const QStringList& vec)
 {
     if(vec.size() < 2) {
         return {};
@@ -105,4 +87,15 @@ QString max(const StringList& vec)
     return *result;
 }
 
+QString mod(const QStringList& vec)
+{
+    if(vec.size() < 2) {
+        return {};
+    }
+    int total = vec.front().toInt();
+    for(int i = 1; i < static_cast<int>(vec.size()); ++i) {
+        total %= vec[i].toInt();
+    }
+    return QString::number(total);
+}
 } // namespace Fy::Core::Scripting

--- a/src/core/scripting/functions/mathfuncs.h
+++ b/src/core/scripting/functions/mathfuncs.h
@@ -19,13 +19,14 @@
 
 #pragma once
 
-#include "core/scripting/scriptvalue.h"
+#include <QStringList>
 
 namespace Fy::Core::Scripting {
-QString add(const StringList& vec);
-QString sub(const StringList& vec);
-QString mul(const StringList& vec);
-QString div(const StringList& vec);
-QString min(const StringList& vec);
-QString max(const StringList& vec);
+QString add(const QStringList& vec);
+QString sub(const QStringList& vec);
+QString mul(const QStringList& vec);
+QString div(const QStringList& vec);
+QString mod(const QStringList& vec);
+QString min(const QStringList& vec);
+QString max(const QStringList& vec);
 } // namespace Fy::Core::Scripting

--- a/src/core/scripting/scriptparser.cpp
+++ b/src/core/scripting/scriptparser.cpp
@@ -19,50 +19,372 @@
 
 #include "scriptparser.h"
 
-#include <QDebug>
+#include "core/constants.h"
 
 namespace Fy::Core::Scripting {
-void Parser::parse(const QString& input)
+ParsedScript Parser::parse(const QString& input)
 {
-    m_scanner.setup(input);
-    m_nodes.clear();
-
-    Expression exp = m_scanner.scanNext();
-    while(exp.type != Null) {
-        m_nodes.emplace_back(exp);
-        exp = m_scanner.scanNext();
+    if(input.isEmpty()) {
+        return {};
     }
+
+    m_hadError = false;
+
+    ParsedScript result;
+    result.input = input;
+
+    m_scanner.setup(input);
+
+    advance();
+    while(m_current.type != TokEos) {
+        result.expressions.emplace_back(expression());
+    }
+
+    consume(TokEos, "Expected end of expression");
+    result.valid   = !m_hadError;
+    m_parsedScript = result;
+
+    return result;
 }
 
 QString Parser::evaluate()
 {
-    QString ret;
-    for(auto& node : m_nodes) {
-        ret.append(evaluate(&node).value);
+    if(!m_parsedScript.valid) {
+        return {};
     }
-    return ret;
+    return evaluate(m_parsedScript);
 }
 
-Value Parser::evaluate(Expression* exp)
+QString Parser::evaluate(const ParsedScript& input)
 {
-    switch(exp->type) {
-        case Literal: {
-            return {std::get<Literal>(exp->value).value, true};
+    if(!input.valid) {
+        return {};
+    }
+
+    m_result.clear();
+
+    for(const auto& expr : input.expressions) {
+        const auto evalExpr = evalExpression(expr);
+        if(evalExpr.cond) {
+            m_result.append(evalExpr.value);
         }
-        case Variable: {
-            return {m_registry.varValue(std::get<Variable>(exp->value).value)};
+    }
+    return m_result;
+}
+
+QString Parser::evaluate(const ParsedScript& input, Track* track)
+{
+    setMetadata(track);
+    return evaluate(input);
+}
+
+void Parser::setMetadata(Track* track)
+{
+    m_registry.changeCurrentTrack(track);
+}
+
+ScriptResult Parser::evalExpression(const Expression& exp) const
+{
+    switch(exp.type) {
+        case(Literal): {
+            return evalLiteral(exp);
         }
-        case Function: {
-            auto value = std::get<Function>(exp->value);
-            ValueList args;
-            for(auto& arg : value.args) {
-                args.emplace_back(evaluate(&arg));
-            }
-            return {m_registry.function(value.name, args)};
+        case(Variable): {
+            return evalVariable(exp);
         }
-        case Null:
+        case(Function): {
+            return evalFunction(exp);
+        }
+        case(FunctionArg): {
+            return evalFunctionArg(exp);
+        }
+        case(Conditional): {
+            return evalConditional(exp);
+        }
+        case(Null):
             break;
     }
     return {};
+}
+
+ScriptResult Parser::evalLiteral(const Expression& exp) const
+{
+    ScriptResult result;
+    result.value = std::get<QString>(exp.value);
+    result.cond  = true;
+    return result;
+}
+
+ScriptResult Parser::evalVariable(const Expression& exp) const
+{
+    const QString var   = std::get<QString>(exp.value);
+    ScriptResult result = m_registry.varValue(var);
+
+    if(result.value.contains(Core::Constants::Separator)) {
+        // TODO: Support custom separators
+        result.value = result.value.replace(Core::Constants::Separator, ", ");
+    }
+    return result;
+}
+
+ScriptResult Parser::evalFunction(const Expression& exp) const
+{
+    auto function = std::get<FuncValue>(exp.value);
+    ValueList args;
+    for(auto& arg : function.args) {
+        args.emplace_back(evalExpression(arg));
+    }
+    return m_registry.function(function.name, args);
+}
+
+ScriptResult Parser::evalFunctionArg(const Expression& exp) const
+{
+    ScriptResult result;
+    bool allPassed{true};
+
+    auto arg = std::get<ExpressionList>(exp.value);
+    for(auto& subArg : arg) {
+        const auto subExpr = evalExpression(subArg);
+        if(!subExpr.cond) {
+            allPassed = false;
+        }
+        if(subExpr.value.contains(Core::Constants::Separator)) {
+            QString values = subExpr.value;
+            values         = values.replace(Core::Constants::Separator, ", ");
+            result.value += values;
+        }
+        else {
+            result.value += subExpr.value;
+        }
+    }
+    result.cond = allPassed;
+    return result;
+}
+
+ScriptResult Parser::evalConditional(const Expression& exp) const
+{
+    ScriptResult result;
+    result.cond = true;
+
+    auto arg = std::get<ExpressionList>(exp.value);
+    for(auto& subArg : arg) {
+        const auto subExpr = evalExpression(subArg);
+        if(subArg.type != Literal) {
+            if(!subExpr.cond || subExpr.value.isEmpty()) {
+                result.value = {};
+                result.cond  = false;
+                return result;
+            }
+        }
+        if(subExpr.value.contains(Core::Constants::Separator)) {
+            QString values = subExpr.value;
+            values         = values.replace(Core::Constants::Separator, ", ");
+            result.value += values;
+        }
+        else {
+            result.value += subExpr.value;
+        }
+    }
+    return result;
+}
+
+void Parser::advance()
+{
+    m_previous = m_current;
+
+    m_current = m_scanner.scanNext();
+    if(m_current.type == TokError) {
+        errorAtCurrent(m_current.value.toString());
+    }
+}
+
+void Parser::consume(TokenType type, const QString& message)
+{
+    if(m_current.type == type) {
+        advance();
+        return;
+    }
+    errorAtCurrent(message);
+}
+
+bool Parser::currentToken(TokenType type) const
+{
+    return m_current.type == type;
+}
+
+bool Parser::match(TokenType type)
+{
+    if(!currentToken(type)) {
+        return false;
+    }
+    advance();
+    return true;
+}
+
+void Parser::errorAtCurrent(const QString& message)
+{
+    errorAt(m_current, message);
+}
+
+void Parser::errorAt(const Token& token, const QString& message)
+{
+    if(m_hadError) {
+        return;
+    }
+    m_hadError    = true;
+    auto errorMsg = QString{"[%1] Error"}.arg(token.position);
+
+    if(token.type == TokEos) {
+        errorMsg += " at end of string";
+    }
+    else {
+        errorMsg += QString(": '%1'").arg(token.value);
+    }
+
+    errorMsg += QString(" (%1)").arg(message);
+
+    qDebug() << errorMsg;
+}
+
+void Parser::error(const QString& message)
+{
+    errorAt(m_previous, message);
+}
+
+Expression Parser::expression()
+{
+    advance();
+    switch(m_previous.type) {
+        case(TokLiteral):
+            return literal();
+        case(TokVar):
+            return variable();
+        case(TokFunc):
+            return function();
+        case(TokQuote):
+            return quote();
+        case(TokLeftSquare):
+            return conditional();
+        case(TokEscape):
+            advance();
+            return literal();
+        case(TokComma):
+        case(TokLeftParen):
+        case(TokRightParen):
+        case(TokRightSquare):
+        case(TokEos):
+        case(TokError):
+            break;
+    }
+    // We shouldn't ever reach here
+    return {Null};
+}
+
+Expression Parser::literal() const
+{
+    return {Literal, m_previous.value.toString()};
+}
+
+Expression Parser::quote()
+{
+    Expression expr{Literal};
+    QString val;
+
+    while(!currentToken(TokQuote)) {
+        advance();
+        val.append(m_previous.value.toString());
+        if(currentToken(TokEscape)) {
+            advance();
+            val.append(m_current.value.toString());
+            advance();
+        }
+    }
+
+    expr.value = val;
+    consume(TokQuote, "Expected '\"' after expression");
+    return expr;
+}
+
+Expression Parser::variable()
+{
+    advance();
+
+    Expression expr{Variable};
+    const auto value = QString{m_previous.value.toString()}.toLower();
+
+    if(!m_registry.varExists(value)) {
+        error("Variable not found");
+    }
+
+    expr.value = value;
+    consume(TokVar, "Expected '%' after expression");
+    return expr;
+}
+
+Expression Parser::function()
+{
+    advance();
+
+    if(m_previous.type != TokLiteral) {
+        error("Expected function name");
+    }
+
+    Expression expr{Function};
+    FuncValue funcExpr;
+    funcExpr.name = QString{m_previous.value.toString()}.toLower();
+
+    if(!m_registry.funcExists(funcExpr.name)) {
+        error("Function not found");
+    }
+
+    consume(TokLeftParen, "Expected '(' after function call");
+
+    if(!currentToken(TokRightParen)) {
+        funcExpr.args.emplace_back(functionArgs());
+        while(match(TokComma)) {
+            funcExpr.args.emplace_back(functionArgs());
+        }
+    }
+
+    expr.value = funcExpr;
+    consume(TokRightParen, "Expected ')' after function call");
+    return expr;
+}
+
+Expression Parser::functionArgs()
+{
+    Expression expr{FunctionArg};
+    ExpressionList funcExpr;
+
+    while(!currentToken(TokComma) && !currentToken(TokRightParen) && !currentToken(TokEos)) {
+        funcExpr.emplace_back(expression());
+    }
+
+    expr.value = funcExpr;
+    return expr;
+}
+
+Expression Parser::conditional()
+{
+    Expression expr{Conditional};
+    ExpressionList condExpr;
+
+    while(!currentToken(TokRightSquare) && !currentToken(TokEos)) {
+        condExpr.emplace_back(expression());
+    }
+
+    expr.value = condExpr;
+    consume(TokRightSquare, "Expected ']' after expression");
+    return expr;
+}
+
+const Registry& Parser::registry() const
+{
+    return m_registry;
+}
+
+const ParsedScript& Parser::lastParsedScript() const
+{
+    return m_parsedScript;
 }
 } // namespace Fy::Core::Scripting

--- a/src/core/scripting/scriptparser.cpp
+++ b/src/core/scripting/scriptparser.cpp
@@ -169,8 +169,11 @@ ScriptResult Parser::evalConditional(const Expression& exp) const
     auto arg = std::get<ExpressionList>(exp.value);
     for(auto& subArg : arg) {
         const auto subExpr = evalExpression(subArg);
+
+        // Literals return false
         if(subArg.type != Literal) {
             if(!subExpr.cond || subExpr.value.isEmpty()) {
+                // No need to evaluate rest
                 result.value = {};
                 result.cond  = false;
                 return result;

--- a/src/core/scripting/scriptregistry.cpp
+++ b/src/core/scripting/scriptregistry.cpp
@@ -19,42 +19,109 @@
 
 #include "scriptregistry.h"
 
+#include "core/constants.h"
 #include "functions/controlfuncs.h"
 #include "functions/mathfuncs.h"
+#include "models/track.h"
 
 #include <QVariant>
 
 namespace Fy::Core::Scripting {
 Registry::Registry()
+    : m_currentTrack{nullptr}
 {
     addDefaultFunctions();
+    addDefaultMetadata();
 }
 
-Value Registry::varValue(const QString& var)
+bool Registry::varExists(const QString& var) const
 {
-    if(var.isEmpty() || !m_vars.count(var)) {
-        return {"", false};
-    }
-    const QVariant v = m_vars.at(var);
-    return {v.toString(), v.toBool()};
+    return m_vars.count(var) || m_metadata.count(var);
 }
 
-Value Registry::function(const QString& func, const ValueList& args)
+bool Registry::funcExists(const QString& func) const
+{
+    return m_funcs.count(func);
+}
+
+ScriptResult Registry::varValue(const QString& var) const
+{
+    if(var.isEmpty()) {
+        return {};
+    }
+    if(m_metadata.count(var) && m_currentTrack) {
+        auto function = m_metadata.at(var);
+        if(std::holds_alternative<StringFunc>(function)) {
+            const auto f        = std::get<0>(function);
+            const QString value = (m_currentTrack->*f)();
+
+            ScriptResult result;
+            result.value = value;
+            result.cond  = !value.isEmpty();
+            return result;
+        }
+        if(std::holds_alternative<IntegerFunc>(function)) {
+            const auto f    = std::get<1>(function);
+            const int value = (m_currentTrack->*f)();
+
+            ScriptResult result;
+            result.value = QString::number(value);
+            result.cond  = value >= 0;
+            return result;
+        }
+        if(std::holds_alternative<StringListFunc>(function)) {
+            const auto f            = std::get<2>(function);
+            const QStringList value = (m_currentTrack->*f)();
+
+            ScriptResult result;
+            result.value = value.empty() ? "" : value.join(Constants::Separator);
+            result.cond  = !value.isEmpty();
+            return result;
+        }
+        if(std::holds_alternative<U64Func>(function)) {
+            const auto f         = std::get<3>(function);
+            const uint64_t value = (m_currentTrack->*f)();
+
+            ScriptResult result;
+            result.value = QString::number(value);
+            result.cond  = true;
+            return result;
+        }
+    }
+
+    if(!m_vars.count(var)) {
+        return {};
+    }
+
+    const QString value = m_vars.at(var).toString();
+    return {value, !value.isEmpty()};
+}
+
+ScriptResult Registry::function(const QString& func, const ValueList& args) const
 {
     if(func.isEmpty() || !m_funcs.count(func)) {
-        return {"", false};
+        return {};
     }
     auto function = m_funcs.at(func);
     if(std::holds_alternative<NativeFunc>(function)) {
-        const auto f         = std::get<0>(function);
-        const QString result = f(containerCast<StringList>(args));
-        return {result, !result.isEmpty()};
+        const auto f        = std::get<NativeFunc>(function);
+        const QString value = f(containerCast<QStringList>(args));
+
+        ScriptResult result;
+        result.value = value;
+        result.cond  = !value.isEmpty();
+        return result;
     }
     if(std::holds_alternative<NativeCondFunc>(function)) {
-        const auto f = std::get<1>(function);
-        return f(args);
+        const auto f = std::get<NativeCondFunc>(function);
+        return f((args));
     }
-    return {"", false};
+    return {};
+}
+
+void Registry::changeCurrentTrack(Track* track)
+{
+    m_currentTrack = track;
 }
 
 void Registry::addDefaultFunctions()
@@ -65,6 +132,38 @@ void Registry::addDefaultFunctions()
     m_funcs.emplace("div", NativeFunc(div));
     m_funcs.emplace("min", NativeFunc(min));
     m_funcs.emplace("max", NativeFunc(max));
+    m_funcs.emplace("mod", NativeFunc(mod));
+
     m_funcs.emplace("if", NativeCondFunc(cif));
+    m_funcs.emplace("ifgreater", NativeCondFunc(ifgreater));
+    m_funcs.emplace("iflonger", NativeCondFunc(iflonger));
+    m_funcs.emplace("ifequal", NativeCondFunc(ifequal));
+}
+
+void Registry::addDefaultMetadata()
+{
+    m_metadata[Constants::MetaData::Title]        = StringFunc(&Track::title);
+    m_metadata[Constants::MetaData::Artist]       = StringListFunc(&Track::artists);
+    m_metadata[Constants::MetaData::Album]        = StringFunc(&Track::album);
+    m_metadata[Constants::MetaData::AlbumArtist]  = StringFunc(&Track::albumArtist);
+    m_metadata[Constants::MetaData::Track]        = IntegerFunc(&Track::trackNumber);
+    m_metadata[Constants::MetaData::TrackTotal]   = IntegerFunc(&Track::trackTotal);
+    m_metadata[Constants::MetaData::Disc]         = IntegerFunc(&Track::discNumber);
+    m_metadata[Constants::MetaData::DiscTotal]    = IntegerFunc(&Track::discTotal);
+    m_metadata[Constants::MetaData::Genre]        = StringListFunc(&Track::genres);
+    m_metadata[Constants::MetaData::Composer]     = StringFunc(&Track::composer);
+    m_metadata[Constants::MetaData::Performer]    = StringFunc(&Track::performer);
+    m_metadata[Constants::MetaData::Duration]     = U64Func(&Track::duration);
+    m_metadata[Constants::MetaData::Lyrics]       = StringFunc(&Track::lyrics);
+    m_metadata[Constants::MetaData::Comment]      = StringFunc(&Track::comment);
+    m_metadata[Constants::MetaData::Date]         = StringFunc(&Track::date);
+    m_metadata[Constants::MetaData::Year]         = IntegerFunc(&Track::year);
+    m_metadata[Constants::MetaData::Cover]        = StringFunc(&Track::coverPath);
+    m_metadata[Constants::MetaData::FileSize]     = U64Func(&Track::fileSize);
+    m_metadata[Constants::MetaData::Bitrate]      = IntegerFunc(&Track::bitrate);
+    m_metadata[Constants::MetaData::SampleRate]   = IntegerFunc(&Track::sampleRate);
+    m_metadata[Constants::MetaData::PlayCount]    = IntegerFunc(&Track::playCount);
+    m_metadata[Constants::MetaData::AddedTime]    = U64Func(&Track::addedTime);
+    m_metadata[Constants::MetaData::ModifiedTime] = U64Func(&Track::modifiedTime);
 }
 } // namespace Fy::Core::Scripting

--- a/src/core/scripting/scriptscanner.h
+++ b/src/core/scripting/scriptscanner.h
@@ -19,29 +19,48 @@
 
 #pragma once
 
-#include "scriptvalue.h"
-
 #include <QString>
 
 namespace Fy::Core::Scripting {
-struct State
+enum TokenType : char
 {
-    const QChar* start;
-    const QChar* current;
+    TokVar         = '%',
+    TokFunc        = '$',
+    TokComma       = ',',
+    TokQuote       = '"',
+    TokLeftParen   = '(',
+    TokRightParen  = ')',
+    TokLeftSquare  = '[',
+    TokRightSquare = ']',
+    TokEscape      = '\\',
+    TokEos         = '\0',
+    TokError,
+    TokLiteral,
+};
+
+struct Token
+{
+    TokenType type;
+    QStringView value;
+    int position;
 };
 
 class Scanner
 {
 public:
     void setup(const QString& input);
-    Expression scanNext();
+    Token scanNext();
 
 private:
-    Expression scanNext(State& state);
+    [[nodiscard]] Token makeToken(TokenType type) const;
+    Token literal();
 
-    Expression parseFunction(State& state);
-    Expression parseFunctionArg(State& state);
+    [[nodiscard]] bool isAtEnd() const;
+    QChar advance();
+    [[nodiscard]] QChar peek() const;
 
-    State m_state;
+    QStringView m_input;
+    const QChar* m_start;
+    const QChar* m_current;
 };
 } // namespace Fy::Core::Scripting

--- a/src/core/scripting/scriptvalue.h
+++ b/src/core/scripting/scriptvalue.h
@@ -20,59 +20,17 @@
 #pragma once
 
 #include <QObject>
+#include <QVariant>
 
 namespace Fy::Core::Scripting {
-enum ExprType : int
+struct ScriptResult
 {
-    // Do not change
-    // These values correspond to the order in ExpressionValue
-    Literal  = 0,
-    Variable = 1,
-    Function = 2,
-    Null     = 3
-};
-
-struct Expression;
-
-struct LiteralValue
-{
-    QString value;
-};
-struct VarValue
-{
-    QString value;
-};
-struct FuncValue
-{
-    QString name;
-    std::vector<Expression> args;
-};
-
-using ExpressionValue = std::variant<LiteralValue, VarValue, FuncValue>;
-
-struct Expression
-{
-    Expression() = default;
-    Expression(ExprType type)
-        : type{type} {};
-    ExprType type{Null};
-    ExpressionValue value;
-};
-
-struct Value
-{
-    operator QString() const
+    explicit operator QString() const
     {
         return value;
     }
     QString value;
-    bool cond;
+    bool cond{false};
 };
-using ValueList  = std::vector<Value>;
-using StringList = std::vector<QString>;
-
-using NativeFunc     = QString (*)(const StringList&);
-using NativeCondFunc = Value (*)(const ValueList&);
-
-using Func = std::variant<NativeFunc, NativeCondFunc>;
+using ValueList  = std::vector<ScriptResult>;
 } // namespace Fy::Core::Scripting

--- a/src/plugins/filters/CMakeLists.txt
+++ b/src/plugins/filters/CMakeLists.txt
@@ -10,10 +10,22 @@ project(
 
 set(SOURCES
     constants.h
+    fieldparser.h
+    fieldparser.cpp
+    fieldregistry.h
+    fieldregistry.cpp
     filtersplugin.h
     filtersplugin.cpp
     filterdelegate.h
     filterdelegate.cpp
+    fielditem.h
+    fielditem.cpp
+    fieldmodel.h
+    fieldmodel.cpp
+    filtersfieldspage.h
+    filtersfieldspage.cpp
+    filtersgeneralpage.h
+    filtersgeneralpage.cpp
     filteritem.h
     filteritem.cpp
     filtermanager.h
@@ -35,7 +47,12 @@ set(SOURCES
     trackfilterer.cpp
 )
 
-add_library(fooyin_filters MODULE ${SOURCES})
+qt_add_resources(
+    SOURCES
+    data/icons.qrc
+)
+
+add_library(fooyin_filters SHARED ${SOURCES})
 target_link_libraries(fooyin_filters
     PRIVATE
       Qt6::Core

--- a/src/plugins/filters/constants.h
+++ b/src/plugins/filters/constants.h
@@ -21,7 +21,19 @@
 
 #include <Qt>
 
-namespace Fy::Filters::Constants::Role {
-constexpr auto Title  = Qt::UserRole + 1;
-constexpr auto Tracks = Qt::UserRole + 2;
-} // namespace Fy::Filters::Constants::Role
+namespace Fy::Filters::Constants {
+namespace Role {
+constexpr auto Title   = Qt::UserRole + 1;
+constexpr auto Tracks  = Qt::UserRole + 2;
+constexpr auto Sorting = Qt::UserRole + 3;
+} // namespace Role
+
+namespace Icons::Category {
+constexpr auto Filters = "://icons/category-filters.svg";
+} // namespace Icons::Category
+
+namespace Page {
+constexpr auto FiltersGeneral = "Fooyin.Page.Filters.General";
+constexpr auto FiltersFields  = "Fooyin.Page.Filters.Fields";
+} // namespace Page
+} // namespace Fy::Filters::Constants

--- a/src/plugins/filters/data/icons.qrc
+++ b/src/plugins/filters/data/icons.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>icons/category-filters.svg</file>
+    </qresource>
+</RCC>

--- a/src/plugins/filters/data/icons/category-filters.svg
+++ b/src/plugins/filters/data/icons/category-filters.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   fill="currentColor"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg18"
+   sodipodi:docname="category-filters.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs160" />
+  <sodipodi:namedview
+     id="namedview158"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="12.039347"
+     inkscape:cx="27.659307"
+     inkscape:cy="29.071344"
+     inkscape:window-width="1886"
+     inkscape:window-height="1080"
+     inkscape:window-x="34"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg18" />
+  <path
+     d="m 21.815457,38.705034 -6.447244,2.149087 V 22.586924 L 5.7403247,11.996256 A 4.2981622,4.2981622 0 0 1 4.6228116,9.1057442 V 4.3197427 H 39.008103 v 4.6678045 a 4.2981622,4.2981622 0 0 1 -1.259352,3.0387918 l -9.486049,9.486049 v 3.223622"
+     id="path140"
+     style="fill:none;stroke:#b3b3b3;stroke-width:4.29812;stroke-opacity:1" />
+  <path
+     d="m 36.861178,36.555963 m -4.298157,0 a 4.2981626,4.2981626 0 1 0 8.596316,0 4.2981626,4.2981626 0 1 0 -8.596316,0"
+     id="path142"
+     style="fill:none;stroke:#b3b3b3;stroke-width:4.29812;stroke-opacity:1" />
+  <path
+     d="m 36.861178,29.034169 v 3.223622"
+     id="path144"
+     style="stroke:#b3b3b3;stroke-width:4.29812;stroke-opacity:1" />
+  <path
+     d="m 36.861178,40.854121 v 3.223622"
+     id="path146"
+     style="stroke:#b3b3b3;stroke-width:4.29812;stroke-opacity:1" />
+  <path
+     d="m 43.375041,32.795066 -2.791664,1.61181"
+     id="path148"
+     style="stroke:#b3b3b3;stroke-width:4.29812;stroke-opacity:1" />
+  <path
+     d="m 33.141111,38.705034 -2.793796,1.611811"
+     id="path150"
+     style="stroke:#b3b3b3;stroke-width:4.29812;stroke-opacity:1" />
+  <path
+     d="m 30.347315,32.795066 2.793796,1.61181"
+     id="path152"
+     style="fill:none;fill-opacity:1;stroke:#b3b3b3;stroke-width:4.29812;stroke-opacity:1" />
+  <path
+     d="m 40.583392,38.705034 2.793796,1.611811"
+     id="path154"
+     style="stroke:#b3b3b3;stroke-width:4.29812;stroke-opacity:1" />
+</svg>

--- a/src/plugins/filters/fielditem.cpp
+++ b/src/plugins/filters/fielditem.cpp
@@ -17,27 +17,21 @@
  *
  */
 
-#pragma once
+#include "fielditem.h"
 
-#include "filterfwd.h"
+namespace Fy::Filters::Settings {
+FieldItem::FieldItem(FilterField field, FieldItem* parent)
+    : TreeItem{parent}
+    , m_field{std::move(field)}
+{ }
 
-#include <utils/helpers.h>
-
-namespace Fy::Filters {
-class FilterStore
+FilterField FieldItem::field() const
 {
-public:
-    [[nodiscard]] FilterList filters() const;
+    return m_field;
+}
 
-    LibraryFilter* addFilter(const FilterField& field);
-    void removeFilter(int index);
-
-    [[nodiscard]] bool hasActiveFilters() const;
-    [[nodiscard]] FilterList activeFilters() const;
-
-    void clearActiveFilters(int index, bool includeIndex = false);
-
-private:
-    FilterList m_filters;
-};
-} // namespace Fy::Filters
+void FieldItem::changeField(const FilterField& field)
+{
+    m_field = field;
+}
+} // namespace Fy::Filters::Settings

--- a/src/plugins/filters/fielditem.h
+++ b/src/plugins/filters/fielditem.h
@@ -21,23 +21,20 @@
 
 #include "filterfwd.h"
 
-#include <utils/helpers.h>
+#include <core/library/libraryinfo.h>
 
-namespace Fy::Filters {
-class FilterStore
+#include <utils/treeitem.h>
+
+namespace Fy::Filters::Settings {
+class FieldItem : public Utils::TreeItem<FieldItem>
 {
 public:
-    [[nodiscard]] FilterList filters() const;
+    explicit FieldItem(FilterField field = {}, FieldItem* parent = nullptr);
 
-    LibraryFilter* addFilter(const FilterField& field);
-    void removeFilter(int index);
-
-    [[nodiscard]] bool hasActiveFilters() const;
-    [[nodiscard]] FilterList activeFilters() const;
-
-    void clearActiveFilters(int index, bool includeIndex = false);
+    [[nodiscard]] FilterField field() const;
+    void changeField(const FilterField& field);
 
 private:
-    FilterList m_filters;
+    FilterField m_field;
 };
-} // namespace Fy::Filters
+} // namespace Fy::Filters::Settings

--- a/src/plugins/filters/fieldmodel.cpp
+++ b/src/plugins/filters/fieldmodel.cpp
@@ -1,0 +1,283 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fieldmodel.h"
+
+#include "fieldregistry.h"
+
+namespace Fy::Filters::Settings {
+
+FieldModel::FieldModel(FieldRegistry* fieldsRegistry, QObject* parent)
+    : TableModel{parent}
+    , m_fieldsRegistry{fieldsRegistry}
+{
+    setupModelData();
+}
+
+void FieldModel::setupModelData()
+{
+    const auto& fields = m_fieldsRegistry->fields();
+
+    for(const auto& [index, field] : fields) {
+        if(field.name.isEmpty()) {
+            continue;
+        }
+        FieldItem* parent = rootItem();
+        FieldItem* child  = m_nodes.emplace_back(std::make_unique<FieldItem>(field, parent)).get();
+        parent->appendChild(child);
+    }
+}
+
+void FieldModel::addNewField()
+{
+    auto* parent    = rootItem();
+    const int index = static_cast<int>(m_nodes.size());
+
+    FilterField field;
+    field.index = index;
+
+    auto* item = m_nodes.emplace_back(std::make_unique<FieldItem>(field, parent)).get();
+
+    const int row = parent->childCount();
+    beginInsertRows({}, row, row);
+    parent->appendChild(item);
+    endInsertRows();
+
+    m_queue.emplace_back(QueueEntry{Add, index});
+}
+
+void FieldModel::markForRemoval(const FilterField& field)
+{
+    QueueEntry operation;
+    const bool isQueued = findInQueue(field.index, Add, &operation);
+
+    if(isQueued) {
+        removeFromQueue(operation);
+    }
+
+    FieldItem* item = m_nodes.at(field.index).get();
+
+    beginRemoveRows({}, item->row(), item->row());
+    rootItem()->removeChild(item->row());
+    endRemoveRows();
+
+    if(!isQueued) {
+        operation = {Remove, field.index};
+        m_queue.emplace_back(operation);
+    }
+}
+
+void FieldModel::markForChange(const FilterField& field)
+{
+    FieldItem* item = m_nodes.at(field.index).get();
+    item->changeField(field);
+    const QModelIndex index = indexOfItem(item);
+    emit dataChanged(index, index, {Qt::DisplayRole});
+
+    m_queue.emplace_back(QueueEntry{Change, field.index});
+}
+
+void FieldModel::processQueue()
+{
+    while(!m_queue.empty()) {
+        const QueueEntry& entry  = m_queue.front();
+        const OperationType type = entry.type;
+        FieldItem* item          = m_nodes.at(entry.index).get();
+        const FilterField field  = item->field();
+
+        m_queue.pop_front();
+
+        if(type == Add) {
+            const FilterField addedField = m_fieldsRegistry->addField(field);
+            if(addedField.isValid()) {
+                item->changeField(addedField);
+            }
+            else {
+                qWarning() << QString{"Field %1 could not be added"}.arg(field.name);
+
+                beginRemoveRows({}, item->row(), item->row());
+                rootItem()->removeChild(item->row());
+                endRemoveRows();
+            }
+        }
+        else if(type == Remove) {
+            if(m_fieldsRegistry->removeByIndex(field.index)) {
+                m_nodes.erase(std::remove_if(m_nodes.begin(),
+                                             m_nodes.end(),
+                                             [field](const auto& item) {
+                                                 return item->field().index == field.index;
+                                             }),
+                              m_nodes.end());
+            }
+            else {
+                qWarning() << QString{"Field (%1) could not be removed"}.arg(field.name);
+
+                const int row = rootItem()->childCount();
+                beginInsertRows({}, row, row);
+                rootItem()->appendChild(item);
+                endInsertRows();
+            }
+        }
+        else if(type == Change) {
+            if(!m_fieldsRegistry->changeField(field)) {
+                qWarning() << QString{"Field (%1) could not be changed"}.arg(field.name);
+
+                item->changeField(m_fieldsRegistry->fieldByIndex(field.index));
+                const QModelIndex index = indexOfItem(item);
+                emit dataChanged(index, index, {Qt::DisplayRole});
+            }
+        }
+    }
+}
+
+Qt::ItemFlags FieldModel::flags(const QModelIndex& index) const
+{
+    if(!index.isValid()) {
+        return Qt::NoItemFlags;
+    }
+
+    auto flags = TableModel::flags(index);
+    flags |= Qt::ItemIsEditable;
+
+    return flags;
+}
+
+QVariant FieldModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(role == Qt::TextAlignmentRole) {
+        return (Qt::AlignHCenter);
+    }
+
+    if(role != Qt::DisplayRole || orientation == Qt::Orientation::Vertical) {
+        return {};
+    }
+
+    switch(section) {
+        case(0):
+            return "Index";
+        case(1):
+            return "Name";
+        case(2):
+            return "Field";
+        case(3):
+            return "Sort Field";
+    }
+    return {};
+}
+
+QVariant FieldModel::data(const QModelIndex& index, int role) const
+{
+    if(role != Qt::DisplayRole && role != Qt::EditRole) {
+        return {};
+    }
+
+    if(!index.isValid()) {
+        return {};
+    }
+
+    const int column = index.column();
+    auto* item       = static_cast<FieldItem*>(index.internalPointer());
+
+    switch(column) {
+        case(0):
+            return item->field().index;
+        case(1): {
+            const QString& name = item->field().name;
+            return !name.isEmpty() ? name : "<enter name here>";
+        }
+        case(2): {
+            const QString& field = item->field().field;
+            return !field.isEmpty() ? field : "<enter field here>";
+        }
+        case(3): {
+            const QString& sortField = item->field().sortField;
+            return !sortField.isEmpty() || item->field().isValid() ? sortField : "<enter sort field here>";
+        }
+    }
+    return {};
+}
+
+bool FieldModel::setData(const QModelIndex& index, const QVariant& value, int role)
+{
+    if(role != Qt::EditRole) {
+        return false;
+    }
+
+    auto* item        = static_cast<FieldItem*>(index.internalPointer());
+    const int col     = index.column();
+    FilterField field = item->field();
+
+    switch(col) {
+        case(1): {
+            if(field.name == value.toString()) {
+                return false;
+            }
+            field.name = value.toString();
+            break;
+        }
+        case(2): {
+            if(field.field == value.toString()) {
+                return false;
+            }
+            field.field = value.toString();
+            break;
+        }
+        case(3): {
+            if(field.sortField == value.toString()) {
+                return false;
+            }
+            field.sortField = value.toString();
+            break;
+        }
+        case(0):
+            break;
+    }
+
+    markForChange(field);
+
+    return true;
+}
+
+int FieldModel::columnCount(const QModelIndex& parent) const
+{
+    Q_UNUSED(parent)
+    return 4;
+}
+
+bool FieldModel::findInQueue(int index, OperationType type, QueueEntry* field) const
+{
+    return std::any_of(m_queue.cbegin(), m_queue.cend(), [index, type, field](const QueueEntry& entry) {
+        if(entry.index == index && entry.type == type) {
+            *field = entry;
+            return true;
+        }
+        return false;
+    });
+}
+
+void FieldModel::removeFromQueue(const QueueEntry& fieldToDelete)
+{
+    m_queue.erase(std::remove_if(m_queue.begin(),
+                                 m_queue.end(),
+                                 [fieldToDelete](const QueueEntry& field) {
+                                     return field == fieldToDelete;
+                                 }),
+                  m_queue.end());
+}
+} // namespace Fy::Filters::Settings

--- a/src/plugins/filters/fieldmodel.h
+++ b/src/plugins/filters/fieldmodel.h
@@ -1,0 +1,78 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fielditem.h"
+
+#include <utils/tablemodel.h>
+
+namespace Fy::Filters {
+class FieldRegistry;
+
+namespace Settings {
+class FieldModel : public Utils::TableModel<FieldItem>
+{
+public:
+    explicit FieldModel(FieldRegistry* fieldsRegistry, QObject* parent = nullptr);
+
+    void setupModelData();
+    void addNewField();
+    void markForRemoval(const FilterField& field);
+    void markForChange(const FilterField& field);
+    void processQueue();
+
+    [[nodiscard]] Qt::ItemFlags flags(const QModelIndex& index) const override;
+    [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+    [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
+    bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+    [[nodiscard]] int columnCount(const QModelIndex& parent) const override;
+
+private:
+    enum OperationType
+    {
+        Add    = 1,
+        Remove = 2,
+        Change = 3
+    };
+
+    struct QueueEntry
+    {
+        OperationType type;
+        int index;
+
+        bool operator==(const QueueEntry& other) const
+        {
+            return std::tie(type, index) == std::tie(other.type, other.index);
+        }
+    };
+
+    [[nodiscard]] bool findInQueue(int index, OperationType op, QueueEntry* field = nullptr) const;
+    void removeFromQueue(const QueueEntry& fieldToDelete);
+
+    using FieldQueueMap = std::deque<QueueEntry>;
+    using FieldItemList = std::vector<std::unique_ptr<FieldItem>>;
+
+    FieldRegistry* m_fieldsRegistry;
+
+    FieldItemList m_nodes;
+    FieldQueueMap m_queue;
+};
+} // namespace Settings
+} // namespace Fy::Filters

--- a/src/plugins/filters/fieldparser.cpp
+++ b/src/plugins/filters/fieldparser.cpp
@@ -1,0 +1,169 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fieldparser.h"
+
+#include <core/constants.h>
+
+namespace Fy::Filters::Scripting {
+using Core::Scripting::Expression;
+using Core::Scripting::ExpressionList;
+using Core::Scripting::ScriptResult;
+
+QStringList evalStringList(const ScriptResult& evalExpr, const QStringList& result)
+{
+    QStringList listResult;
+    const QStringList values = evalExpr.value.split(Core::Constants::Separator);
+    const bool isEmpty       = result.empty();
+
+    for(const QString& value : values) {
+        if(isEmpty) {
+            listResult.append(value);
+        }
+        else {
+            for(const QString& retValue : result) {
+                listResult.append(retValue + value);
+            }
+        }
+    }
+    return listResult;
+}
+
+QString FieldParser::evaluate(const Core::Scripting::ParsedScript& parsedScript)
+{
+    Core::Scripting::ParsedScript input{parsedScript};
+    if(!input.valid) {
+        input = lastParsedScript();
+    }
+
+    m_result.clear();
+
+    const auto expressions = input.expressions;
+    for(const auto& expr : expressions) {
+        const auto evalExpr = evalExpression(expr);
+        const bool isEmpty  = m_result.empty();
+
+        if(evalExpr.value.isNull()) {
+            continue;
+        }
+
+        if(evalExpr.value.contains(Core::Constants::Separator)) {
+            const QStringList evalList = evalStringList(evalExpr, m_result);
+            if(!evalList.empty()) {
+                m_result = evalList;
+            }
+        }
+        else {
+            if(isEmpty) {
+                m_result.append(evalExpr.value);
+            }
+            else {
+                for(QString& value : m_result) {
+                    value.append(evalExpr.value);
+                }
+            }
+        }
+    }
+    if(m_result.size() == 1) {
+        // Calling join on a QStringList with a single empty string will return a null QString, so return the first
+        // result.
+        return m_result.constFirst();
+    }
+    if(m_result.size() > 1) {
+        return m_result.join(Core::Constants::Separator);
+    }
+    return {};
+}
+
+ScriptResult FieldParser::evalVariable(const Expression& exp) const
+{
+    const QString var = std::get<QString>(exp.value);
+    return registry().varValue(var);
+}
+
+ScriptResult FieldParser::evalFunctionArg(const Expression& exp) const
+{
+    ScriptResult result;
+    bool allPassed{true};
+
+    auto arg = std::get<ExpressionList>(exp.value);
+    for(auto& subArg : arg) {
+        const auto subExpr = evalExpression(subArg);
+        if(!subExpr.cond) {
+            allPassed = false;
+        }
+        if(subExpr.value.contains(Core::Constants::Separator)) {
+            QStringList newResult;
+            const auto values = subExpr.value.split(Core::Constants::Separator);
+            for(const auto& value : values) {
+                newResult.emplace_back(result.value + value);
+            }
+            result.value = newResult.join(Core::Constants::Separator);
+        }
+        else {
+            result.value += subExpr.value;
+        }
+    }
+    result.cond = allPassed;
+    return result;
+}
+
+ScriptResult FieldParser::evalConditional(const Expression& exp) const
+{
+    QStringList exprResult;
+    ScriptResult result;
+    result.cond = true;
+
+    auto arg = std::get<ExpressionList>(exp.value);
+    for(auto& subArg : arg) {
+        const bool isEmpty = exprResult.empty();
+        const auto subExpr = evalExpression(subArg);
+
+        // Literals return false
+        if(subArg.type != Core::Scripting::Literal) {
+            if(!subExpr.cond || subExpr.value.isEmpty()) {
+                // No need to evaluate rest
+                result.value = {};
+                result.cond  = false;
+                return result;
+            }
+        }
+        if(subExpr.value.contains(Core::Constants::Separator)) {
+            const QStringList evalList = evalStringList(subExpr, exprResult);
+            if(!evalList.empty()) {
+                exprResult = evalList;
+            }
+        }
+        else {
+            if(isEmpty) {
+                exprResult.append(subExpr.value);
+            }
+            else {
+                for(QString& value : exprResult) {
+                    value.append(subExpr.value);
+                }
+            }
+        }
+    }
+    if(!exprResult.empty()) {
+        result.value = exprResult.join(Core::Constants::Separator);
+    }
+    return result;
+}
+} // namespace Fy::Filters::Scripting

--- a/src/plugins/filters/fieldparser.h
+++ b/src/plugins/filters/fieldparser.h
@@ -19,25 +19,20 @@
 
 #pragma once
 
-#include "filterfwd.h"
+#include <core/scripting/scriptparser.h>
 
-#include <utils/helpers.h>
-
-namespace Fy::Filters {
-class FilterStore
+namespace Fy::Filters::Scripting {
+class FieldParser : public Core::Scripting::Parser
 {
 public:
-    [[nodiscard]] FilterList filters() const;
+    QString evaluate(const Core::Scripting::ParsedScript& parsedScript) override;
 
-    LibraryFilter* addFilter(const FilterField& field);
-    void removeFilter(int index);
-
-    [[nodiscard]] bool hasActiveFilters() const;
-    [[nodiscard]] FilterList activeFilters() const;
-
-    void clearActiveFilters(int index, bool includeIndex = false);
+protected:
+    Core::Scripting::ScriptResult evalVariable(const Core::Scripting::Expression& exp) const override;
+    Core::Scripting::ScriptResult evalFunctionArg(const Core::Scripting::Expression& exp) const override;
+    Core::Scripting::ScriptResult evalConditional(const Core::Scripting::Expression& exp) const override;
 
 private:
-    FilterList m_filters;
+    QStringList m_result;
 };
-} // namespace Fy::Filters
+} // namespace Fy::Filters::Scripting

--- a/src/plugins/filters/fieldregistry.cpp
+++ b/src/plugins/filters/fieldregistry.cpp
@@ -167,11 +167,11 @@ QDataStream& operator>>(QDataStream& stream, IndexFieldMap& fieldMap)
     while(size > 0) {
         --size;
 
-        FilterField field;
+        FilterField field{};
         int index;
         stream >> index;
         stream >> field;
-        fieldMap.emplace(index, std::move(field));
+        fieldMap.emplace(index, field);
     }
     return stream;
 }

--- a/src/plugins/filters/fieldregistry.cpp
+++ b/src/plugins/filters/fieldregistry.cpp
@@ -1,0 +1,178 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fieldregistry.h"
+
+#include "filtersettings.h"
+
+#include <utils/settings/settingsmanager.h>
+
+#include <QIODevice>
+
+namespace Fy::Filters {
+FieldRegistry::FieldRegistry(Utils::SettingsManager* settings, QObject* parent)
+    : QObject{parent}
+    , m_settings{settings}
+{ }
+
+const IndexFieldMap& FieldRegistry::fields() const
+{
+    return m_fields;
+}
+
+FilterField FieldRegistry::addField(const FilterField& field)
+{
+    if(!field.isValid()) {
+        return {};
+    }
+
+    FilterField newField{field};
+    if(find(newField.name)) {
+        auto count = find(newField.name + " (");
+        newField.name += QString{" (%1)"}.arg(count);
+    }
+    newField.index = static_cast<int>(m_fields.size());
+
+    return m_fields.emplace(newField.index, newField).first->second;
+}
+
+bool FieldRegistry::changeField(const FilterField& field)
+{
+    auto filterIt = std::find_if(m_fields.begin(), m_fields.end(), [field](const auto& filterField) {
+        return filterField.first == field.index;
+    });
+    if(filterIt != m_fields.end()) {
+        filterIt->second = field;
+        emit fieldChanged(field);
+        return true;
+    }
+    return false;
+}
+
+FilterField FieldRegistry::fieldByIndex(int index) const
+{
+    if(!m_fields.count(index)) {
+        return {};
+    }
+    return m_fields.at(index);
+}
+
+FilterField FieldRegistry::fieldByName(const QString& name) const
+{
+    if(m_fields.empty()) {
+        return {};
+    }
+    auto it = std::find_if(m_fields.begin(), m_fields.end(), [name](const auto& field) {
+        return field.second.name == name;
+    });
+    if(it == m_fields.end()) {
+        return m_fields.at(0);
+    }
+    return it->second;
+}
+
+bool FieldRegistry::removeByIndex(int index)
+{
+    if(!m_fields.count(index)) {
+        return false;
+    }
+    m_fields.erase(index);
+    return true;
+}
+
+void FieldRegistry::saveFields()
+{
+    QByteArray byteArray;
+    QDataStream out(&byteArray, QIODevice::WriteOnly);
+
+    out << m_fields;
+
+    byteArray = byteArray.toBase64();
+    m_settings->set<Settings::Fields>(byteArray);
+}
+
+void FieldRegistry::loadFields()
+{
+    QByteArray fields = m_settings->value<Settings::Fields>();
+    fields            = QByteArray::fromBase64(fields);
+
+    QDataStream in(&fields, QIODevice::ReadOnly);
+
+    in >> m_fields;
+}
+
+int FieldRegistry::find(const QString& name) const
+{
+    return static_cast<int>(std::count_if(m_fields.cbegin(), m_fields.cend(), [name](const auto& field) {
+        return field.second.name == name;
+    }));
+}
+
+int FieldRegistry::findAll(const QString& name) const
+{
+    return static_cast<int>(std::count_if(m_fields.cbegin(), m_fields.cend(), [name](const auto& field) {
+        return field.second.name.contains(name);
+    }));
+}
+
+QDataStream& operator<<(QDataStream& stream, const FilterField& field)
+{
+    stream << field.index;
+    stream << field.name;
+    stream << field.field;
+    stream << field.sortField;
+    return stream;
+}
+
+QDataStream& operator>>(QDataStream& stream, FilterField& field)
+{
+    stream >> field.index;
+    stream >> field.name;
+    stream >> field.field;
+    stream >> field.sortField;
+    return stream;
+}
+
+QDataStream& operator<<(QDataStream& stream, const IndexFieldMap& fieldMap)
+{
+    stream << static_cast<int>(fieldMap.size());
+    for(const auto& [index, field] : fieldMap) {
+        stream << index;
+        stream << field;
+    }
+    return stream;
+}
+
+QDataStream& operator>>(QDataStream& stream, IndexFieldMap& fieldMap)
+{
+    int size;
+    stream >> size;
+
+    while(size > 0) {
+        --size;
+
+        FilterField field;
+        int index;
+        stream >> index;
+        stream >> field;
+        fieldMap.emplace(index, std::move(field));
+    }
+    return stream;
+}
+} // namespace Fy::Filters

--- a/src/plugins/filters/fieldregistry.h
+++ b/src/plugins/filters/fieldregistry.h
@@ -1,0 +1,68 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "filterfwd.h"
+
+namespace Fy {
+namespace Utils {
+class SettingsManager;
+}
+
+namespace Filters {
+class FieldRegistry : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit FieldRegistry(Utils::SettingsManager* settings, QObject* parent = nullptr);
+
+    [[nodiscard]] const IndexFieldMap& fields() const;
+
+    FilterField addField(const FilterField& field);
+    bool changeField(const FilterField& field);
+
+    [[nodiscard]] FilterField fieldByIndex(int index) const;
+    [[nodiscard]] FilterField fieldByName(const QString& name) const;
+
+    bool removeByIndex(int index);
+
+    void saveFields();
+    void loadFields();
+
+signals:
+    void fieldChanged(const FilterField& field);
+
+private:
+    [[nodiscard]] int find(const QString& name) const;
+    [[nodiscard]] int findAll(const QString& name) const;
+
+    Utils::SettingsManager* m_settings;
+
+    IndexFieldMap m_fields;
+};
+
+QDataStream& operator<<(QDataStream& stream, const FilterField& field);
+QDataStream& operator>>(QDataStream& stream, FilterField& field);
+
+QDataStream& operator<<(QDataStream& stream, const IndexFieldMap& fieldMap);
+QDataStream& operator>>(QDataStream& stream, IndexFieldMap& fieldMap);
+} // namespace Filters
+} // namespace Fy

--- a/src/plugins/filters/filterfwd.h
+++ b/src/plugins/filters/filterfwd.h
@@ -28,7 +28,7 @@
 namespace Fy::Filters {
 struct FilterField
 {
-    int index;
+    int index{-1};
     QString name;
     QString field;
     QString sortField;

--- a/src/plugins/filters/filterfwd.h
+++ b/src/plugins/filters/filterfwd.h
@@ -26,23 +26,32 @@
 #include <deque>
 
 namespace Fy::Filters {
-Q_NAMESPACE
-enum class FilterType
+struct FilterField
 {
-    Genre = 0,
-    Year,
-    AlbumArtist,
-    Artist,
-    Album,
+    int index;
+    QString name;
+    QString field;
+    QString sortField;
+
+    bool operator==(const FilterField& other) const
+    {
+        return std::tie(index, name, field, sortField)
+            == std::tie(other.index, other.name, other.field, other.sortField);
+    }
+
+    [[nodiscard]] bool isValid() const
+    {
+        return !name.isEmpty() && !field.isEmpty();
+    }
 };
-Q_ENUM_NS(FilterType)
 
 struct LibraryFilter
 {
-    FilterType type;
+    FilterField field;
     int index;
     Core::TrackPtrList tracks;
 };
 
-using FilterList = std::deque<LibraryFilter>;
+using IndexFieldMap = std::map<int, FilterField>;
+using FilterList    = std::deque<LibraryFilter>;
 } // namespace Fy::Filters

--- a/src/plugins/filters/filteritem.h
+++ b/src/plugins/filters/filteritem.h
@@ -19,8 +19,6 @@
 
 #pragma once
 
-#include "constants.h"
-
 #include <core/models/trackfwd.h>
 
 #include <utils/treeitem.h>
@@ -31,18 +29,23 @@ namespace Fy::Filters {
 class FilterItem : public Utils::TreeItem<FilterItem>
 {
 public:
-    explicit FilterItem(QString title = "", FilterItem* parent = {});
+    explicit FilterItem(QString title = "", FilterItem* parent = {}, bool isAllNode = false);
 
     void changeTitle(const QString& title);
 
-    [[nodiscard]] QVariant data(int role = Constants::Role::Title) const;
+    [[nodiscard]] QVariant data(int role) const;
     [[nodiscard]] int trackCount() const;
     void addTrack(Core::Track* track);
+
+    [[nodiscard]] bool hasSortTitle() const;
+    void setSortTitle(const QString& title);
 
     void sortChildren(Qt::SortOrder order);
 
 private:
     QString m_title;
+    QString m_sortTitle;
     Core::TrackPtrList m_tracks;
+    bool m_isAllNode;
 };
 } // namespace Fy::Filters

--- a/src/plugins/filters/filtermanager.h
+++ b/src/plugins/filters/filtermanager.h
@@ -25,8 +25,9 @@
 #include <core/library/libraryinteractor.h>
 #include <core/models/trackfwd.h>
 
-namespace Fy {
+class QMenu;
 
+namespace Fy {
 namespace Utils {
 class ThreadManager;
 }
@@ -36,29 +37,35 @@ class MusicLibrary;
 } // namespace Core::Library
 
 namespace Filters {
+class FieldRegistry;
+
 class FilterManager : public Core::Library::LibraryInteractor
 {
     Q_OBJECT
 
 public:
     explicit FilterManager(Utils::ThreadManager* threadManager, Core::Library::MusicLibrary* library,
-                           QObject* parent = nullptr);
+                           FieldRegistry* fieldsRegistry, QObject* parent = nullptr);
 
     [[nodiscard]] Core::TrackPtrList tracks() const override;
     [[nodiscard]] bool hasTracks() const override;
 
-    [[nodiscard]] bool hasFilter(FilterType type) const;
-
-    LibraryFilter* registerFilter(FilterType type);
-    void unregisterFilter(FilterType type);
+    LibraryFilter* registerFilter(const QString& name);
+    void unregisterFilter(int index);
     void changeFilter(int index);
+
+    [[nodiscard]] FilterField findField(const QString& name) const;
 
     void getFilteredTracks();
 
-    void selectionChanged(LibraryFilter& filter, const Core::TrackPtrList& tracks);
+    void selectionChanged(int index);
     void searchChanged(const QString& search);
 
+    QMenu* filterHeaderMenu(int index, FilterField* field);
+
 signals:
+    void fieldChanged(const Fy::Filters::FilterField& field);
+    void filterChanged(int index, const QString& name);
     void filterTracks(const Core::TrackPtrList& tracks, const QString& search);
     void filteredItems(int index);
     void filteredTracks();
@@ -72,6 +79,7 @@ private:
 
     TrackFilterer m_searchManager;
 
+    FieldRegistry* m_fieldsRegistry;
     Core::TrackPtrList m_filteredTracks;
     int m_lastFilterIndex;
     FilterStore m_filterStore;

--- a/src/plugins/filters/filtermodel.h
+++ b/src/plugins/filters/filtermodel.h
@@ -19,25 +19,27 @@
 
 #pragma once
 
-#include "filterfwd.h"
-
 #include <core/models/trackfwd.h>
 
 #include <utils/treemodel.h>
 
 #include <QAbstractListModel>
 
-namespace Fy::Filters {
+namespace Fy {
+namespace Core::Scripting {
+class Parser;
+}
+
+namespace Filters {
 class FilterItem;
+class FilterField;
 
 class FilterModel : public QAbstractListModel
 {
 public:
-    explicit FilterModel(Filters::FilterType type, QObject* parent = nullptr);
+    explicit FilterModel(FilterField* field, QObject* parent = nullptr);
 
-    void setType(Filters::FilterType type);
-    [[nodiscard]] int index() const;
-    void setIndex(int index);
+    void setField(FilterField* field);
 
     [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
     [[nodiscard]] Qt::ItemFlags flags(const QModelIndex& index) const override;
@@ -47,20 +49,23 @@ public:
     [[nodiscard]] int rowCount(const QModelIndex& parent) const override;
     [[nodiscard]] int columnCount(const QModelIndex& parent) const override;
 
-    void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
-    [[nodiscard]] QModelIndexList match(const QModelIndex& start, int role, const QVariant& value, int hits,
-                                        Qt::MatchFlags flags) const override;
+    void sort(int column, Qt::SortOrder order) override;
+    //    [[nodiscard]] QModelIndexList match(const QModelIndex& start, int role, const QVariant& value, int hits,
+    //                                        Qt::MatchFlags flags) const override;
     void reload(const Core::TrackPtrList& tracks);
 
 private:
     void beginReset();
     void setupModelData(const Core::TrackPtrList& tracks);
-    FilterItem* createNode(const QString& title);
-    std::vector<FilterItem*> createNodes(const QStringList& titles);
+    FilterItem* createNode(const QString& title, const QString& sortTitle = {});
+    std::vector<FilterItem*> createNodes(const QStringList& titles, const QString& sortTitle = {});
 
     std::unique_ptr<FilterItem> m_root;
     std::unique_ptr<FilterItem> m_allNode;
     std::unordered_map<QString, std::unique_ptr<FilterItem>> m_nodes;
-    FilterType m_type;
+    FilterField* m_field;
+
+    std::unique_ptr<Core::Scripting::Parser> m_parser;
 };
-} // namespace Fy::Filters
+} // namespace Filters
+} // namespace Fy

--- a/src/plugins/filters/filtersettings.cpp
+++ b/src/plugins/filters/filtersettings.cpp
@@ -28,5 +28,13 @@ FiltersSettings::FiltersSettings(Utils::SettingsManager* settingsManager)
     m_settings->createSetting(Settings::FilterAltColours, false, "Filters");
     m_settings->createSetting(Settings::FilterHeader, true, "Filters");
     m_settings->createSetting(Settings::FilterScrollBar, true, "Filters");
+    m_settings->createSetting(
+        Settings::Fields,
+        "AAAABAAAAAAAAAAAAAAACgBHAGUAbgByAGUAAAAOACUAZwBlAG4AcgBlACUAAAAAAAAAAQAAAAEAAAAYAEEAbABiAHUAbQAgAEEAcgB0AGkAcw"
+        "B0AAAAGgAlAGEAbABiAHUAbQBhAHIAdABpAHMAdAAlAAAAAAAAAAIAAAACAAAADABBAHIAdABpAHMAdAAAABAAJQBhAHIAdABpAHMAdAAlAAAA"
+        "AAAAAAMAAAADAAAACgBBAGwAYgB1AG0AAAAOACUAYQBsAGIAdQBtACUAAAAA",
+        "Filters");
+
+    m_settings->loadSettings();
 }
 } // namespace Fy::Filters::Settings

--- a/src/plugins/filters/filtersettings.h
+++ b/src/plugins/filters/filtersettings.h
@@ -36,13 +36,14 @@ enum Filters : uint32_t
     FilterAltColours = 1 | Utils::Settings::Bool,
     FilterHeader     = 2 | Utils::Settings::Bool,
     FilterScrollBar  = 3 | Utils::Settings::Bool,
+    Fields           = 4 | Utils::Settings::ByteArray,
 };
 Q_ENUM_NS(Filters)
 
 class FiltersSettings
 {
 public:
-    FiltersSettings(Utils::SettingsManager* settingsManager);
+    explicit FiltersSettings(Utils::SettingsManager* settingsManager);
 
 private:
     Utils::SettingsManager* m_settings;

--- a/src/plugins/filters/filtersfieldspage.cpp
+++ b/src/plugins/filters/filtersfieldspage.cpp
@@ -1,0 +1,120 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "filtersfieldspage.h"
+
+#include "constants.h"
+#include "fieldmodel.h"
+
+#include <utils/settings/settingsmanager.h>
+
+#include <QHeaderView>
+#include <QPushButton>
+#include <QTableView>
+#include <QVBoxLayout>
+
+namespace Fy::Filters::Settings {
+class FiltersFieldsPageWidget : public Utils::SettingsPageWidget
+{
+public:
+    explicit FiltersFieldsPageWidget(FieldRegistry* fieldsRegistry);
+
+    void apply() override;
+
+private:
+    void addField() const;
+    void removeField() const;
+
+    FieldRegistry* m_fieldsRegistry;
+
+    QTableView* m_fieldList;
+    FieldModel* m_model;
+};
+
+FiltersFieldsPageWidget::FiltersFieldsPageWidget(FieldRegistry* fieldsRegistry)
+    : m_fieldsRegistry{fieldsRegistry}
+    , m_fieldList{new QTableView(this)}
+    , m_model{new FieldModel(m_fieldsRegistry, this)}
+{
+    m_fieldList->setModel(m_model);
+
+    // Hide index column
+    m_fieldList->hideColumn(0);
+
+    m_fieldList->verticalHeader()->hide();
+    m_fieldList->horizontalHeader()->setStretchLastSection(true);
+    m_fieldList->setSelectionBehavior(QAbstractItemView::SelectRows);
+
+    auto* buttons       = new QWidget(this);
+    auto* buttonsLayout = new QVBoxLayout(buttons);
+    buttonsLayout->setAlignment(Qt::AlignTop | Qt::AlignHCenter);
+
+    auto* addButton    = new QPushButton("Add", this);
+    auto* removeButton = new QPushButton("Remove", this);
+
+    buttonsLayout->addWidget(addButton);
+    buttonsLayout->addWidget(removeButton);
+
+    auto* fieldLayout = new QHBoxLayout();
+    fieldLayout->addWidget(m_fieldList);
+    fieldLayout->addWidget(buttons);
+
+    auto* mainLayout = new QVBoxLayout(this);
+    mainLayout->addLayout(fieldLayout);
+
+    connect(addButton, &QPushButton::clicked, this, [this]() {
+        addField();
+    });
+    connect(removeButton, &QPushButton::clicked, this, [this]() {
+        removeField();
+    });
+}
+
+void FiltersFieldsPageWidget::apply()
+{
+    m_model->processQueue();
+}
+
+void FiltersFieldsPageWidget::addField() const
+{
+    m_model->addNewField();
+}
+
+void FiltersFieldsPageWidget::removeField() const
+{
+    const auto selectedItems = m_fieldList->selectionModel()->selectedRows();
+    for(const auto& selected : selectedItems) {
+        const auto* item = static_cast<FieldItem*>(selected.internalPointer());
+        m_model->markForRemoval(item->field());
+    }
+}
+
+FiltersFieldsPage::FiltersFieldsPage(FieldRegistry* fieldsRegistry, Utils::SettingsManager* settings)
+    : Utils::SettingsPage{settings->settingsDialog()}
+{
+    setId(Constants::Page::FiltersFields);
+    setName(tr("Fields"));
+    setCategory("Category.Filters");
+    setCategoryName(tr("Filters"));
+    setWidgetCreator([fieldsRegistry] {
+        return new FiltersFieldsPageWidget(fieldsRegistry);
+    });
+    setCategoryIconPath(Constants::Icons::Category::Filters);
+}
+} // namespace Fy::Filters::Settings

--- a/src/plugins/filters/filtersfieldspage.h
+++ b/src/plugins/filters/filtersfieldspage.h
@@ -19,25 +19,23 @@
 
 #pragma once
 
-#include "filterfwd.h"
+#include <utils/settings/settingspage.h>
 
-#include <utils/helpers.h>
+namespace Fy {
+namespace Utils {
+class SettingsManager;
+class SettingsDialogController;
+} // namespace Utils
 
-namespace Fy::Filters {
-class FilterStore
+namespace Filters {
+class FieldRegistry;
+
+namespace Settings {
+class FiltersFieldsPage : public Utils::SettingsPage
 {
 public:
-    [[nodiscard]] FilterList filters() const;
-
-    LibraryFilter* addFilter(const FilterField& field);
-    void removeFilter(int index);
-
-    [[nodiscard]] bool hasActiveFilters() const;
-    [[nodiscard]] FilterList activeFilters() const;
-
-    void clearActiveFilters(int index, bool includeIndex = false);
-
-private:
-    FilterList m_filters;
+    explicit FiltersFieldsPage(FieldRegistry* fieldsRegistry, Utils::SettingsManager* settings);
 };
-} // namespace Fy::Filters
+} // namespace Settings
+} // namespace Filters
+} // namespace Fy

--- a/src/plugins/filters/filtersgeneralpage.cpp
+++ b/src/plugins/filters/filtersgeneralpage.cpp
@@ -1,0 +1,81 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "filtersgeneralpage.h"
+
+#include "constants.h"
+#include "filtersettings.h"
+
+#include <utils/settings/settingsmanager.h>
+
+#include <QCheckBox>
+#include <QGroupBox>
+#include <QVBoxLayout>
+
+namespace Fy::Filters::Settings {
+class FiltersGeneralPageWidget : public Utils::SettingsPageWidget
+{
+public:
+    explicit FiltersGeneralPageWidget(Utils::SettingsManager* settings);
+
+    void apply() override;
+
+private:
+    Utils::SettingsManager* m_settings;
+
+    QVBoxLayout* m_mainLayout;
+
+    QGroupBox* m_splitterBox;
+    QVBoxLayout* m_splitterBoxLayout;
+    QCheckBox* m_filterScrollBars;
+};
+
+FiltersGeneralPageWidget::FiltersGeneralPageWidget(Utils::SettingsManager* settings)
+    : m_settings{settings}
+    , m_mainLayout{new QVBoxLayout(this)}
+    , m_splitterBox{new QGroupBox(tr("Filters"))}
+    , m_splitterBoxLayout{new QVBoxLayout(m_splitterBox)}
+    , m_filterScrollBars{new QCheckBox("Show Filter Scrollbars", this)}
+{
+    m_filterScrollBars->setChecked(m_settings->value<Settings::FilterScrollBar>());
+
+    m_splitterBoxLayout->addWidget(m_filterScrollBars);
+    m_mainLayout->addWidget(m_splitterBox);
+
+    m_mainLayout->addStretch();
+}
+
+void FiltersGeneralPageWidget::apply()
+{
+    m_settings->set<Settings::FilterScrollBar>(m_filterScrollBars->isChecked());
+}
+
+FiltersGeneralPage::FiltersGeneralPage(Utils::SettingsManager* settings)
+    : Utils::SettingsPage{settings->settingsDialog()}
+{
+    setId(Constants::Page::FiltersGeneral);
+    setName(tr("General"));
+    setCategory("Category.Filters");
+    setCategoryName(tr("Filters"));
+    setWidgetCreator([settings] {
+        return new FiltersGeneralPageWidget(settings);
+    });
+    setCategoryIconPath(Constants::Icons::Category::Filters);
+}
+} // namespace Fy::Filters::Settings

--- a/src/plugins/filters/filtersgeneralpage.h
+++ b/src/plugins/filters/filtersgeneralpage.h
@@ -19,25 +19,19 @@
 
 #pragma once
 
-#include "filterfwd.h"
+#include <utils/settings/settingspage.h>
 
-#include <utils/helpers.h>
+namespace Fy {
+namespace Utils {
+class SettingsManager;
+class SettingsDialogController;
+} // namespace Utils
 
-namespace Fy::Filters {
-class FilterStore
+namespace Filters::Settings {
+class FiltersGeneralPage : public Utils::SettingsPage
 {
 public:
-    [[nodiscard]] FilterList filters() const;
-
-    LibraryFilter* addFilter(const FilterField& field);
-    void removeFilter(int index);
-
-    [[nodiscard]] bool hasActiveFilters() const;
-    [[nodiscard]] FilterList activeFilters() const;
-
-    void clearActiveFilters(int index, bool includeIndex = false);
-
-private:
-    FilterList m_filters;
+    explicit FiltersGeneralPage(Utils::SettingsManager* settings);
 };
-} // namespace Fy::Filters
+} // namespace Filters::Settings
+} // namespace Fy

--- a/src/plugins/filters/filtersplugin.h
+++ b/src/plugins/filters/filtersplugin.h
@@ -19,16 +19,17 @@
 
 #pragma once
 
+#include "fieldregistry.h"
+#include "filtersfieldspage.h"
+#include "filtersgeneralpage.h"
 #include "filterwidget.h"
 
 #include <core/coreplugin.h>
 #include <core/plugins/plugin.h>
 
 #include <gui/guiplugin.h>
-#include <gui/widgetfactory.h>
 
-namespace Fy {
-namespace Filters {
+namespace Fy::Filters {
 class FilterManager;
 
 namespace Settings {
@@ -52,16 +53,6 @@ public:
     void shutdown() override;
 
 private:
-    template <typename T>
-    void registerFilter(const QString& key, const QString& name)
-    {
-        m_factory->registerClass<T>(key,
-                                    [this]() {
-                                        return new T(m_filterManager, m_settings);
-                                    },
-                                    name, {"Filter"});
-    }
-
     Utils::ActionManager* m_actionManager;
     Utils::SettingsManager* m_settings;
     Utils::ThreadManager* m_threadManager;
@@ -70,7 +61,10 @@ private:
     Gui::Widgets::WidgetFactory* m_factory;
 
     FilterManager* m_filterManager;
+    std::unique_ptr<FieldRegistry> m_fieldsRegistry;
     std::unique_ptr<Settings::FiltersSettings> m_filterSettings;
+
+    std::unique_ptr<Settings::FiltersGeneralPage> m_generalPage;
+    std::unique_ptr<Settings::FiltersFieldsPage> m_fieldsPage;
 };
-} // namespace Filters
 } // namespace Fy

--- a/src/plugins/filters/filterstore.cpp
+++ b/src/plugins/filters/filterstore.cpp
@@ -26,47 +26,22 @@ FilterList FilterStore::filters() const
     return m_filters;
 }
 
-LibraryFilter& FilterStore::addFilter(FilterType type)
+LibraryFilter* FilterStore::addFilter(const FilterField& field)
 {
     LibraryFilter& filter = m_filters.emplace_back();
-    filter.type           = type;
+    filter.field          = field;
     filter.index          = static_cast<int>(m_filters.size() - 1);
-    return filter;
+    return &filter;
 }
 
-void FilterStore::removeFilter(FilterType type)
+void FilterStore::removeFilter(int index)
 {
-    m_filters.erase(std::remove_if(m_filters.begin(), m_filters.end(),
-                                   [type](const LibraryFilter& filter) {
-                                       return filter.type == type;
+    m_filters.erase(std::remove_if(m_filters.begin(),
+                                   m_filters.end(),
+                                   [index](const LibraryFilter& filter) {
+                                       return filter.index == index;
                                    }),
                     m_filters.end());
-}
-
-LibraryFilter* FilterStore::find(FilterType type)
-{
-    for(auto& filter : m_filters) {
-        if(filter.type == type) {
-            return &filter;
-        }
-    }
-    return nullptr;
-}
-
-bool FilterStore::hasFilter(FilterType type) const
-{
-    return std::find_if(m_filters.cbegin(), m_filters.cend(),
-                        [type](const LibraryFilter& filter) {
-                            return (filter.type == type);
-                        })
-        != m_filters.cend();
-}
-
-bool FilterStore::filterIsActive(FilterType type) const
-{
-    return std::any_of(m_filters.cbegin(), m_filters.cend(), [type](const LibraryFilter& filter) {
-        return (filter.type == type);
-    });
 }
 
 [[nodiscard]] bool FilterStore::hasActiveFilters() const
@@ -83,11 +58,13 @@ FilterList FilterStore::activeFilters() const
     });
 }
 
-void FilterStore::deactivateFilter(FilterType type)
+void FilterStore::clearActiveFilters(int index, bool includeIndex)
 {
-    if(auto* filter = find(type)) {
-        filter->tracks.clear();
+    const int fromIndex = includeIndex ? index - 1 : index;
+    for(LibraryFilter& filter : m_filters) {
+        if(filter.index > fromIndex) {
+            filter.tracks.clear();
+        }
     }
 }
-
 } // namespace Fy::Filters

--- a/src/plugins/filters/filterwidget.h
+++ b/src/plugins/filters/filterwidget.h
@@ -42,28 +42,29 @@ class FilterWidget : public Gui::Widgets::FyWidget
     Q_OBJECT
 
 public:
-    explicit FilterWidget(FilterManager* manager, Utils::SettingsManager* settings,
-                          FilterType type = FilterType::AlbumArtist, QWidget* parent = nullptr);
+    explicit FilterWidget(FilterManager* manager, Utils::SettingsManager* settings, QWidget* parent = nullptr);
     ~FilterWidget() override;
 
     void setupConnections();
 
-    Filters::FilterType type();
-    void setType(Filters::FilterType newType);
+    void setField(const QString& name);
 
-    bool isHeaderHidden();
-    void setHeaderHidden(bool showHeader);
+    bool isHeaderEnabled();
+    void setHeaderEnabled(bool enabled);
 
-    bool isScrollbarHidden();
-    void setScrollbarHidden(bool showScrollBar);
+    bool isScrollbarEnabled();
+    void setScrollbarEnabled(bool enabled);
 
-    bool altRowColors();
-    void setAltRowColors(bool altColours);
+    bool hasAltColors();
+    void setAltColors(bool enabled);
 
     [[nodiscard]] QString name() const override;
     void layoutEditingMenu(Utils::ActionContainer* menu) override;
 
     void customHeaderMenuRequested(QPoint pos);
+
+    void saveLayout(QJsonArray& array) override;
+    void loadLayout(QJsonObject& object) override;
 
 signals:
     void typeChanged(int index);
@@ -72,7 +73,8 @@ protected:
     void selectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
 
 private:
-    void editFilter(QAction* action);
+    void fieldChanged(const FilterField& field);
+    void editFilter(int index, const QString& name);
     void changeOrder();
     void resetByIndex(int idx);
     void resetByType();
@@ -85,51 +87,6 @@ private:
     FilterView* m_view;
     FilterModel* m_model;
     Qt::SortOrder m_sortOrder;
-};
-
-class GenreFilter : public FilterWidget
-{
-public:
-    explicit GenreFilter(FilterManager* manager, Utils::SettingsManager* settings, QWidget* parent = nullptr);
-
-    [[nodiscard]] QString name() const override;
-    [[nodiscard]] QString layoutName() const override;
-};
-
-class YearFilter : public FilterWidget
-{
-public:
-    explicit YearFilter(FilterManager* manager, Utils::SettingsManager* settings, QWidget* parent = nullptr);
-
-    [[nodiscard]] QString name() const override;
-    [[nodiscard]] QString layoutName() const override;
-};
-
-class AlbumArtistFilter : public FilterWidget
-{
-public:
-    explicit AlbumArtistFilter(FilterManager* manager, Utils::SettingsManager* settings, QWidget* parent = nullptr);
-
-    [[nodiscard]] QString name() const override;
-    [[nodiscard]] QString layoutName() const override;
-};
-
-class ArtistFilter : public FilterWidget
-{
-public:
-    explicit ArtistFilter(FilterManager* manager, Utils::SettingsManager* settings, QWidget* parent = nullptr);
-
-    [[nodiscard]] QString name() const override;
-    [[nodiscard]] QString layoutName() const override;
-};
-
-class AlbumFilter : public FilterWidget
-{
-public:
-    explicit AlbumFilter(FilterManager* manager, Utils::SettingsManager* settings, QWidget* parent = nullptr);
-
-    [[nodiscard]] QString name() const override;
-    [[nodiscard]] QString layoutName() const override;
 };
 } // namespace Filters
 } // namespace Fy

--- a/src/utils/tablemodel.h
+++ b/src/utils/tablemodel.h
@@ -60,13 +60,13 @@ public:
         return QAbstractItemModel::flags(index);
     }
 
-    [[nodiscard]] virtual QModelIndex index(int row, int column, const QModelIndex& parent) const override
+    [[nodiscard]] virtual QModelIndex index(int row, int column, const QModelIndex& parent = {}) const override
     {
         if(!hasIndex(row, column, parent)) {
             return {};
         }
 
-        Item* childItem = m_root.get()->child(row);
+        Item* childItem = m_root->child(row);
         if(childItem) {
             return createIndex(row, column, childItem);
         }
@@ -79,10 +79,10 @@ public:
         return {};
     }
 
-    [[nodiscard]] virtual int rowCount(const QModelIndex& parent) const override
+    [[nodiscard]] virtual int rowCount(const QModelIndex& parent = {}) const override
     {
         Q_UNUSED(parent)
-        return m_root.get()->childCount();
+        return m_root->childCount();
     }
 
     [[nodiscard]] virtual QModelIndex indexOfItem(const Item* item)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+enable_testing(true)
+
+add_executable(test_scriptparser
+  scriptparsertest.cpp
+)
+
+target_link_libraries(
+  test_scriptparser
+  GTest::gtest_main
+  Qt6::Core
+  fooyin_core
+)
+
+include(GoogleTest)
+
+gtest_discover_tests(test_scriptparser)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,16 +1,30 @@
 enable_testing(true)
 
-add_executable(test_scriptparser
-  scriptparsertest.cpp
-)
-
-target_link_libraries(
-  test_scriptparser
-  GTest::gtest_main
-  Qt6::Core
-  fooyin_core
-)
-
 include(GoogleTest)
 
-gtest_discover_tests(test_scriptparser)
+#find_package(
+#    Qt6
+#    COMPONENTS
+#    Test
+#)
+#set_package_properties(Qt6Test PROPERTIES TYPE OPTIONAL)
+
+function(fooyin_add_test name)
+    add_executable(${name} ${ARGN})
+    target_link_libraries(${name} GTest::gtest_main)
+    gtest_discover_tests(test_scriptparser)
+endfunction()
+
+fooyin_add_test(test_scriptparser scriptparsertest.cpp)
+target_link_libraries(test_scriptparser
+    Qt6::Core
+    fooyin_core
+)
+
+fooyin_add_test(test_fieldparser filters/fieldparsertest.cpp)
+target_link_libraries(test_fieldparser
+    Qt6::Core
+    fooyin_core
+    fooyin_filters
+)
+

--- a/tests/filters/fieldparsertest.cpp
+++ b/tests/filters/fieldparsertest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <core/models/track.h>
+#include <core/scripting/scriptparser.h>
+
+#include <filters/fieldparser.h>
+
+#include <gtest/gtest.h>
+
+namespace Fy::Testing {
+class FieldParserTest : public ::testing::Test
+{
+public:
+    void SetUp() override
+    {
+        m_parser = std::make_unique<Filters::Scripting::FieldParser>();
+    }
+
+protected:
+    std::unique_ptr<Core::Scripting::Parser> m_parser;
+};
+
+TEST_F(FieldParserTest, MetadataTest)
+{
+    Core::Track track;
+    track.setTitle("A Test");
+    m_parser->setMetadata(&track);
+
+    m_parser->parse("%title%");
+    EXPECT_EQ("A Test", m_parser->evaluate());
+
+    m_parser->parse("%title%[ - %album%]");
+    EXPECT_EQ("A Test", m_parser->evaluate());
+
+    track.setAlbum("A Test Album");
+    EXPECT_EQ("A Test - A Test Album", m_parser->evaluate());
+
+    track.setGenres({"Pop", "Rock"});
+    m_parser->parse("%genre%");
+    EXPECT_EQ("Pop\037Rock", m_parser->evaluate());
+
+    track.setArtists({"Me", "You"});
+    m_parser->parse("%genre% - %artist%");
+    EXPECT_EQ("Pop - Me\037Rock - Me\037Pop - You\037Rock - You", m_parser->evaluate());
+
+    m_parser->parse("[%disc% - %track%]");
+    EXPECT_EQ("", m_parser->evaluate());
+}
+} // namespace Fy::Testing

--- a/tests/scriptparsertest.cpp
+++ b/tests/scriptparsertest.cpp
@@ -1,0 +1,103 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <core/models/track.h>
+#include <core/scripting/scriptparser.h>
+
+#include <gtest/gtest.h>
+
+namespace Fy::Testing {
+class ScriptParserTest : public ::testing::Test
+{
+protected:
+    Core::Scripting::Parser m_parser;
+};
+
+TEST_F(ScriptParserTest, BasicLiteral)
+{
+    m_parser.parse("I am a test.");
+    EXPECT_EQ("I am a test.", m_parser.evaluate());
+}
+
+TEST_F(ScriptParserTest, EscapeComment)
+{
+    m_parser.parse(R"("I am a \% test.")");
+    EXPECT_EQ("I am a % test.", m_parser.evaluate());
+
+    m_parser.parse(R"("I am an \"escape test.")");
+    EXPECT_EQ("I am an \"escape test.", m_parser.evaluate());
+}
+
+TEST_F(ScriptParserTest, Quote)
+{
+    m_parser.parse(R"("I %am% a $test$.")");
+    EXPECT_EQ("I %am% a $test$.", m_parser.evaluate());
+}
+
+TEST_F(ScriptParserTest, MathTest)
+{
+    m_parser.parse("$add(1,2)");
+    EXPECT_EQ(3, m_parser.evaluate().toInt());
+
+    m_parser.parse("$sub(10,8)");
+    EXPECT_EQ(2, m_parser.evaluate().toInt());
+
+    m_parser.parse("$mul(3,33)");
+    EXPECT_EQ(99, m_parser.evaluate().toInt());
+
+    m_parser.parse("$div(33,3)");
+    EXPECT_EQ(11, m_parser.evaluate().toInt());
+
+    m_parser.parse("$mod(10,3)");
+    EXPECT_EQ(1, m_parser.evaluate().toInt());
+
+    m_parser.parse("$min(3,2,3,9,23,100,4)");
+    EXPECT_EQ(2, m_parser.evaluate().toInt());
+
+    m_parser.parse("$max(3,2,3,9,23,100,4)");
+    EXPECT_EQ(100, m_parser.evaluate().toInt());
+}
+
+TEST_F(ScriptParserTest, MetadataTest)
+{
+    Core::Track track;
+    track.setTitle("A Test");
+    m_parser.setMetadata(&track);
+
+    m_parser.parse("%title%");
+    EXPECT_EQ("A Test", m_parser.evaluate());
+
+    m_parser.parse("%title%[ - %album%]");
+    EXPECT_EQ("A Test", m_parser.evaluate());
+
+    track.setAlbum("A Test Album");
+    EXPECT_EQ("A Test - A Test Album", m_parser.evaluate());
+
+    track.setGenres({"Pop", "Rock"});
+    m_parser.parse("%genre%");
+    EXPECT_EQ("Pop, Rock", m_parser.evaluate());
+
+    track.setArtists({"Me", "You"});
+    m_parser.parse("%genre% - %artist%");
+    EXPECT_EQ("Pop, Rock - Me, You", m_parser.evaluate());
+
+    m_parser.parse("[%disc% - %track%]");
+    EXPECT_EQ("", m_parser.evaluate());
+}
+} // namespace Fy::Testing


### PR DESCRIPTION
Filters can currently be used to filter a small number of predefined tags: 
- Genre
- Year
- Album Artist
- Artist
- Album

Following the implementation of the script parser, allow filtering tracks based on a user-defined field/script. The script parser returns a formatted string based on a track's metadata. This also allows for a sort field to be supplied, providing independent sorting different from the display value.