### PR TITLE
Implicitly share track data

### DIFF
--- a/src/core/database/librarydatabase.cpp
+++ b/src/core/database/librarydatabase.cpp
@@ -262,7 +262,7 @@ bool LibraryDatabase::deleteTrack(int id)
     return (!q.hasError());
 }
 
-bool LibraryDatabase::deleteTracks(const TrackPtrList& tracks)
+bool LibraryDatabase::deleteTracks(const TrackList& tracks)
 {
     if(tracks.empty()) {
         return true;
@@ -270,8 +270,8 @@ bool LibraryDatabase::deleteTracks(const TrackPtrList& tracks)
 
     module()->db().transaction();
 
-    const int fileCount = static_cast<int>(std::count_if(tracks.cbegin(), tracks.cend(), [&](Track* track) {
-        return deleteTrack(track->id());
+    const int fileCount = static_cast<int>(std::count_if(tracks.cbegin(), tracks.cend(), [&](const Track& track) {
+        return deleteTrack(track.id());
     }));
 
     const auto success = module()->db().commit();

--- a/src/core/database/librarydatabase.h
+++ b/src/core/database/librarydatabase.h
@@ -41,7 +41,7 @@ public:
 
     bool updateTrack(const Track& track);
     bool deleteTrack(int id);
-    bool deleteTracks(const TrackPtrList& tracks);
+    bool deleteTracks(const TrackList& tracks);
 
 protected:
     Module* module();

--- a/src/core/engine/engine.h
+++ b/src/core/engine/engine.h
@@ -30,12 +30,12 @@ public:
     explicit Engine(QObject* parent = nullptr)
         : QObject{parent} {};
 
-    virtual void play()                    = 0;
-    virtual void stop()                    = 0;
-    virtual void pause()                   = 0;
-    virtual void seek(uint64_t pos)        = 0;
-    virtual void changeTrack(Track* track) = 0;
-    virtual void setVolume(float value)    = 0;
+    virtual void play()                          = 0;
+    virtual void stop()                          = 0;
+    virtual void pause()                         = 0;
+    virtual void seek(uint64_t pos)              = 0;
+    virtual void changeTrack(const Track& track) = 0;
+    virtual void setVolume(float value)          = 0;
 
 signals:
     void currentPositionChanged(uint64_t ms);

--- a/src/core/engine/enginempv.cpp
+++ b/src/core/engine/enginempv.cpp
@@ -125,9 +125,9 @@ void EngineMpv::seek(uint64_t pos)
     mpv_command(m_mpv, cmd);
 }
 
-void EngineMpv::changeTrack(Track* track)
+void EngineMpv::changeTrack(const Track& track)
 {
-    const QByteArray path_ba = track->filepath().toUtf8();
+    const QByteArray path_ba = track.filepath().toUtf8();
     const char* cmd[]        = {"loadfile", path_ba.constData(), "replace", nullptr}; // NOLINT
     mpv_command(m_mpv, cmd);
 }

--- a/src/core/engine/enginempv.h
+++ b/src/core/engine/enginempv.h
@@ -43,7 +43,7 @@ public:
     void stop() override;
     void pause() override;
     void seek(uint64_t pos) override;
-    void changeTrack(Track* track) override;
+    void changeTrack(const Track& track) override;
     void setVolume(float value) override;
 
 signals:

--- a/src/core/library/librarydatabasemanager.cpp
+++ b/src/core/library/librarydatabasemanager.cpp
@@ -61,12 +61,12 @@ void LibraryDatabaseManager::getAllTracks(SortOrder order)
     emit allTracksLoaded();
 }
 
-void LibraryDatabaseManager::updateTracks(const TrackPtrList& tracks)
+void LibraryDatabaseManager::updateTracks(const TrackList& tracks)
 {
-    for(const auto& track : tracks) {
-        const bool saved = Tagging::writeMetaData(*track);
+    for(const Track& track : tracks) {
+        const bool saved = Tagging::writeMetaData(track);
         if(saved) {
-            m_libraryDatabase.updateTrack(*track);
+            m_libraryDatabase.updateTrack(track);
         }
     }
 }

--- a/src/core/library/librarydatabasemanager.h
+++ b/src/core/library/librarydatabasemanager.h
@@ -49,7 +49,7 @@ public:
     void closeThread() override;
 
     void getAllTracks(SortOrder order);
-    void updateTracks(const TrackPtrList& tracks);
+    void updateTracks(const TrackList& tracks);
 
 signals:
     void allTracksLoaded();

--- a/src/core/library/libraryinteractor.h
+++ b/src/core/library/libraryinteractor.h
@@ -32,7 +32,7 @@ public:
     explicit LibraryInteractor(QObject* parent)
         : QObject{parent} {};
 
-    [[nodiscard]] virtual TrackPtrList tracks() const = 0;
-    [[nodiscard]] virtual bool hasTracks() const      = 0;
+    [[nodiscard]] virtual TrackList tracks() const = 0;
+    [[nodiscard]] virtual bool hasTracks() const   = 0;
 };
 } // namespace Fy::Core::Library

--- a/src/core/library/libraryscanner.h
+++ b/src/core/library/libraryscanner.h
@@ -30,7 +30,6 @@
 class QDir;
 
 namespace Fy::Core {
-
 namespace DB {
 class Database;
 }
@@ -48,12 +47,12 @@ public:
     void closeThread() override;
     void stopThread() override;
 
-    void scanLibrary(const TrackPtrList& tracks);
+    void scanLibrary(const TrackList& tracks);
 
 signals:
     void updatedTracks(Core::TrackList tracks);
     void addedTracks(Core::TrackList tracks);
-    void tracksDeleted(const Core::TrackPtrList& tracks);
+    void tracksDeleted(const Core::TrackList& tracks);
 
 private:
     void storeTracks(TrackList& tracks);

--- a/src/core/library/musiclibrary.h
+++ b/src/core/library/musiclibrary.h
@@ -44,7 +44,6 @@ public:
     virtual void reload() = 0;
     virtual void rescan() = 0;
 
-    [[nodiscard]] virtual Track track(int id) const   = 0;
     [[nodiscard]] virtual TrackList tracks() const    = 0;
     [[nodiscard]] virtual TrackList allTracks() const = 0;
 

--- a/src/core/library/musiclibrary.h
+++ b/src/core/library/musiclibrary.h
@@ -44,9 +44,9 @@ public:
     virtual void reload() = 0;
     virtual void rescan() = 0;
 
-    [[nodiscard]] virtual Track* track(int id) const     = 0;
-    [[nodiscard]] virtual TrackPtrList tracks() const    = 0;
-    [[nodiscard]] virtual TrackPtrList allTracks() const = 0;
+    [[nodiscard]] virtual Track track(int id) const   = 0;
+    [[nodiscard]] virtual TrackList tracks() const    = 0;
+    [[nodiscard]] virtual TrackList allTracks() const = 0;
 
     [[nodiscard]] virtual SortOrder sortOrder() const = 0;
     virtual void sortTracks(SortOrder order)          = 0;
@@ -58,12 +58,12 @@ public:
 signals:
     void loadAllTracks(Core::Library::SortOrder order);
     void allTracksLoaded();
-    void runLibraryScan(const Core::TrackPtrList& tracks);
+    void runLibraryScan(const Core::TrackList& tracks);
 
-    void tracksLoaded(const Core::TrackPtrList& tracks);
-    void tracksAdded(const Core::TrackPtrList& tracks);
-    void tracksUpdated(const Core::TrackPtrList& tracks);
-    void tracksDeleted(const Core::TrackPtrList& tracks);
+    void tracksLoaded(const Core::TrackList& tracks);
+    void tracksAdded(const Core::TrackList& tracks);
+    void tracksUpdated(const Core::TrackList& tracks);
+    void tracksDeleted(const Core::TrackList& tracks);
 
     void libraryRemoved();
     void libraryChanged();

--- a/src/core/library/musiclibrarycontainer.cpp
+++ b/src/core/library/musiclibrarycontainer.cpp
@@ -55,11 +55,6 @@ void MusicLibraryContainer::changeLibrary(MusicLibraryInternal* library)
     emit libraryChanged();
 }
 
-Track MusicLibraryContainer::track(int id) const
-{
-    return m_currentLibrary->track(id);
-}
-
 TrackList MusicLibraryContainer::tracks() const
 {
     TrackList intersectedTracks;

--- a/src/core/library/musiclibrarycontainer.cpp
+++ b/src/core/library/musiclibrarycontainer.cpp
@@ -55,14 +55,14 @@ void MusicLibraryContainer::changeLibrary(MusicLibraryInternal* library)
     emit libraryChanged();
 }
 
-Track* MusicLibraryContainer::track(int id) const
+Track MusicLibraryContainer::track(int id) const
 {
     return m_currentLibrary->track(id);
 }
 
-TrackPtrList MusicLibraryContainer::tracks() const
+TrackList MusicLibraryContainer::tracks() const
 {
-    TrackPtrList intersectedTracks;
+    TrackList intersectedTracks;
 
     for(const auto& interactor : m_interactors) {
         if(interactor->hasTracks()) {
@@ -71,14 +71,14 @@ TrackPtrList MusicLibraryContainer::tracks() const
                 intersectedTracks.insert(intersectedTracks.end(), interactorTracks.cbegin(), interactorTracks.cend());
             }
             else {
-                intersectedTracks = Utils::intersection<Track*>(interactorTracks, intersectedTracks);
+                intersectedTracks = Utils::intersection<Track, Track::TrackHash>(interactorTracks, intersectedTracks);
             }
         }
     }
     return !intersectedTracks.empty() ? intersectedTracks : m_currentLibrary->tracks();
 }
 
-TrackPtrList MusicLibraryContainer::allTracks() const
+TrackList MusicLibraryContainer::allTracks() const
 {
     return m_currentLibrary->tracks();
 }

--- a/src/core/library/musiclibrarycontainer.h
+++ b/src/core/library/musiclibrarycontainer.h
@@ -39,9 +39,9 @@ public:
 
     void changeLibrary(MusicLibraryInternal* library);
 
-    [[nodiscard]] Track* track(int id) const override;
-    [[nodiscard]] TrackPtrList tracks() const override;
-    [[nodiscard]] TrackPtrList allTracks() const override;
+    [[nodiscard]] Track track(int id) const override;
+    [[nodiscard]] TrackList tracks() const override;
+    [[nodiscard]] TrackList allTracks() const override;
 
     [[nodiscard]] SortOrder sortOrder() const override;
     void sortTracks(SortOrder order) override;

--- a/src/core/library/musiclibrarycontainer.h
+++ b/src/core/library/musiclibrarycontainer.h
@@ -39,7 +39,6 @@ public:
 
     void changeLibrary(MusicLibraryInternal* library);
 
-    [[nodiscard]] Track track(int id) const override;
     [[nodiscard]] TrackList tracks() const override;
     [[nodiscard]] TrackList allTracks() const override;
 

--- a/src/core/library/musiclibraryinteractor.h
+++ b/src/core/library/musiclibraryinteractor.h
@@ -32,7 +32,7 @@ public:
     explicit MusicLibraryInteractor(QObject* parent)
         : QObject{parent} {};
 
-    [[nodiscard]] virtual TrackPtrList tracks() const = 0;
-    [[nodiscard]] virtual bool hasTracks() const      = 0;
+    [[nodiscard]] virtual TrackList tracks() const = 0;
+    [[nodiscard]] virtual bool hasTracks() const   = 0;
 };
 } // namespace Fy::Core::Library

--- a/src/core/library/musiclibraryinternal.h
+++ b/src/core/library/musiclibraryinternal.h
@@ -44,8 +44,7 @@ public:
     virtual void reload() = 0;
     virtual void rescan() = 0;
 
-    [[nodiscard]] virtual Track track(int id) const = 0;
-    [[nodiscard]] virtual TrackList tracks() const  = 0;
+    [[nodiscard]] virtual TrackList tracks() const = 0;
 
     [[nodiscard]] virtual SortOrder sortOrder() const = 0;
     virtual void sortTracks(SortOrder order)          = 0;

--- a/src/core/library/musiclibraryinternal.h
+++ b/src/core/library/musiclibraryinternal.h
@@ -44,8 +44,8 @@ public:
     virtual void reload() = 0;
     virtual void rescan() = 0;
 
-    [[nodiscard]] virtual Track* track(int id) const  = 0;
-    [[nodiscard]] virtual TrackPtrList tracks() const = 0;
+    [[nodiscard]] virtual Track track(int id) const = 0;
+    [[nodiscard]] virtual TrackList tracks() const  = 0;
 
     [[nodiscard]] virtual SortOrder sortOrder() const = 0;
     virtual void sortTracks(SortOrder order)          = 0;
@@ -55,13 +55,13 @@ public:
 signals:
     void loadAllTracks(Core::Library::SortOrder order);
     void allTracksLoaded();
-    void runLibraryScan(const Core::TrackPtrList& tracks);
+    void runLibraryScan(const Core::TrackList& tracks);
 
-    void tracksLoaded(const Core::TrackPtrList& tracks);
-    void tracksAdded(const Core::TrackPtrList& tracks);
-    void tracksUpdated(const Core::TrackPtrList& tracks);
-    void tracksDeleted(const Core::TrackPtrList& tracks);
-    void tracksChanged(const Core::TrackPtrList& tracks);
+    void tracksLoaded(const Core::TrackList& tracks);
+    void tracksAdded(const Core::TrackList& tracks);
+    void tracksUpdated(const Core::TrackList& tracks);
+    void tracksDeleted(const Core::TrackList& tracks);
+    void tracksChanged(const Core::TrackList& tracks);
 
     void libraryRemoved();
 };

--- a/src/core/library/singlemusiclibrary.cpp
+++ b/src/core/library/singlemusiclibrary.cpp
@@ -55,11 +55,13 @@ SingleMusicLibrary::SingleMusicLibrary(LibraryInfo* info, DB::Database* database
     connect(&m_scanner, &LibraryScanner::tracksDeleted, this, &SingleMusicLibrary::removeDeletedTracks);
 
     connect(&m_libraryDatabaseManager, &LibraryDatabaseManager::gotTracks, this, &SingleMusicLibrary::loadTracks);
-    connect(&m_libraryDatabaseManager, &LibraryDatabaseManager::allTracksLoaded, this,
+    connect(&m_libraryDatabaseManager,
+            &LibraryDatabaseManager::allTracksLoaded,
+            this,
             &SingleMusicLibrary::allTracksLoaded);
     connect(this, &SingleMusicLibrary::loadAllTracks, &m_libraryDatabaseManager, &LibraryDatabaseManager::getAllTracks);
-    connect(this, &SingleMusicLibrary::updateSaveTracks, &m_libraryDatabaseManager,
-            &LibraryDatabaseManager::updateTracks);
+    connect(
+        this, &SingleMusicLibrary::updateSaveTracks, &m_libraryDatabaseManager, &LibraryDatabaseManager::updateTracks);
 
     if(m_settings->value<Settings::AutoRefresh>()) {
         QTimer::singleShot(3000, this, &Library::SingleMusicLibrary::reload);
@@ -71,7 +73,7 @@ void SingleMusicLibrary::loadLibrary()
     getAllTracks();
 }
 
-void SingleMusicLibrary::updateTracks(const TrackPtrList& tracks)
+void SingleMusicLibrary::updateTracks(const TrackList& tracks)
 {
     emit updateSaveTracks(tracks);
 }
@@ -84,20 +86,19 @@ void SingleMusicLibrary::loadTracks(const TrackList& tracks)
 
 void SingleMusicLibrary::addNewTracks(const TrackList& tracks)
 {
-    const TrackPtrList addedTracks = m_trackStore->add(tracks);
+    const TrackList addedTracks = m_trackStore->add(tracks);
     //    m_trackStore->sort(m_order);
     emit tracksAdded(addedTracks);
 }
 
 void SingleMusicLibrary::updateChangedTracks(const TrackList& tracks)
 {
-    const TrackPtrList updatedTracks = m_trackStore->update(tracks);
+    const TrackList updatedTracks = m_trackStore->update(tracks);
     emit tracksUpdated(updatedTracks);
 }
 
-void SingleMusicLibrary::removeDeletedTracks(const TrackPtrList& tracks)
+void SingleMusicLibrary::removeDeletedTracks(const TrackList& tracks)
 {
-    m_trackStore->markForDelete(tracks);
     emit tracksDeleted(tracks);
     m_trackStore->remove(tracks);
 }
@@ -116,7 +117,7 @@ void SingleMusicLibrary::refreshTracks(const TrackList& tracks)
 {
     //    m_trackStore.clear();
 
-    const TrackPtrList newTracks = m_trackStore->add(tracks);
+    const TrackList newTracks = m_trackStore->add(tracks);
     //    m_trackStore.sort(m_order);
 
     emit tracksLoaded(newTracks);
@@ -132,12 +133,12 @@ TrackStore* SingleMusicLibrary::trackStore() const
     return m_trackStore.get();
 }
 
-Track* SingleMusicLibrary::track(int id) const
+Track SingleMusicLibrary::track(int id) const
 {
     return m_trackStore->track(id);
 }
 
-TrackPtrList SingleMusicLibrary::tracks() const
+TrackList SingleMusicLibrary::tracks() const
 {
     return m_trackStore->tracks();
 }

--- a/src/core/library/singlemusiclibrary.cpp
+++ b/src/core/library/singlemusiclibrary.cpp
@@ -86,15 +86,15 @@ void SingleMusicLibrary::loadTracks(const TrackList& tracks)
 
 void SingleMusicLibrary::addNewTracks(const TrackList& tracks)
 {
-    const TrackList addedTracks = m_trackStore->add(tracks);
+    m_trackStore->add(tracks);
     //    m_trackStore->sort(m_order);
-    emit tracksAdded(addedTracks);
+    emit tracksAdded(tracks);
 }
 
 void SingleMusicLibrary::updateChangedTracks(const TrackList& tracks)
 {
-    const TrackList updatedTracks = m_trackStore->update(tracks);
-    emit tracksUpdated(updatedTracks);
+    m_trackStore->update(tracks);
+    emit tracksUpdated(tracks);
 }
 
 void SingleMusicLibrary::removeDeletedTracks(const TrackList& tracks)
@@ -116,11 +116,9 @@ void SingleMusicLibrary::rescan()
 void SingleMusicLibrary::refreshTracks(const TrackList& tracks)
 {
     //    m_trackStore.clear();
-
-    const TrackList newTracks = m_trackStore->add(tracks);
+    m_trackStore->add(tracks);
     //    m_trackStore.sort(m_order);
-
-    emit tracksLoaded(newTracks);
+    emit tracksLoaded(tracks);
 }
 
 LibraryInfo* SingleMusicLibrary::info() const
@@ -131,11 +129,6 @@ LibraryInfo* SingleMusicLibrary::info() const
 TrackStore* SingleMusicLibrary::trackStore() const
 {
     return m_trackStore.get();
-}
-
-Track SingleMusicLibrary::track(int id) const
-{
-    return m_trackStore->track(id);
 }
 
 TrackList SingleMusicLibrary::tracks() const

--- a/src/core/library/singlemusiclibrary.cpp
+++ b/src/core/library/singlemusiclibrary.cpp
@@ -99,8 +99,8 @@ void SingleMusicLibrary::updateChangedTracks(const TrackList& tracks)
 
 void SingleMusicLibrary::removeDeletedTracks(const TrackList& tracks)
 {
-    emit tracksDeleted(tracks);
     m_trackStore->remove(tracks);
+    emit tracksDeleted(tracks);
 }
 
 void SingleMusicLibrary::reload()

--- a/src/core/library/singlemusiclibrary.h
+++ b/src/core/library/singlemusiclibrary.h
@@ -54,7 +54,6 @@ public:
 
     [[nodiscard]] LibraryInfo* info() const override;
 
-    [[nodiscard]] Track track(int id) const override;
     [[nodiscard]] TrackList tracks() const override;
 
     [[nodiscard]] TrackStore* trackStore() const override;

--- a/src/core/library/singlemusiclibrary.h
+++ b/src/core/library/singlemusiclibrary.h
@@ -54,26 +54,26 @@ public:
 
     [[nodiscard]] LibraryInfo* info() const override;
 
-    [[nodiscard]] Track* track(int id) const override;
-    [[nodiscard]] TrackPtrList tracks() const override;
+    [[nodiscard]] Track track(int id) const override;
+    [[nodiscard]] TrackList tracks() const override;
 
     [[nodiscard]] TrackStore* trackStore() const override;
 
     [[nodiscard]] SortOrder sortOrder() const override;
     void sortTracks(SortOrder order) override;
 
-    void updateTracks(const TrackPtrList& tracks);
+    void updateTracks(const TrackList& tracks);
 
 signals:
     void tracksSelChanged();
-    void updateSaveTracks(Core::TrackPtrList tracks);
+    void updateSaveTracks(Core::TrackList tracks);
 
 protected:
     void getAllTracks();
     void loadTracks(const TrackList& tracks);
     void addNewTracks(const TrackList& tracks);
     void updateChangedTracks(const TrackList& tracks);
-    void removeDeletedTracks(const TrackPtrList& tracks);
+    void removeDeletedTracks(const TrackList& tracks);
 
 private:
     LibraryInfo* m_info;

--- a/src/core/library/singletrackstore.cpp
+++ b/src/core/library/singletrackstore.cpp
@@ -22,22 +22,22 @@
 #include "core/library/sorting/sorting.h"
 
 namespace Fy::Core::Library {
-Track* SingleTrackStore::track(int id)
+Track SingleTrackStore::track(int id)
 {
     if(hasTrack(id)) {
-        return &m_trackIdMap.at(id);
+        return m_trackIdMap.at(id);
     }
-    return nullptr;
+    return {};
 }
 
-TrackPtrList SingleTrackStore::tracks() const
+TrackList SingleTrackStore::tracks() const
 {
     return m_tracks;
 }
 
-TrackPtrList SingleTrackStore::add(const TrackList& tracks)
+TrackList SingleTrackStore::add(const TrackList& tracks)
 {
-    TrackPtrList addedTracks;
+    TrackList addedTracks;
     const auto size = tracks.size();
 
     addedTracks.reserve(size);
@@ -47,20 +47,21 @@ TrackPtrList SingleTrackStore::add(const TrackList& tracks)
     for(const Track& track : tracks) {
         addedTracks.emplace_back(add(track));
     }
+
     return addedTracks;
 }
 
-Track* SingleTrackStore::add(const Track& track)
+Track SingleTrackStore::add(const Track& track)
 {
-    Track* newTrack = &m_trackIdMap.emplace(track.id(), track).first->second;
-    m_tracks.emplace_back(newTrack);
+    m_trackIdMap.emplace(track.id(), track);
+    m_tracks.emplace_back(track);
 
-    return newTrack;
+    return track;
 }
 
-TrackPtrList SingleTrackStore::update(const TrackList& tracks)
+TrackList SingleTrackStore::update(const TrackList& tracks)
 {
-    TrackPtrList updatedTracks;
+    TrackList updatedTracks;
     updatedTracks.reserve(tracks.size());
 
     for(const auto& track : tracks) {
@@ -69,38 +70,24 @@ TrackPtrList SingleTrackStore::update(const TrackList& tracks)
     return updatedTracks;
 }
 
-Track* SingleTrackStore::update(const Track& track)
+Track SingleTrackStore::update(const Track& track)
 {
-    Track* libraryTrack = &m_trackIdMap.at(track.id());
-    *libraryTrack       = track;
+    Track& libraryTrack = m_trackIdMap.at(track.id());
+    libraryTrack        = track;
     return libraryTrack;
 }
 
-void SingleTrackStore::markForDelete(const TrackPtrList& tracks)
+void SingleTrackStore::remove(const TrackList& tracks)
 {
-    for(auto* track : tracks) {
-        markForDelete(track);
-    }
-}
-
-void SingleTrackStore::markForDelete(Track* track)
-{
-    if(hasTrack(track->id())) {
-        track->setIsEnabled(false);
-    }
-}
-
-void SingleTrackStore::remove(const TrackPtrList& tracks)
-{
-    for(const auto& track : tracks) {
-        remove(track->id());
+    for(const Track& track : tracks) {
+        remove(track.id());
     }
 }
 
 void SingleTrackStore::remove(int trackId)
 {
     if(hasTrack(trackId)) {
-        Track* track = &m_trackIdMap.at(trackId);
+        Track& track = m_trackIdMap.at(trackId);
         m_tracks.erase(std::find(m_tracks.begin(), m_tracks.end(), track));
         m_trackIdMap.erase(trackId);
     }

--- a/src/core/library/singletrackstore.cpp
+++ b/src/core/library/singletrackstore.cpp
@@ -87,7 +87,7 @@ void SingleTrackStore::remove(const TrackList& tracks)
 void SingleTrackStore::remove(int trackId)
 {
     if(hasTrack(trackId)) {
-        Track& track = m_trackIdMap.at(trackId);
+        const Track& track = m_trackIdMap.at(trackId);
         m_tracks.erase(std::find(m_tracks.begin(), m_tracks.end(), track));
         m_trackIdMap.erase(trackId);
     }

--- a/src/core/library/singletrackstore.h
+++ b/src/core/library/singletrackstore.h
@@ -25,16 +25,11 @@ namespace Fy::Core::Library {
 class SingleTrackStore : public TrackStore
 {
 public:
-    [[nodiscard]] bool hasTrack(int id) const override;
-
-    [[nodiscard]] Track track(int id) override;
     [[nodiscard]] TrackList tracks() const override;
 
-    TrackList add(const TrackList& tracks) override;
-    Track add(const Track& track);
+    void add(const TrackList& tracks) override;
 
-    TrackList update(const TrackList& tracks) override;
-    Track update(const Track& track);
+    void update(const TrackList& tracks) override;
 
     void remove(const TrackList& tracks) override;
     void remove(int trackId);
@@ -44,7 +39,6 @@ public:
     void clear();
 
 private:
-    TrackIdMap m_trackIdMap;
     TrackList m_tracks;
 };
 } // namespace Fy::Core::Library

--- a/src/core/library/singletrackstore.h
+++ b/src/core/library/singletrackstore.h
@@ -27,19 +27,16 @@ class SingleTrackStore : public TrackStore
 public:
     [[nodiscard]] bool hasTrack(int id) const override;
 
-    [[nodiscard]] Track* track(int id) override;
-    [[nodiscard]] TrackPtrList tracks() const override;
+    [[nodiscard]] Track track(int id) override;
+    [[nodiscard]] TrackList tracks() const override;
 
-    TrackPtrList add(const TrackList& tracks) override;
-    Track* add(const Track& track);
+    TrackList add(const TrackList& tracks) override;
+    Track add(const Track& track);
 
-    TrackPtrList update(const TrackList& tracks) override;
-    Track* update(const Track& track);
+    TrackList update(const TrackList& tracks) override;
+    Track update(const Track& track);
 
-    void markForDelete(const TrackPtrList& tracks) override;
-    void markForDelete(Track* trackId);
-
-    void remove(const TrackPtrList& tracks) override;
+    void remove(const TrackList& tracks) override;
     void remove(int trackId);
 
     void sort(SortOrder order) override;
@@ -48,6 +45,6 @@ public:
 
 private:
     TrackIdMap m_trackIdMap;
-    TrackPtrList m_tracks;
+    TrackList m_tracks;
 };
 } // namespace Fy::Core::Library

--- a/src/core/library/sorting/sorting.cpp
+++ b/src/core/library/sorting/sorting.cpp
@@ -22,65 +22,9 @@
 #include <algorithm>
 
 namespace Fy::Core::Library::Sorting {
-bool tracksBase(Track* tr1, Track* tr2)
+void sortTracks(TrackList& tracks, SortOrder sortOrder)
 {
-    if(tr1->discNumber() != tr2->discNumber()) {
-        return tr1->discNumber() < tr2->discNumber();
-    }
-    return tr1->trackNumber() < tr2->trackNumber();
-}
-
-bool tracksByTitleAsc(Track* tr1, Track* tr2)
-{
-    if(tr1->album() != tr2->album()) {
-        return tr1->album() < tr2->album();
-    }
-    return tracksBase(tr1, tr2);
-}
-
-bool tracksByTitleDesc(Track* tr1, Track* tr2)
-{
-    if(tr1->album() != tr2->album()) {
-        return tr1->album() < tr2->album();
-    }
-    return tracksBase(tr1, tr2);
-}
-
-bool tracksByYearAsc(Track* tr1, Track* tr2)
-{
-    if(tr1->albumArtist() != tr2->albumArtist()) {
-        return tr1->albumArtist() < tr2->albumArtist();
-    }
-    if(tr1->year() != tr2->year()) {
-        return tr1->year() < tr2->year();
-    }
-    return tracksByTitleDesc(tr1, tr2);
-}
-
-bool tracksByYearDesc(Track* tr1, Track* tr2)
-{
-    if(tr1->albumArtist() != tr2->albumArtist()) {
-        return tr1->albumArtist() < tr2->albumArtist();
-    }
-    if(tr1->year() != tr2->year()) {
-        return tr1->year() > tr2->year();
-    }
-    return tracksByTitleDesc(tr1, tr2);
-}
-
-void sortTracks(TrackPtrList& tracks, SortOrder sortOrder)
-{
-    switch(sortOrder) {
-            //        case(SortOrder::YearDesc):
-            //            return std::sort(tracks.begin(), tracks.end(), tracksByYearDesc);
-            //        case(SortOrder::YearAsc):
-            //            return std::sort(tracks.begin(), tracks.end(), tracksByYearAsc);
-            //        case(SortOrder::TitleDesc):
-            //            return std::sort(tracks.begin(), tracks.end(), tracksByTitleDesc);
-            //        case(SortOrder::TitleAsc):
-            //            return std::sort(tracks.begin(), tracks.end(), tracksByTitleAsc);
-        case(SortOrder::NoSorting):
-            return std::sort(tracks.begin(), tracks.end(), tracksBase);
-    }
+    Q_UNUSED(tracks)
+    Q_UNUSED(sortOrder)
 }
 } // namespace Fy::Core::Library::Sorting

--- a/src/core/library/sorting/sorting.h
+++ b/src/core/library/sorting/sorting.h
@@ -23,5 +23,5 @@
 #include "sortorder.h"
 
 namespace Fy::Core::Library::Sorting {
-void sortTracks(TrackPtrList& tracks, SortOrder sortOrder);
+void sortTracks(TrackList& tracks, SortOrder sortOrder);
 } // namespace Fy::Core::Library::Sorting

--- a/src/core/library/trackstore.h
+++ b/src/core/library/trackstore.h
@@ -30,13 +30,11 @@ class TrackStore
 public:
     virtual ~TrackStore() = default;
 
-    [[nodiscard]] virtual bool hasTrack(int id) const = 0;
-    [[nodiscard]] virtual Track track(int id)         = 0;
-    [[nodiscard]] virtual TrackList tracks() const    = 0;
+    [[nodiscard]] virtual TrackList tracks() const = 0;
 
-    virtual TrackList add(const TrackList& tracks)    = 0;
-    virtual TrackList update(const TrackList& tracks) = 0;
-    virtual void remove(const TrackList& tracks)      = 0;
+    virtual void add(const TrackList& tracks)    = 0;
+    virtual void update(const TrackList& tracks) = 0;
+    virtual void remove(const TrackList& tracks) = 0;
 
     virtual void sort(SortOrder order) = 0;
 };

--- a/src/core/library/trackstore.h
+++ b/src/core/library/trackstore.h
@@ -31,13 +31,12 @@ public:
     virtual ~TrackStore() = default;
 
     [[nodiscard]] virtual bool hasTrack(int id) const = 0;
-    [[nodiscard]] virtual Track* track(int id)        = 0;
-    [[nodiscard]] virtual TrackPtrList tracks() const = 0;
+    [[nodiscard]] virtual Track track(int id)         = 0;
+    [[nodiscard]] virtual TrackList tracks() const    = 0;
 
-    virtual TrackPtrList add(const TrackList& tracks)      = 0;
-    virtual TrackPtrList update(const TrackList& tracks)   = 0;
-    virtual void markForDelete(const TrackPtrList& tracks) = 0;
-    virtual void remove(const TrackPtrList& tracks)        = 0;
+    virtual TrackList add(const TrackList& tracks)    = 0;
+    virtual TrackList update(const TrackList& tracks) = 0;
+    virtual void remove(const TrackList& tracks)      = 0;
 
     virtual void sort(SortOrder order) = 0;
 };

--- a/src/core/library/unifiedmusiclibrary.cpp
+++ b/src/core/library/unifiedmusiclibrary.cpp
@@ -61,12 +61,12 @@ LibraryInfo* UnifiedMusicLibrary::info() const
     return m_info;
 }
 
-Track* UnifiedMusicLibrary::track(int id) const
+Track UnifiedMusicLibrary::track(int id) const
 {
     return m_trackStore->track(id);
 }
 
-TrackPtrList UnifiedMusicLibrary::tracks() const
+TrackList UnifiedMusicLibrary::tracks() const
 {
     return m_trackStore->tracks();
 }

--- a/src/core/library/unifiedmusiclibrary.cpp
+++ b/src/core/library/unifiedmusiclibrary.cpp
@@ -61,11 +61,6 @@ LibraryInfo* UnifiedMusicLibrary::info() const
     return m_info;
 }
 
-Track UnifiedMusicLibrary::track(int id) const
-{
-    return m_trackStore->track(id);
-}
-
 TrackList UnifiedMusicLibrary::tracks() const
 {
     return m_trackStore->tracks();

--- a/src/core/library/unifiedmusiclibrary.h
+++ b/src/core/library/unifiedmusiclibrary.h
@@ -38,7 +38,6 @@ public:
 
     [[nodiscard]] LibraryInfo* info() const override;
 
-    [[nodiscard]] Track track(int id) const override;
     [[nodiscard]] TrackList tracks() const override;
 
     [[nodiscard]] UnifiedTrackStore* trackStore() const override;

--- a/src/core/library/unifiedmusiclibrary.h
+++ b/src/core/library/unifiedmusiclibrary.h
@@ -38,8 +38,8 @@ public:
 
     [[nodiscard]] LibraryInfo* info() const override;
 
-    [[nodiscard]] Track* track(int id) const override;
-    [[nodiscard]] TrackPtrList tracks() const override;
+    [[nodiscard]] Track track(int id) const override;
+    [[nodiscard]] TrackList tracks() const override;
 
     [[nodiscard]] UnifiedTrackStore* trackStore() const override;
 

--- a/src/core/library/unifiedtrackstore.cpp
+++ b/src/core/library/unifiedtrackstore.cpp
@@ -20,23 +20,6 @@
 #include "unifiedtrackstore.h"
 
 namespace Fy::Core::Library {
-bool UnifiedTrackStore::hasTrack(int id) const
-{
-    return std::any_of(m_libraryStores.cbegin(), m_libraryStores.cend(), [id](const auto& library) {
-        return library.second->hasTrack(id);
-    });
-}
-
-Track UnifiedTrackStore::track(int id)
-{
-    for(const auto& [libraryId, store] : m_libraryStores) {
-        if(store->hasTrack(id)) {
-            return store->track(id);
-        }
-    }
-    return {};
-}
-
 TrackList UnifiedTrackStore::tracks() const
 {
     TrackList tracks{};
@@ -47,16 +30,14 @@ TrackList UnifiedTrackStore::tracks() const
     return tracks;
 }
 
-TrackList UnifiedTrackStore::add(const TrackList& tracks)
+void UnifiedTrackStore::add(const TrackList& tracks)
 {
     Q_UNUSED(tracks)
-    return {};
 }
 
-TrackList UnifiedTrackStore::update(const TrackList& tracks)
+void UnifiedTrackStore::update(const TrackList& tracks)
 {
     Q_UNUSED(tracks)
-    return {};
 }
 
 void UnifiedTrackStore::remove(const TrackList& tracks)

--- a/src/core/library/unifiedtrackstore.cpp
+++ b/src/core/library/unifiedtrackstore.cpp
@@ -27,19 +27,19 @@ bool UnifiedTrackStore::hasTrack(int id) const
     });
 }
 
-Track* UnifiedTrackStore::track(int id)
+Track UnifiedTrackStore::track(int id)
 {
     for(const auto& [libraryId, store] : m_libraryStores) {
-        if(Track* track = store->track(id)) {
-            return track;
+        if(store->hasTrack(id)) {
+            return store->track(id);
         }
     }
-    return nullptr;
+    return {};
 }
 
-TrackPtrList UnifiedTrackStore::tracks() const
+TrackList UnifiedTrackStore::tracks() const
 {
-    TrackPtrList tracks{};
+    TrackList tracks{};
     for(const auto& [libraryId, store] : m_libraryStores) {
         const auto libraryTracks = store->tracks();
         tracks.insert(tracks.end(), libraryTracks.cbegin(), libraryTracks.cend());
@@ -47,26 +47,19 @@ TrackPtrList UnifiedTrackStore::tracks() const
     return tracks;
 }
 
-TrackPtrList UnifiedTrackStore::add(const TrackList& tracks)
+TrackList UnifiedTrackStore::add(const TrackList& tracks)
 {
     Q_UNUSED(tracks)
     return {};
 }
 
-TrackPtrList UnifiedTrackStore::update(const TrackList& tracks)
+TrackList UnifiedTrackStore::update(const TrackList& tracks)
 {
     Q_UNUSED(tracks)
     return {};
 }
 
-void UnifiedTrackStore::markForDelete(const TrackPtrList& tracks)
-{
-    for(auto* track : tracks) {
-        markForDelete(track);
-    }
-}
-
-void UnifiedTrackStore::remove(const TrackPtrList& tracks)
+void UnifiedTrackStore::remove(const TrackList& tracks)
 {
     Q_UNUSED(tracks)
 }
@@ -86,12 +79,5 @@ void UnifiedTrackStore::addLibrary(int libraryId, TrackStore* store)
 void UnifiedTrackStore::removeLibrary(int libraryId)
 {
     m_libraryStores.erase(libraryId);
-}
-
-void UnifiedTrackStore::markForDelete(Track* track)
-{
-    if(hasTrack(track->id())) {
-        track->setIsEnabled(false);
-    }
 }
 } // namespace Fy::Core::Library

--- a/src/core/library/unifiedtrackstore.h
+++ b/src/core/library/unifiedtrackstore.h
@@ -25,13 +25,10 @@ namespace Fy::Core::Library {
 class UnifiedTrackStore : public TrackStore
 {
 public:
-    [[nodiscard]] bool hasTrack(int id) const override;
-
-    [[nodiscard]] Track track(int id) override;
     [[nodiscard]] TrackList tracks() const override;
 
-    TrackList add(const TrackList& tracks) override;
-    TrackList update(const TrackList& tracks) override;
+    void add(const TrackList& tracks) override;
+    void update(const TrackList& tracks) override;
     void remove(const TrackList& tracks) override;
 
     void sort(SortOrder order) override;

--- a/src/core/library/unifiedtrackstore.h
+++ b/src/core/library/unifiedtrackstore.h
@@ -27,13 +27,12 @@ class UnifiedTrackStore : public TrackStore
 public:
     [[nodiscard]] bool hasTrack(int id) const override;
 
-    [[nodiscard]] Track* track(int id) override;
-    [[nodiscard]] TrackPtrList tracks() const override;
+    [[nodiscard]] Track track(int id) override;
+    [[nodiscard]] TrackList tracks() const override;
 
-    TrackPtrList add(const TrackList& tracks) override;
-    TrackPtrList update(const TrackList& tracks) override;
-    void markForDelete(const TrackPtrList& tracks) override;
-    void remove(const TrackPtrList& tracks) override;
+    TrackList add(const TrackList& tracks) override;
+    TrackList update(const TrackList& tracks) override;
+    void remove(const TrackList& tracks) override;
 
     void sort(SortOrder order) override;
 
@@ -41,8 +40,6 @@ public:
     void removeLibrary(int libraryId);
 
 private:
-    void markForDelete(Track* trackId);
-
     std::unordered_map<int, TrackStore*> m_libraryStores;
 };
 } // namespace Fy::Core::Library

--- a/src/core/models/album.cpp
+++ b/src/core/models/album.cpp
@@ -115,24 +115,24 @@ void Album::setCoverPath(const QString& path)
     m_coverPath = path;
 }
 
-void Album::addTrack(Track* track)
+void Album::addTrack(const Track& track)
 {
     ++m_trackCount;
-    m_duration += track->duration();
+    m_duration += track.duration();
 
-    for(const auto& genre : track->genres()) {
+    for(const auto& genre : track.genres()) {
         if(!Utils::contains(m_genres, genre)) {
             m_genres.emplace_back(genre);
         }
     }
 
-    m_discCount = track->discTotal();
+    m_discCount = track.discTotal();
 }
 
-void Album::removeTrack(Track* track)
+void Album::removeTrack(const Track& track)
 {
     --m_trackCount;
-    m_duration -= track->duration();
+    m_duration -= track.duration();
 }
 
 void Album::reset()

--- a/src/core/models/album.h
+++ b/src/core/models/album.h
@@ -51,8 +51,8 @@ public:
     void setDiscCount(int count);
     void setCoverPath(const QString& path);
 
-    void addTrack(Track* track);
-    void removeTrack(Track* track);
+    void addTrack(const Track& track);
+    void removeTrack(const Track& track);
 
     void reset();
 

--- a/src/core/models/container.cpp
+++ b/src/core/models/container.cpp
@@ -63,15 +63,15 @@ void Container::setDuration(uint64_t duration)
     m_duration = duration;
 }
 
-void Container::addTrack(Track* track)
+void Container::addTrack(const Track& track)
 {
     ++m_trackCount;
-    m_duration += track->duration();
+    m_duration += track.duration();
 }
 
-void Container::removeTrack(Track* track)
+void Container::removeTrack(const Track& track)
 {
     --m_trackCount;
-    m_duration -= track->duration();
+    m_duration -= track.duration();
 }
 } // namespace Fy::Core

--- a/src/core/models/container.h
+++ b/src/core/models/container.h
@@ -38,8 +38,8 @@ public:
     void setTrackCount(int count);
     void setDuration(uint64_t duration);
 
-    void addTrack(Track* track);
-    void removeTrack(Track* track);
+    void addTrack(const Track& track);
+    void removeTrack(const Track& track);
     void reset();
 
 private:

--- a/src/core/models/track.cpp
+++ b/src/core/models/track.cpp
@@ -26,184 +26,215 @@
 #include <QJsonObject>
 
 namespace Fy::Core {
-Track::Track()
-    : Track("")
-{ }
+struct Track::Private : public QSharedData
+{
+    int libraryId{-1};
+
+    int id{-1};
+    QString hash;
+    QString filepath;
+    QString title;
+    QStringList artists;
+    QString album;
+    QString albumArtist;
+    int trackNumber{-1};
+    int trackTotal{-1};
+    int discNumber{-1};
+    int discTotal{-1};
+    QStringList genres;
+    QString composer;
+    QString performer;
+    uint64_t duration{0};
+    QString lyrics;
+    QString comment;
+    QString date;
+    int year{-1};
+    QString coverPath;
+    ExtraTags extraTags;
+
+    uint64_t filesize{0};
+    int bitrate{0};
+    int sampleRate{0};
+
+    int playcount{0};
+
+    uint64_t addedTime{0};
+    uint64_t modifiedTime{0};
+
+    explicit Private(QString filepath = {})
+        : filepath{std::move(filepath)}
+    { }
+};
 
 Track::Track(QString filepath)
-    : m_enabled{true}
-    , m_libraryId{-1}
-    , m_id{-1}
-    , m_filepath{std::move(filepath)}
-    , m_trackNumber{-1}
-    , m_trackTotal{-1}
-    , m_discNumber{-1}
-    , m_discTotal{-1}
-    , m_duration{0}
-    , m_filesize{0}
-    , m_bitrate{-1}
-    , m_sampleRate{-1}
-    , m_playcount{0}
-    , m_addedTime{0}
-    , m_modifiedTime{0}
+    : p{new Private(std::move(filepath))}
 { }
+
+bool Track::operator==(const Track& other) const
+{
+    return filepath() == other.filepath();
+}
+
+bool Track::operator!=(const Track& other) const
+{
+    return filepath() != other.filepath();
+}
+
+Track::~Track()                             = default;
+Track::Track(const Track& other)            = default;
+Track& Track::operator=(const Track& other) = default;
 
 QString Track::generateHash()
 {
-    m_hash = QString{"%1|%2|%3|%4.%5|%6"}.arg(m_artists.join(","),
-                                              m_album,
-                                              m_date,
-                                              QString::number(m_discNumber),
-                                              QStringLiteral("%1").arg(m_trackNumber, 2, 10, QLatin1Char('0')),
-                                              QString::number(m_duration));
-    return m_hash;
-}
-
-bool Track::isEnabled() const
-{
-    return m_enabled;
+    p->hash = QString{"%1|%2|%3|%4.%5|%6"}.arg(p->artists.join(","),
+                                               p->album,
+                                               p->date,
+                                               QString::number(p->discNumber),
+                                               QStringLiteral("%1").arg(p->trackNumber, 2, 10, QLatin1Char('0')),
+                                               QString::number(p->duration));
+    return p->hash;
 }
 
 int Track::libraryId() const
 {
-    return m_libraryId;
+    return p->libraryId;
 }
 
 int Track::id() const
 {
-    return m_id;
+    return p->id;
 }
 
 QString Track::hash() const
 {
-    return m_hash;
+    return p->hash;
 }
 
 QString Track::albumHash() const
 {
-    return QString{"%1|%2|%3"}.arg(m_date, !m_albumArtist.isEmpty() ? m_albumArtist : m_artists.join(""), m_album);
+    return QString{"%1|%2|%3"}.arg(p->date, !p->albumArtist.isEmpty() ? p->albumArtist : p->artists.join(""), p->album);
 }
 
 QString Track::filepath() const
 {
-    return m_filepath;
+    return p->filepath;
 }
 
 QString Track::title() const
 {
-    return m_title;
+    return p->title;
 }
 
 QStringList Track::artists() const
 {
-    return m_artists;
+    return p->artists;
 }
 
 QString Track::artist() const
 {
-    return m_artists.join(Constants::Separator);
+    return p->artists.join(Constants::Separator);
 }
 
 QString Track::album() const
 {
-    return m_album;
+    return p->album;
 }
 
 QString Track::albumArtist() const
 {
-    return m_albumArtist;
+    return p->albumArtist;
 }
 
 int Track::trackNumber() const
 {
-    return m_trackNumber;
+    return p->trackNumber;
 }
 
 int Track::trackTotal() const
 {
-    return m_trackTotal;
+    return p->trackTotal;
 }
 
 int Track::discNumber() const
 {
-    return m_discNumber;
+    return p->discNumber;
 }
 
 int Track::discTotal() const
 {
-    return m_discTotal;
+    return p->discTotal;
 }
 
 QStringList Track::genres() const
 {
-    return m_genres;
+    return p->genres;
 }
 
 QString Track::genre() const
 {
-    return m_genres.join(Constants::Separator);
+    return p->genres.join(Constants::Separator);
 }
 
 QString Track::composer() const
 {
-    return m_composer;
+    return p->composer;
 }
 
 QString Track::performer() const
 {
-    return m_performer;
+    return p->performer;
 }
 
 uint64_t Track::duration() const
 {
-    return m_duration;
+    return p->duration;
 }
 
 QString Track::lyrics() const
 {
-    return m_lyrics;
+    return p->lyrics;
 }
 
 QString Track::comment() const
 {
-    return m_comment;
+    return p->comment;
 }
 
 QString Track::date() const
 {
-    return m_date;
+    return p->date;
 }
 
 int Track::year() const
 {
-    return m_year;
+    return p->year;
 }
 
 QString Track::coverPath() const
 {
-    return m_coverPath;
+    return p->coverPath;
 }
 
 bool Track::hasCover() const
 {
-    return !m_coverPath.isEmpty();
+    return !p->coverPath.isEmpty();
 }
 
 bool Track::isSingleDiscAlbum() const
 {
-    return m_discTotal <= 1;
+    return p->discTotal <= 1;
 }
 
 ExtraTags Track::extraTags() const
 {
-    return m_extraTags;
+    return p->extraTags;
 }
 
 QByteArray Track::extraTagsToJson() const
 {
     QJsonObject extra;
     QJsonArray extraArray;
-    for(const auto& [tag, values] : m_extraTags) {
+    for(const auto& [tag, values] : p->extraTags) {
         QJsonObject tagObject;
         const auto tagArray = QJsonArray::fromStringList(values);
         tagObject[tag]      = tagArray;
@@ -217,145 +248,140 @@ QByteArray Track::extraTagsToJson() const
 
 uint64_t Track::fileSize() const
 {
-    return m_filesize;
+    return p->filesize;
 }
 
 int Track::bitrate() const
 {
-    return m_bitrate;
+    return p->bitrate;
 }
 
 int Track::sampleRate() const
 {
-    return m_sampleRate;
+    return p->sampleRate;
 }
 
 int Track::playCount() const
 {
-    return m_playcount;
+    return p->playcount;
 }
 
 uint64_t Track::addedTime() const
 {
-    return m_addedTime;
+    return p->addedTime;
 }
 
 uint64_t Track::modifiedTime() const
 {
-    return m_modifiedTime;
-}
-
-void Track::setIsEnabled(bool enabled)
-{
-    m_enabled = enabled;
+    return p->modifiedTime;
 }
 
 void Track::setLibraryId(int id)
 {
-    m_libraryId = id;
+    p->libraryId = id;
 }
 
 void Track::setId(int id)
 {
-    m_id = id;
+    p->id = id;
 }
 
 void Track::setHash(const QString& hash)
 {
-    m_hash = hash;
+    p->hash = hash;
 }
 
 void Track::setTitle(const QString& title)
 {
-    m_title = title;
+    p->title = title;
 }
 
 void Track::setArtists(const QStringList& artists)
 {
-    m_artists = artists;
+    p->artists = artists;
 }
 
 void Track::setAlbum(const QString& title)
 {
-    m_album = title;
+    p->album = title;
 }
 
 void Track::setAlbumArtist(const QString& artist)
 {
-    m_albumArtist = artist;
+    p->albumArtist = artist;
 }
 
 void Track::setTrackNumber(int number)
 {
-    m_trackNumber = number;
+    p->trackNumber = number;
 }
 
 void Track::setTrackTotal(int total)
 {
-    m_trackTotal = total;
+    p->trackTotal = total;
 }
 
 void Track::setDiscNumber(int number)
 {
-    m_discNumber = number;
+    p->discNumber = number;
 }
 
 void Track::setDiscTotal(int total)
 {
-    m_discTotal = total;
+    p->discTotal = total;
 }
 
 void Track::setGenres(const QStringList& genres)
 {
-    m_genres = genres;
+    p->genres = genres;
 }
 
 void Track::setComposer(const QString& composer)
 {
-    m_composer = composer;
+    p->composer = composer;
 }
 
 void Track::setPerformer(const QString& performer)
 {
-    m_performer = performer;
+    p->performer = performer;
 }
 
 void Track::setDuration(uint64_t duration)
 {
-    m_duration = duration;
+    p->duration = duration;
 }
 
 void Track::setLyrics(const QString& lyrics)
 {
-    m_lyrics = lyrics;
+    p->lyrics = lyrics;
 }
 
 void Track::setComment(const QString& comment)
 {
-    m_comment = comment;
+    p->comment = comment;
 }
 
 void Track::setDate(const QString& date)
 {
-    m_date = date;
-    m_year = date.toInt();
+    p->date = date;
+    p->year = date.toInt();
 }
 
 void Track::setCoverPath(const QString& path)
 {
-    m_coverPath = path;
+    p->coverPath = path;
 }
 
 void Track::addExtraTag(const QString& tag, const QString& value)
 {
     if(!tag.isEmpty() && !value.isEmpty()) {
-        if(m_extraTags.count(tag)) {
-            auto entry = m_extraTags.at(tag);
+        if(p->extraTags.count(tag)) {
+            auto entry = p->extraTags.at(tag);
             entry.append(value);
-            m_extraTags.emplace(tag, entry);
+            p->extraTags.emplace(tag, entry);
         }
     }
-    m_extraTags.emplace(tag, value);
+    p->extraTags.emplace(tag, value);
 }
 
 void Track::jsonToExtraTags(const QByteArray& json)
@@ -378,7 +404,7 @@ void Track::jsonToExtraTags(const QByteArray& json)
                         for(const auto& value : tagArray) {
                             values.append(value.toString());
                         }
-                        m_extraTags.emplace(tag, values);
+                        p->extraTags.emplace(tag, values);
                     }
                 }
             }
@@ -388,31 +414,36 @@ void Track::jsonToExtraTags(const QByteArray& json)
 
 void Track::setFileSize(uint64_t fileSize)
 {
-    m_filesize = fileSize;
+    p->filesize = fileSize;
 }
 
 void Track::setBitrate(int rate)
 {
-    m_bitrate = rate;
+    p->bitrate = rate;
 }
 
 void Track::setSampleRate(int rate)
 {
-    m_sampleRate = rate;
+    p->sampleRate = rate;
 }
 
 void Track::setPlayCount(int count)
 {
-    m_playcount = count;
+    p->playcount = count;
 }
 
 void Track::setAddedTime(uint64_t time)
 {
-    m_addedTime = time;
+    p->addedTime = time;
 }
 
 void Track::setModifiedTime(uint64_t time)
 {
-    m_modifiedTime = time;
+    p->modifiedTime = time;
 }
 } // namespace Fy::Core
+
+size_t qHash(const Fy::Core::Track& track)
+{
+    return qHash(track.filepath());
+}

--- a/src/core/models/track.cpp
+++ b/src/core/models/track.cpp
@@ -66,6 +66,10 @@ struct Track::Private : public QSharedData
     { }
 };
 
+Track::Track()
+    : Track{""}
+{ }
+
 Track::Track(QString filepath)
     : p{new Private(std::move(filepath))}
 { }
@@ -93,6 +97,11 @@ QString Track::generateHash()
                                                QStringLiteral("%1").arg(p->trackNumber, 2, 10, QLatin1Char('0')),
                                                QString::number(p->duration));
     return p->hash;
+}
+
+bool Track::isValid() const
+{
+    return p->id >= 0 && !p->filepath.isEmpty();
 }
 
 int Track::libraryId() const
@@ -441,9 +450,9 @@ void Track::setModifiedTime(uint64_t time)
 {
     p->modifiedTime = time;
 }
-} // namespace Fy::Core
 
-size_t qHash(const Fy::Core::Track& track)
+size_t qHash(const Track& track)
 {
     return qHash(track.filepath());
 }
+} // namespace Fy::Core

--- a/src/core/models/track.h
+++ b/src/core/models/track.h
@@ -38,7 +38,8 @@ public:
         }
     };
 
-    Track(QString filepath = {});
+    Track();
+    explicit Track(QString filepath);
     ~Track();
 
     Track(const Track& other);
@@ -47,6 +48,8 @@ public:
     bool operator!=(const Track& other) const;
 
     QString generateHash();
+
+    [[nodiscard]] bool isValid() const;
 
     [[nodiscard]] int libraryId() const;
 
@@ -126,6 +129,6 @@ private:
     struct Private;
     QSharedDataPointer<Private> p;
 };
-} // namespace Fy::Core
 
-size_t qHash(const Fy::Core::Track& track);
+size_t qHash(const Track& track);
+} // namespace Fy::Core

--- a/src/core/models/track.h
+++ b/src/core/models/track.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <QList>
+#include <QSharedDataPointer>
 
 #include <map>
 
@@ -29,12 +30,23 @@ using ExtraTags = std::map<QString, QList<QString>>;
 class Track
 {
 public:
-    Track();
-    explicit Track(QString filepath);
+    struct TrackHash
+    {
+        size_t operator()(const Track& track) const
+        {
+            return qHash(track.filepath());
+        }
+    };
+
+    Track(QString filepath = {});
+    ~Track();
+
+    Track(const Track& other);
+    Track& operator=(const Track& other);
+    bool operator==(const Track& other) const;
+    bool operator!=(const Track& other) const;
 
     QString generateHash();
-
-    [[nodiscard]] bool isEnabled() const;
 
     [[nodiscard]] int libraryId() const;
 
@@ -76,8 +88,6 @@ public:
     [[nodiscard]] uint64_t addedTime() const;
     [[nodiscard]] uint64_t modifiedTime() const;
 
-    void setIsEnabled(bool enabled);
-
     void setLibraryId(int id);
 
     void setId(int id);
@@ -113,39 +123,9 @@ public:
     void setModifiedTime(uint64_t time);
 
 private:
-    bool m_enabled;
-
-    int m_libraryId;
-
-    int m_id;
-    QString m_hash;
-    QString m_filepath;
-    QString m_title;
-    QStringList m_artists;
-    QString m_album;
-    QString m_albumArtist;
-    int m_trackNumber;
-    int m_trackTotal;
-    int m_discNumber;
-    int m_discTotal;
-    QStringList m_genres;
-    QString m_composer;
-    QString m_performer;
-    uint64_t m_duration;
-    QString m_lyrics;
-    QString m_comment;
-    QString m_date;
-    int m_year;
-    QString m_coverPath;
-    ExtraTags m_extraTags;
-
-    uint64_t m_filesize;
-    int m_bitrate;
-    int m_sampleRate;
-
-    int m_playcount;
-
-    uint64_t m_addedTime;
-    uint64_t m_modifiedTime;
+    struct Private;
+    QSharedDataPointer<Private> p;
 };
 } // namespace Fy::Core
+
+size_t qHash(const Fy::Core::Track& track);

--- a/src/core/models/trackfwd.h
+++ b/src/core/models/trackfwd.h
@@ -26,8 +26,7 @@
 
 namespace Fy::Core {
 using TrackList    = std::vector<Track>;
-using TrackPtrList = std::vector<Track*>;
-using TrackSet     = std::set<Track*>;
+using TrackSet     = std::set<Track>;
 using TrackIdMap   = std::unordered_map<int, Track>;
-using TrackPathMap = std::unordered_map<QString, Track*>;
+using TrackPathMap = std::unordered_map<QString, Track>;
 } // namespace Fy::Core

--- a/src/core/player/playercontroller.cpp
+++ b/src/core/player/playercontroller.cpp
@@ -43,9 +43,8 @@ PlayerController::PlayerController(Utils::SettingsManager* settings, QObject* pa
 
 void PlayerController::reset()
 {
-    m_playStatus   = Stopped;
-    m_position     = 0;
-    m_currentTrack = nullptr;
+    m_playStatus = Stopped;
+    m_position   = 0;
 }
 
 void PlayerController::play()
@@ -99,8 +98,8 @@ void PlayerController::setCurrentPosition(uint64_t ms)
     // TODO: Only increment playCount based on total time listened excluding seeking.
     if(!m_counted && ms >= m_totalDuration / 2) {
         // TODO: Save playCounts to db.
-        int playCount = m_currentTrack->playCount();
-        m_currentTrack->setPlayCount(++playCount);
+        int playCount = m_currentTrack.playCount();
+        m_currentTrack.setPlayCount(++playCount);
         m_counted = true;
     }
     emit positionChanged(ms);
@@ -115,10 +114,10 @@ void PlayerController::changePosition(uint64_t ms)
     emit positionMoved(ms);
 }
 
-void PlayerController::changeCurrentTrack(Track* track)
+void PlayerController::changeCurrentTrack(const Track& track)
 {
     m_currentTrack  = track;
-    m_totalDuration = track->duration();
+    m_totalDuration = track.duration();
     m_position      = 0;
     m_counted       = false;
 
@@ -162,7 +161,7 @@ uint64_t PlayerController::currentPosition() const
     return m_position;
 }
 
-Track* PlayerController::currentTrack() const
+Track PlayerController::currentTrack() const
 {
     return m_currentTrack;
 }

--- a/src/core/player/playercontroller.h
+++ b/src/core/player/playercontroller.h
@@ -19,12 +19,12 @@
 
 #pragma once
 
+#include "core/models/track.h"
 #include "playermanager.h"
 
 #include <QObject>
 
 namespace Fy {
-
 namespace Utils {
 class SettingsManager;
 }
@@ -48,7 +48,7 @@ protected:
     void stop() override;
     void setCurrentPosition(uint64_t ms) override;
     void changePosition(uint64_t ms) override;
-    void changeCurrentTrack(Track* track) override;
+    void changeCurrentTrack(const Track& track) override;
     void setPlayMode(PlayMode mode) override;
     void volumeUp() override;
     void volumeDown() override;
@@ -57,7 +57,7 @@ protected:
     [[nodiscard]] PlayState playState() const override;
     [[nodiscard]] PlayMode playMode() const override;
     [[nodiscard]] uint64_t currentPosition() const override;
-    [[nodiscard]] Track* currentTrack() const override;
+    [[nodiscard]] Track currentTrack() const override;
     [[nodiscard]] double volume() const override;
 
 private:
@@ -65,7 +65,7 @@ private:
 
     Utils::SettingsManager* m_settings;
 
-    Track* m_currentTrack;
+    Track m_currentTrack;
     uint64_t m_totalDuration;
     PlayState m_playStatus;
     PlayMode m_playMode;

--- a/src/core/player/playermanager.h
+++ b/src/core/player/playermanager.h
@@ -54,7 +54,7 @@ public:
     [[nodiscard]] virtual PlayState playState() const      = 0;
     [[nodiscard]] virtual PlayMode playMode() const        = 0;
     [[nodiscard]] virtual uint64_t currentPosition() const = 0;
-    [[nodiscard]] virtual Track* currentTrack() const      = 0;
+    [[nodiscard]] virtual Track currentTrack() const       = 0;
     [[nodiscard]] virtual double volume() const            = 0;
 
 signals:
@@ -65,26 +65,26 @@ signals:
     void previousTrack();
     void positionChanged(uint64_t ms);
     void positionMoved(uint64_t ms);
-    void currentTrackChanged(Core::Track* track);
+    void currentTrackChanged(const Core::Track& track);
     void volumeChanged(double value);
     void muteChanged(bool b);
 
 public:
-    virtual void play()                                 = 0;
-    virtual void wakeUp()                               = 0;
-    virtual void playPause()                            = 0;
-    virtual void pause()                                = 0;
-    virtual void previous()                             = 0;
-    virtual void next()                                 = 0;
-    virtual void stop()                                 = 0;
-    virtual void reset()                                = 0;
-    virtual void setPlayMode(PlayMode mode)             = 0;
-    virtual void setCurrentPosition(uint64_t ms)        = 0;
-    virtual void changePosition(uint64_t ms)            = 0;
-    virtual void changeCurrentTrack(Core::Track* track) = 0;
-    virtual void volumeUp()                             = 0;
-    virtual void volumeDown()                           = 0;
-    virtual void setVolume(double vol)                  = 0;
+    virtual void play()                                       = 0;
+    virtual void wakeUp()                                     = 0;
+    virtual void playPause()                                  = 0;
+    virtual void pause()                                      = 0;
+    virtual void previous()                                   = 0;
+    virtual void next()                                       = 0;
+    virtual void stop()                                       = 0;
+    virtual void reset()                                      = 0;
+    virtual void setPlayMode(PlayMode mode)                   = 0;
+    virtual void setCurrentPosition(uint64_t ms)              = 0;
+    virtual void changePosition(uint64_t ms)                  = 0;
+    virtual void changeCurrentTrack(const Core::Track& track) = 0;
+    virtual void volumeUp()                                   = 0;
+    virtual void volumeDown()                                 = 0;
+    virtual void setVolume(double vol)                        = 0;
 };
 } // namespace Player
 } // namespace Fy::Core

--- a/src/core/playlist/libraryplaylistinterface.h
+++ b/src/core/playlist/libraryplaylistinterface.h
@@ -27,7 +27,7 @@ class LibraryPlaylistInterface
 public:
     virtual ~LibraryPlaylistInterface() = default;
 
-    virtual void createPlaylist(const TrackPtrList& tracks, int startIndex) = 0;
-    virtual void append(const TrackPtrList& tracks)                         = 0;
+    virtual void createPlaylist(const TrackList& tracks, int startIndex) = 0;
+    virtual void append(const TrackList& tracks)                         = 0;
 };
 } // namespace Fy::Core::Playlist

--- a/src/core/playlist/libraryplaylistmanager.cpp
+++ b/src/core/playlist/libraryplaylistmanager.cpp
@@ -28,14 +28,14 @@ LibraryPlaylistManager::LibraryPlaylistManager(Library::MusicLibrary* library, P
     , m_playlistHandler{playlistHandler}
 { }
 
-void LibraryPlaylistManager::createPlaylist(const TrackPtrList& tracks, int startIndex)
+void LibraryPlaylistManager::createPlaylist(const TrackList& tracks, int startIndex)
 {
     const QString name = "Playlist";
     m_playlistHandler->createPlaylist(tracks, name);
     activatePlaylist(startIndex);
 }
 
-void LibraryPlaylistManager::append(const TrackPtrList& tracks)
+void LibraryPlaylistManager::append(const TrackList& tracks)
 {
     auto* playlist = m_playlistHandler->activePlaylist();
     playlist->appendTracks(tracks);

--- a/src/core/playlist/libraryplaylistmanager.h
+++ b/src/core/playlist/libraryplaylistmanager.h
@@ -35,8 +35,8 @@ class LibraryPlaylistManager : public LibraryPlaylistInterface
 public:
     explicit LibraryPlaylistManager(Library::MusicLibrary* library, PlaylistManager* playlistHandler);
 
-    void createPlaylist(const TrackPtrList& tracks, int startIndex) override;
-    void append(const TrackPtrList& tracks) override;
+    void createPlaylist(const TrackList& tracks, int startIndex) override;
+    void append(const TrackList& tracks) override;
 
 private:
     void activatePlaylist(int startIndex);

--- a/src/core/playlist/playlist.cpp
+++ b/src/core/playlist/playlist.cpp
@@ -39,7 +39,7 @@ QString Playlist::name()
     return m_name;
 }
 
-int Playlist::createPlaylist(const TrackPtrList& tracks)
+int Playlist::createPlaylist(const TrackList& tracks)
 {
     m_tracks.insert(m_tracks.end(), tracks.begin(), tracks.end());
     return static_cast<int>(m_tracks.size());
@@ -47,12 +47,8 @@ int Playlist::createPlaylist(const TrackPtrList& tracks)
 
 int Playlist::currentTrackIndex() const
 {
-    if(!m_playingTrack) {
-        return -1;
-    }
-
-    auto it = std::find_if(m_tracks.cbegin(), m_tracks.cend(), [this](Track* track) {
-        return (track->id() == m_playingTrack->id());
+    auto it = std::find_if(m_tracks.cbegin(), m_tracks.cend(), [this](const Track& track) {
+        return (track.id() == m_playingTrack.id());
     });
 
     if(it == m_tracks.end()) {
@@ -62,7 +58,7 @@ int Playlist::currentTrackIndex() const
     return static_cast<int>(std::distance(m_tracks.cbegin(), it));
 }
 
-Track* Playlist::currentTrack() const
+Track Playlist::currentTrack() const
 {
     const auto trackIndex = currentTrackIndex();
     if(trackIndex >= numberOfTracks() || trackIndex < 0) {
@@ -77,12 +73,12 @@ int Playlist::index() const
     return m_playlistIndex;
 }
 
-void Playlist::insertTracks(const TrackPtrList& tracks)
+void Playlist::insertTracks(const TrackList& tracks)
 {
     m_tracks = tracks;
 }
 
-void Playlist::appendTracks(const TrackPtrList& tracks)
+void Playlist::appendTracks(const TrackList& tracks)
 {
     m_tracks.insert(m_tracks.end(), tracks.begin(), tracks.end());
 }
@@ -99,7 +95,7 @@ void Playlist::setCurrentTrack(int index)
     }
 
     else {
-        Track* track   = m_tracks[index];
+        Track track    = m_tracks[index];
         m_playingTrack = track;
         m_playerManager->changeCurrentTrack(track);
     }
@@ -114,8 +110,8 @@ bool Playlist::changeTrack(int index)
         return false;
     }
 
-    while(!Utils::File::exists(m_tracks[index]->filepath())) {
-        Utils::showMessageBox(QString{"Track %1 cannot be found."}.arg(index), m_tracks[index]->filepath());
+    while(!Utils::File::exists(m_tracks[index].filepath())) {
+        Utils::showMessageBox(QString{"Track %1 cannot be found."}.arg(index), m_tracks[index].filepath());
         setCurrentTrack(++index);
     }
 
@@ -131,10 +127,7 @@ void Playlist::play()
     }
 }
 
-void Playlist::stop()
-{
-    m_playingTrack = nullptr;
-}
+void Playlist::stop() { }
 
 int Playlist::next()
 {

--- a/src/core/playlist/playlist.h
+++ b/src/core/playlist/playlist.h
@@ -39,15 +39,15 @@ public:
 
     QString name();
 
-    int createPlaylist(const TrackPtrList& tracks);
+    int createPlaylist(const TrackList& tracks);
 
     [[nodiscard]] int currentTrackIndex() const;
-    [[nodiscard]] Track* currentTrack() const;
+    [[nodiscard]] Track currentTrack() const;
 
     [[nodiscard]] int index() const;
 
-    void insertTracks(const TrackPtrList& tracks);
-    void appendTracks(const TrackPtrList& tracks);
+    void insertTracks(const TrackList& tracks);
+    void appendTracks(const TrackList& tracks);
 
     void clear();
 
@@ -68,8 +68,8 @@ private:
 
     QString m_name;
     int m_playlistIndex;
-    Track* m_playingTrack;
-    TrackPtrList m_tracks;
+    Track m_playingTrack;
+    TrackList m_tracks;
 };
 } // namespace Playlist
 } // namespace Fy::Core

--- a/src/core/playlist/playlisthandler.cpp
+++ b/src/core/playlist/playlisthandler.cpp
@@ -47,7 +47,7 @@ Playlist* PlaylistHandler::playlist(int id)
     return {};
 }
 
-int PlaylistHandler::createPlaylist(const TrackPtrList& tracks, const QString& name)
+int PlaylistHandler::createPlaylist(const TrackList& tracks, const QString& name)
 {
     const auto index = addNewPlaylist(name);
 

--- a/src/core/playlist/playlisthandler.h
+++ b/src/core/playlist/playlisthandler.h
@@ -43,7 +43,7 @@ public:
 
     Playlist* playlist(int id) override;
 
-    int createPlaylist(const TrackPtrList& tracks, const QString& name) override;
+    int createPlaylist(const TrackList& tracks, const QString& name) override;
     int createEmptyPlaylist() override;
 
     [[nodiscard]] int activeIndex() const override;

--- a/src/core/playlist/playlistmanager.h
+++ b/src/core/playlist/playlistmanager.h
@@ -38,7 +38,7 @@ public:
 
     [[nodiscard]] virtual int count() const = 0;
 
-    virtual int createPlaylist(const TrackPtrList& tracks, const QString& name) = 0;
+    virtual int createPlaylist(const TrackList& tracks, const QString& name) = 0;
     virtual int createEmptyPlaylist()                                           = 0;
 };
 } // namespace Fy::Core::Playlist

--- a/src/core/scripting/scriptparser.cpp
+++ b/src/core/scripting/scriptparser.cpp
@@ -72,13 +72,13 @@ QString Parser::evaluate(const ParsedScript& input)
     return m_result;
 }
 
-QString Parser::evaluate(const ParsedScript& input, Track* track)
+QString Parser::evaluate(const ParsedScript& input, const Core::Track& track)
 {
     setMetadata(track);
     return evaluate(input);
 }
 
-void Parser::setMetadata(Track* track)
+void Parser::setMetadata(const Core::Track& track)
 {
     m_registry.changeCurrentTrack(track);
 }

--- a/src/core/scripting/scriptparser.h
+++ b/src/core/scripting/scriptparser.h
@@ -41,11 +41,11 @@ public:
     ParsedScript parse(const QString& input);
 
     QString evaluate();
-    QString evaluate(const ParsedScript& input, Track* track);
+    QString evaluate(const ParsedScript& input, const Core::Track& track);
 
     virtual QString evaluate(const ParsedScript& input);
 
-    void setMetadata(Track* track);
+    void setMetadata(const Core::Track& track);
 
 protected:
     ScriptResult evalExpression(const Expression& exp) const;

--- a/src/core/scripting/scriptregistry.cpp
+++ b/src/core/scripting/scriptregistry.cpp
@@ -49,11 +49,11 @@ ScriptResult Registry::varValue(const QString& var) const
     if(var.isEmpty()) {
         return {};
     }
-    if(m_metadata.count(var) && m_currentTrack) {
+    if(m_metadata.count(var)) {
         auto function = m_metadata.at(var);
         if(std::holds_alternative<StringFunc>(function)) {
             const auto f        = std::get<0>(function);
-            const QString value = (m_currentTrack->*f)();
+            const QString value = (m_currentTrack.*f)();
 
             ScriptResult result;
             result.value = value;
@@ -61,8 +61,8 @@ ScriptResult Registry::varValue(const QString& var) const
             return result;
         }
         if(std::holds_alternative<IntegerFunc>(function)) {
-            const auto f    = std::get<1>(function);
-            const int value = (m_currentTrack->*f)();
+            auto f    = std::get<1>(function);
+            int value = (m_currentTrack.*f)();
 
             ScriptResult result;
             result.value = QString::number(value);
@@ -71,7 +71,7 @@ ScriptResult Registry::varValue(const QString& var) const
         }
         if(std::holds_alternative<StringListFunc>(function)) {
             const auto f            = std::get<2>(function);
-            const QStringList value = (m_currentTrack->*f)();
+            const QStringList value = (m_currentTrack.*f)();
 
             ScriptResult result;
             result.value = value.empty() ? "" : value.join(Constants::Separator);
@@ -80,7 +80,7 @@ ScriptResult Registry::varValue(const QString& var) const
         }
         if(std::holds_alternative<U64Func>(function)) {
             const auto f         = std::get<3>(function);
-            const uint64_t value = (m_currentTrack->*f)();
+            const uint64_t value = (m_currentTrack.*f)();
 
             ScriptResult result;
             result.value = QString::number(value);
@@ -119,7 +119,7 @@ ScriptResult Registry::function(const QString& func, const ValueList& args) cons
     return {};
 }
 
-void Registry::changeCurrentTrack(Track* track)
+void Registry::changeCurrentTrack(const Core::Track& track)
 {
     m_currentTrack = track;
 }

--- a/src/core/scripting/scriptregistry.h
+++ b/src/core/scripting/scriptregistry.h
@@ -21,12 +21,11 @@
 
 #include "scriptvalue.h"
 
+#include <core/models/track.h>
+
 #include <QObject>
 
-namespace Fy::Core {
-class Track;
-
-namespace Scripting {
+namespace Fy::Core::Scripting {
 class Registry
 {
 public:
@@ -38,7 +37,7 @@ public:
     ScriptResult varValue(const QString& var) const;
     ScriptResult function(const QString& func, const ValueList& args) const;
 
-    void changeCurrentTrack(Track* track);
+    void changeCurrentTrack(const Core::Track& track);
 
     template <typename NewCntr, typename Cntr>
     NewCntr containerCast(Cntr&& from) const
@@ -52,20 +51,19 @@ private:
 
     using Func = std::variant<NativeFunc, NativeCondFunc>;
 
-    using StringFunc     = QString (Track::*)();
-    using IntegerFunc    = int (Track::*)();
-    using StringListFunc = QStringList (Track::*)();
-    using U64Func        = uint64_t (Track::*)();
+    using StringFunc     = QString (Track::*)() const;
+    using IntegerFunc    = int (Track::*)() const;
+    using StringListFunc = QStringList (Track::*)() const;
+    using U64Func        = uint64_t (Track::*)() const;
 
     using TrackFunc = std::variant<StringFunc, IntegerFunc, StringListFunc, U64Func>;
 
     void addDefaultFunctions();
     void addDefaultMetadata();
 
-    Track* m_currentTrack;
+    Track m_currentTrack;
     std::unordered_map<QString, TrackFunc> m_metadata;
     std::unordered_map<QString, QVariant> m_vars;
     std::unordered_map<QString, Func> m_funcs;
 };
 } // namespace Scripting
-} // namespace Fy::Core

--- a/src/gui/controls/controlwidget.cpp
+++ b/src/gui/controls/controlwidget.cpp
@@ -59,8 +59,8 @@ void ControlWidget::setupUi()
     m_layout->setContentsMargins(0, 0, 0, 0);
     m_layout->setSpacing(15);
 
-    m_playerControls->setEnabled(m_playerManager->currentTrack());
-    m_progress->setEnabled(m_playerManager->currentTrack());
+    m_playerControls->setEnabled(m_playerManager->currentTrack().id());
+    m_progress->setEnabled(m_playerManager->currentTrack().id());
     m_progress->changeTrack(m_playerManager->currentTrack());
 }
 

--- a/src/gui/controls/progresswidget.cpp
+++ b/src/gui/controls/progresswidget.cpp
@@ -69,16 +69,13 @@ void ProgressWidget::setupUi()
     m_layout->addWidget(m_slider, 0, Qt::AlignVCenter);
     m_layout->addWidget(m_total, 0, Qt::AlignVCenter | Qt::AlignLeft);
 
-    setEnabled(m_playerManager->currentTrack());
+    setEnabled(m_playerManager->currentTrack().id());
 }
 
-void ProgressWidget::changeTrack(Core::Track* track)
+void ProgressWidget::changeTrack(const Core::Track& track)
 {
-    if(!track) {
-        return;
-    }
     reset();
-    m_max = static_cast<int>(track->duration());
+    m_max = static_cast<int>(track.duration());
     m_slider->setMaximum(m_max);
     m_total->setText(m_elapsedTotal ? "-" : "" + Utils::msToString(m_max));
 }

--- a/src/gui/controls/progresswidget.h
+++ b/src/gui/controls/progresswidget.h
@@ -51,7 +51,7 @@ public:
 
     void setupUi();
 
-    void changeTrack(Core::Track* track);
+    void changeTrack(const Core::Track& track);
     void setCurrentPosition(int ms);
     void updateTime(int elapsed);
     void reset();

--- a/src/gui/info/infomodel.cpp
+++ b/src/gui/info/infomodel.cpp
@@ -113,35 +113,33 @@ QVariant InfoModel::data(const QModelIndex& index, int role) const
         return item->data();
     }
 
-    Core::Track* track = m_playerManager->currentTrack();
+    Core::Track track = m_playerManager->currentTrack();
 
-    if(track) {
-        switch(item->role()) {
-            case(InfoItem::Title):
-                return track->title();
-            case(InfoItem::Artist):
-                return track->artists().join(", ");
-            case(InfoItem::Album):
-                return track->album();
-            case(InfoItem::Year):
-                return track->year();
-            case(InfoItem::Genre):
-                return track->genres().join(", ");
-            case(InfoItem::TrackNumber):
-                return track->trackNumber();
-            case(InfoItem::Filename):
-                return track->filepath().split("/").constLast();
-            case(InfoItem::Path):
-                return track->filepath();
-            case(InfoItem::Duration):
-                return Utils::msToString(track->duration());
-            case(InfoItem::Bitrate):
-                return QString::number(track->bitrate()).append(" kbps");
-            case(InfoItem::SampleRate):
-                return track->sampleRate();
-            case(InfoItem::None):
-                break;
-        }
+    switch(item->role()) {
+        case(InfoItem::Title):
+            return track.title();
+        case(InfoItem::Artist):
+            return track.artists().join(", ");
+        case(InfoItem::Album):
+            return track.album();
+        case(InfoItem::Year):
+            return track.year();
+        case(InfoItem::Genre):
+            return track.genres().join(", ");
+        case(InfoItem::TrackNumber):
+            return track.trackNumber();
+        case(InfoItem::Filename):
+            return track.filepath().split("/").constLast();
+        case(InfoItem::Path):
+            return track.filepath();
+        case(InfoItem::Duration):
+            return Utils::msToString(track.duration());
+        case(InfoItem::Bitrate):
+            return QString::number(track.bitrate()).append(" kbps");
+        case(InfoItem::SampleRate):
+            return track.sampleRate();
+        case(InfoItem::None):
+            break;
     }
     return {};
 }

--- a/src/gui/info/infomodel.cpp
+++ b/src/gui/info/infomodel.cpp
@@ -113,7 +113,11 @@ QVariant InfoModel::data(const QModelIndex& index, int role) const
         return item->data();
     }
 
-    Core::Track track = m_playerManager->currentTrack();
+    const Core::Track track = m_playerManager->currentTrack();
+
+    if(!track.isValid()) {
+        return {};
+    }
 
     switch(item->role()) {
         case(InfoItem::Title):

--- a/src/gui/library/coverwidget.cpp
+++ b/src/gui/library/coverwidget.cpp
@@ -71,7 +71,7 @@ void CoverWidget::reloadCover()
 {
     QString coverPath;
     Core::Track track = m_playerManager->currentTrack();
-    if(track.id()) {
+    if(track.isValid()) {
         coverPath = track.coverPath();
     }
 

--- a/src/gui/library/coverwidget.cpp
+++ b/src/gui/library/coverwidget.cpp
@@ -70,17 +70,16 @@ void CoverWidget::resizeEvent(QResizeEvent* e)
 void CoverWidget::reloadCover()
 {
     QString coverPath;
-    if(auto* track = m_playerManager->currentTrack()) {
-        coverPath = track->coverPath();
+    Core::Track track = m_playerManager->currentTrack();
+    if(track.id()) {
+        coverPath = track.coverPath();
     }
 
     else {
         auto tracks = m_library->tracks();
         if(!tracks.empty()) {
-            Core::Track* track = tracks.front();
-            if(track) {
-                coverPath = track->coverPath();
-            }
+            Core::Track track = tracks.front();
+            coverPath         = track.coverPath();
         }
     }
 

--- a/src/gui/library/coverwidget.cpp
+++ b/src/gui/library/coverwidget.cpp
@@ -36,7 +36,11 @@ CoverWidget::CoverWidget(Core::Library::MusicLibrary* library, Core::Player::Pla
     , m_coverLabel{new QLabel(this)}
 {
     setObjectName("Artwork");
-    setupUi();
+
+    m_layout->setContentsMargins(0, 0, 0, 0);
+    m_layout->setAlignment(Qt::AlignCenter);
+    m_coverLabel->setMinimumSize(100, 100);
+    m_layout->addWidget(m_coverLabel);
 
     connect(m_playerManager, &Core::Player::PlayerManager::currentTrackChanged, this, &CoverWidget::reloadCover);
     //    connect(m_library, &Core::Library::MusicLibrary::tracksChanged, this, &CoverWidget::reloadCover);
@@ -47,16 +51,6 @@ CoverWidget::CoverWidget(Core::Library::MusicLibrary* library, Core::Player::Pla
 QString CoverWidget::name() const
 {
     return "Artwork";
-}
-
-void CoverWidget::setupUi()
-{
-    m_layout->setContentsMargins(0, 0, 0, 0);
-    m_layout->setAlignment(Qt::AlignCenter);
-    //    setAutoFillBackground(true);
-
-    m_coverLabel->setMinimumSize(100, 100);
-    m_layout->addWidget(m_coverLabel);
 }
 
 void CoverWidget::resizeEvent(QResizeEvent* e)

--- a/src/gui/library/coverwidget.cpp
+++ b/src/gui/library/coverwidget.cpp
@@ -39,9 +39,9 @@ CoverWidget::CoverWidget(Core::Library::MusicLibrary* library, Core::Player::Pla
     setupUi();
 
     connect(m_playerManager, &Core::Player::PlayerManager::currentTrackChanged, this, &CoverWidget::reloadCover);
-    connect(m_library, &Core::Library::MusicLibrary::tracksChanged, this, &CoverWidget::reloadCover);
+    //    connect(m_library, &Core::Library::MusicLibrary::tracksChanged, this, &CoverWidget::reloadCover);
 
-    reloadCover();
+    reloadCover({});
 }
 
 QString CoverWidget::name() const
@@ -67,28 +67,14 @@ void CoverWidget::resizeEvent(QResizeEvent* e)
     QWidget::resizeEvent(e);
 }
 
-void CoverWidget::reloadCover()
+void CoverWidget::reloadCover(const Core::Track& track)
 {
     QString coverPath;
-    Core::Track track = m_playerManager->currentTrack();
     if(track.isValid()) {
         coverPath = track.coverPath();
     }
-
     else {
-        auto tracks = m_library->tracks();
-        if(!tracks.empty()) {
-            Core::Track track = tracks.front();
-            coverPath         = track.coverPath();
-        }
-    }
-
-    if(coverPath.isEmpty()) {
         coverPath = "://images/nocover.png";
-        //        setAutoFillBackground(true);
-        //        QPalette palette = m_coverLabel->palette();
-        //        palette.setColor(m_coverLabel->backgroundRole(), palette.base().color());
-        //        m_coverLabel->setPalette(palette);
     }
 
     if(coverPath != m_coverPath) {

--- a/src/gui/library/coverwidget.h
+++ b/src/gui/library/coverwidget.h
@@ -27,6 +27,8 @@ class QLabel;
 namespace Fy {
 
 namespace Core {
+class Track;
+
 namespace Library {
 class MusicLibrary;
 }
@@ -51,7 +53,7 @@ protected:
 
 private:
     void setupUi();
-    void reloadCover();
+    void reloadCover(const Core::Track& track);
     void rescaleCover();
 
     Core::Library::MusicLibrary* m_library;

--- a/src/gui/library/coverwidget.h
+++ b/src/gui/library/coverwidget.h
@@ -52,7 +52,6 @@ protected:
     void resizeEvent(QResizeEvent* event) override;
 
 private:
-    void setupUi();
     void reloadCover(const Core::Track& track);
     void rescaleCover();
 

--- a/src/gui/library/statuswidget.cpp
+++ b/src/gui/library/statuswidget.cpp
@@ -91,8 +91,8 @@ void StatusWidget::labelClicked()
 
 void StatusWidget::reloadStatus()
 {
-    auto* track = m_playerManager->currentTrack();
-    m_playing->setText(track->title());
+    Core::Track track = m_playerManager->currentTrack();
+    m_playing->setText(track.title());
 }
 
 void StatusWidget::stateChanged(Core::Player::PlayState state)
@@ -102,12 +102,12 @@ void StatusWidget::stateChanged(Core::Player::PlayState state)
             m_playing->setText("Waiting for track...");
             break;
         case(Core::Player::Playing): {
-            auto* track      = m_playerManager->currentTrack();
-            auto number      = QStringLiteral("%1").arg(track->trackNumber(), 2, 10, QLatin1Char('0'));
-            auto duration    = QString(" (%1)").arg(Utils::msToString(track->duration()));
-            auto albumArtist = !track->albumArtist().isEmpty() ? " \u2022 " + track->albumArtist() : "";
-            auto album       = !track->album().isEmpty() ? " \u2022 " + track->album() : "";
-            auto text        = number + ". " + track->title() + duration + albumArtist + album;
+            Core::Track track = m_playerManager->currentTrack();
+            auto number       = QStringLiteral("%1").arg(track.trackNumber(), 2, 10, QLatin1Char('0'));
+            auto duration     = QString(" (%1)").arg(Utils::msToString(track.duration()));
+            auto albumArtist  = !track.albumArtist().isEmpty() ? " \u2022 " + track.albumArtist() : "";
+            auto album        = !track.album().isEmpty() ? " \u2022 " + track.album() : "";
+            auto text         = number + ". " + track.title() + duration + albumArtist + album;
             m_playing->setText(text);
         }
         case(Core::Player::Paused):

--- a/src/gui/playlist/playlistitem.h
+++ b/src/gui/playlist/playlistitem.h
@@ -19,19 +19,20 @@
 
 #pragma once
 
+#include <core/models/track.h>
+
 #include <utils/treeitem.h>
 
 #include <QObject>
 
 namespace Fy {
 namespace Core {
-class Track;
 class Album;
 class Container;
 } // namespace Core
 
 namespace Gui::Widgets {
-using ItemType = std::variant<Core::Track*, Core::Album*, Core::Container*>;
+using ItemType = std::variant<Core::Track, Core::Album*, Core::Container*>;
 
 class PlaylistItem : public Utils::TreeItem<PlaylistItem>
 {

--- a/src/gui/playlist/playlistmodel.h
+++ b/src/gui/playlist/playlistmodel.h
@@ -31,7 +31,6 @@
 #include <QPixmap>
 
 namespace Fy {
-
 namespace Utils {
 class SettingsManager;
 }
@@ -70,7 +69,7 @@ public:
     [[nodiscard]] QModelIndexList match(const QModelIndex& start, int role, const QVariant& value, int hits,
                                         Qt::MatchFlags flags) const override;
 
-    [[nodiscard]] Core::TrackPtrList tracks() const;
+    [[nodiscard]] Core::TrackList tracks() const;
 
     void reset();
     void changeRowColours();
@@ -78,14 +77,14 @@ public:
 
     [[nodiscard]] QModelIndex indexForId(int id) const;
     [[nodiscard]] QModelIndex indexForItem(PlaylistItem* item) const;
-    [[nodiscard]] int findTrackIndex(Core::Track* track) const;
+    [[nodiscard]] int findTrackIndex(const Core::Track& track) const;
 
 private:
     using PlaylistItemHash = std::unordered_map<QString, std::unique_ptr<PlaylistItem>>;
 
     void setupModelData();
-    void createAlbums(const Core::TrackPtrList& tracks);
-    PlaylistItem* iterateTrack(Core::Track* track, bool discHeaders, bool splitDiscs);
+    void createAlbums(const Core::TrackList& tracks);
+    PlaylistItem* iterateTrack(const Core::Track& track, bool discHeaders, bool splitDiscs);
 
     PlaylistItem* checkInsertKey(const QString& key, PlaylistItem::Type type, const ItemType& item,
                                  PlaylistItem* parent);
@@ -109,7 +108,7 @@ private:
     bool m_altColours;
     bool m_simplePlaylist;
 
-    Core::TrackPtrList m_tracks;
+    Core::TrackList m_tracks;
 
     bool m_resetting;
 

--- a/src/gui/playlist/playlistmodel.h
+++ b/src/gui/playlist/playlistmodel.h
@@ -72,7 +72,7 @@ public:
     [[nodiscard]] Core::TrackList tracks() const;
 
     void reset();
-    void changeRowColours();
+    void setupModelData();
     void changeTrackState();
 
     [[nodiscard]] QModelIndex indexForId(int id) const;
@@ -82,7 +82,6 @@ public:
 private:
     using PlaylistItemHash = std::unordered_map<QString, std::unique_ptr<PlaylistItem>>;
 
-    void setupModelData();
     void createAlbums(const Core::TrackList& tracks);
     PlaylistItem* iterateTrack(const Core::Track& track, bool discHeaders, bool splitDiscs);
 

--- a/src/gui/playlist/playlistwidget.cpp
+++ b/src/gui/playlist/playlistwidget.cpp
@@ -122,10 +122,12 @@ void PlaylistWidget::setupConnections()
     connect(m_model, &QAbstractItemModel::modelReset, this, &PlaylistWidget::reset);
     connect(m_model, &QAbstractItemModel::modelAboutToBeReset, m_playlist, &QAbstractItemView::clearSelection);
 
-    connect(m_playlist->header(), &QHeaderView::customContextMenuRequested, this,
+    connect(m_playlist->header(),
+            &QHeaderView::customContextMenuRequested,
+            this,
             &PlaylistWidget::customHeaderMenuRequested);
-    connect(m_playlist->selectionModel(), &QItemSelectionModel::selectionChanged, this,
-            &PlaylistWidget::selectionChanged);
+    connect(
+        m_playlist->selectionModel(), &QItemSelectionModel::selectionChanged, this, &PlaylistWidget::selectionChanged);
     connect(m_playlist, &PlaylistView::doubleClicked, this, &PlaylistWidget::playTrack);
 
     connect(m_playerManager, &Core::Player::PlayerManager::playStateChanged, this, &PlaylistWidget::changeState);
@@ -212,8 +214,7 @@ void PlaylistWidget::selectionChanged()
         if(index.isValid()) {
             const auto type = index.data(Playlist::Type).value<PlaylistItem::Type>();
             if(type == PlaylistItem::Track) {
-                auto* track = index.data(PlaylistItem::Role::Data).value<Core::Track*>();
-                m_selectedTracks.emplace_back(track);
+                m_selectedTracks.emplace_back(index.data(PlaylistItem::Role::Data).value<Core::Track>());
             }
             else {
                 const QItemSelection selectedChildren{m_model->index(0, 0, index),
@@ -323,17 +324,13 @@ void PlaylistWidget::changeState(Core::Player::PlayState state)
 void PlaylistWidget::playTrack(const QModelIndex& index)
 {
     const auto type = index.data(Playlist::Type).value<PlaylistItem::Type>();
-    Core::Track* track{nullptr};
+    Core::Track track;
 
     if(type != PlaylistItem::Track && !m_selectedTracks.empty()) {
         track = m_selectedTracks.front();
     }
     else {
-        track = index.data(PlaylistItem::Role::Data).value<Core::Track*>();
-    }
-
-    if(!track) {
-        return;
+        track = index.data(PlaylistItem::Role::Data).value<Core::Track>();
     }
 
     const int playlistIndex = m_model->findTrackIndex(track);

--- a/src/gui/playlist/playlistwidget.cpp
+++ b/src/gui/playlist/playlistwidget.cpp
@@ -164,25 +164,6 @@ QString PlaylistWidget::name() const
     return "Playlist";
 }
 
-void PlaylistWidget::layoutEditingMenu(Utils::ActionContainer* menu)
-{
-    auto* showHeaders = new QAction("Show Header", menu);
-    showHeaders->setCheckable(true);
-    showHeaders->setChecked(!isHeaderHidden());
-    QAction::connect(showHeaders, &QAction::triggered, this, [this] {
-        m_settings->set<Settings::PlaylistHeader>(isHeaderHidden());
-    });
-    menu->addAction(showHeaders);
-
-    auto* showScrollBar = new QAction("Show Scrollbar", menu);
-    showScrollBar->setCheckable(true);
-    showScrollBar->setChecked(!isScrollbarHidden());
-    QAction::connect(showScrollBar, &QAction::triggered, this, [this] {
-        m_settings->set<Settings::PlaylistScrollBar>(isScrollbarHidden());
-    });
-    menu->addAction(showScrollBar);
-}
-
 void PlaylistWidget::selectionChanged()
 {
     if(m_changingSelection) {

--- a/src/gui/playlist/playlistwidget.h
+++ b/src/gui/playlist/playlistwidget.h
@@ -76,7 +76,6 @@ public:
     void setScrollbarHidden(bool showScrollBar);
 
     [[nodiscard]] QString name() const override;
-    void layoutEditingMenu(Utils::ActionContainer* menu) override;
 
 signals:
     void clickedTrack(int idx);

--- a/src/gui/playlist/playlistwidget.h
+++ b/src/gui/playlist/playlistwidget.h
@@ -69,8 +69,6 @@ public:
 
     void setupConnections();
 
-    void setAltRowColours(bool altColours);
-
     bool isHeaderHidden();
     void setHeaderHidden(bool showHeader);
 
@@ -114,7 +112,6 @@ private:
     QHBoxLayout* m_layout;
     PlaylistModel* m_model;
     PlaylistView* m_playlist;
-    bool m_altRowColours;
     bool m_changingSelection;
     Utils::OverlayWidget* m_noLibrary;
 };

--- a/src/gui/playlist/playlistwidget.h
+++ b/src/gui/playlist/playlistwidget.h
@@ -82,7 +82,7 @@ public:
 
 signals:
     void clickedTrack(int idx);
-    void selectionWasChanged(const Core::TrackPtrList& tracks);
+    void selectionWasChanged(const Core::TrackList& tracks);
 
 protected:
     void selectionChanged();
@@ -109,7 +109,7 @@ private:
     Core::Playlist::PlaylistManager* m_playlistHandler;
     std::unique_ptr<Core::Playlist::LibraryPlaylistInterface> m_libraryPlaylistManager;
 
-    Core::TrackPtrList m_selectedTracks;
+    Core::TrackList m_selectedTracks;
 
     QHBoxLayout* m_layout;
     PlaylistModel* m_model;

--- a/src/gui/settings/playlistguipage.cpp
+++ b/src/gui/settings/playlistguipage.cpp
@@ -43,8 +43,10 @@ private:
     QRadioButton* m_noHeaders;
     QRadioButton* m_discSubheaders;
     QRadioButton* m_splitDiscs;
-    QCheckBox* m_simpleList;
+    QCheckBox* m_scrollBars;
+    QCheckBox* m_header;
     QCheckBox* m_altColours;
+    QCheckBox* m_simplePlaylist;
 };
 
 PlaylistGuiPageWidget::PlaylistGuiPageWidget(Utils::SettingsManager* settings)
@@ -52,8 +54,10 @@ PlaylistGuiPageWidget::PlaylistGuiPageWidget(Utils::SettingsManager* settings)
     , m_noHeaders{new QRadioButton(tr("None"), this)}
     , m_discSubheaders{new QRadioButton(tr("Disc Subheaders"), this)}
     , m_splitDiscs{new QRadioButton("Split Discs", this)}
-    , m_simpleList{new QCheckBox("Simple Playlist", this)}
+    , m_scrollBars{new QCheckBox("Show Scrollbar", this)}
+    , m_header{new QCheckBox("Show Header", this)}
     , m_altColours{new QCheckBox("Alternate Row Colours", this)}
+    , m_simplePlaylist{new QCheckBox("Simple Playlist", this)}
 {
     if(m_settings->value<Settings::DiscHeaders>()) {
         m_discSubheaders->setChecked(true);
@@ -65,8 +69,10 @@ PlaylistGuiPageWidget::PlaylistGuiPageWidget(Utils::SettingsManager* settings)
         m_noHeaders->setChecked(true);
     }
 
-    m_simpleList->setChecked(m_settings->value<Settings::SimplePlaylist>());
+    m_scrollBars->setChecked(m_settings->value<Settings::PlaylistScrollBar>());
+    m_header->setChecked(m_settings->value<Settings::PlaylistHeader>());
     m_altColours->setChecked(m_settings->value<Settings::PlaylistAltColours>());
+    m_simplePlaylist->setChecked(m_settings->value<Settings::SimplePlaylist>());
 
     auto* discBox       = new QGroupBox(tr("Disc Handling"), this);
     auto* discBoxLayout = new QVBoxLayout(discBox);
@@ -76,8 +82,10 @@ PlaylistGuiPageWidget::PlaylistGuiPageWidget(Utils::SettingsManager* settings)
 
     auto* mainLayout = new QVBoxLayout(this);
     mainLayout->addWidget(discBox);
-    mainLayout->addWidget(m_simpleList);
+    mainLayout->addWidget(m_scrollBars);
+    mainLayout->addWidget(m_header);
     mainLayout->addWidget(m_altColours);
+    mainLayout->addWidget(m_simplePlaylist);
     mainLayout->addStretch();
 }
 
@@ -85,8 +93,10 @@ void PlaylistGuiPageWidget::apply()
 {
     m_settings->set<Settings::DiscHeaders>(m_discSubheaders->isChecked());
     m_settings->set<Settings::SplitDiscs>(m_splitDiscs->isChecked());
-    m_settings->set<Settings::SimplePlaylist>(m_simpleList->isChecked());
+    m_settings->set<Settings::PlaylistScrollBar>(m_scrollBars->isChecked());
+    m_settings->set<Settings::PlaylistHeader>(m_header->isChecked());
     m_settings->set<Settings::PlaylistAltColours>(m_altColours->isChecked());
+    m_settings->set<Settings::SimplePlaylist>(m_simplePlaylist->isChecked());
 }
 
 PlaylistGuiPage::PlaylistGuiPage(Utils::SettingsManager* settings)

--- a/src/plugins/filters/filterfwd.h
+++ b/src/plugins/filters/filterfwd.h
@@ -49,7 +49,7 @@ struct LibraryFilter
 {
     FilterField field;
     int index;
-    Core::TrackPtrList tracks;
+    Core::TrackList tracks;
 };
 
 using IndexFieldMap = std::map<int, FilterField>;

--- a/src/plugins/filters/filteritem.cpp
+++ b/src/plugins/filters/filteritem.cpp
@@ -54,7 +54,7 @@ int FilterItem::trackCount() const
     return static_cast<int>(m_tracks.size());
 }
 
-void FilterItem::addTrack(Core::Track* track)
+void FilterItem::addTrack(const Core::Track& track)
 {
     m_tracks.emplace_back(track);
 }

--- a/src/plugins/filters/filteritem.h
+++ b/src/plugins/filters/filteritem.h
@@ -35,7 +35,7 @@ public:
 
     [[nodiscard]] QVariant data(int role) const;
     [[nodiscard]] int trackCount() const;
-    void addTrack(Core::Track* track);
+    void addTrack(const Core::Track& track);
 
     [[nodiscard]] bool hasSortTitle() const;
     void setSortTitle(const QString& title);
@@ -45,7 +45,7 @@ public:
 private:
     QString m_title;
     QString m_sortTitle;
-    Core::TrackPtrList m_tracks;
+    Core::TrackList m_tracks;
     bool m_isAllNode;
 };
 } // namespace Fy::Filters

--- a/src/plugins/filters/filtermanager.cpp
+++ b/src/plugins/filters/filtermanager.cpp
@@ -55,7 +55,7 @@ FilterManager::FilterManager(Utils::ThreadManager* threadManager, Core::Library:
     m_library->addInteractor(this);
 }
 
-Core::TrackPtrList FilterManager::tracks() const
+Core::TrackList FilterManager::tracks() const
 {
     return hasTracks() ? m_filteredTracks : m_library->allTracks();
 }
@@ -99,7 +99,8 @@ void FilterManager::getFilteredTracks()
             m_filteredTracks.insert(m_filteredTracks.cend(), filter.tracks.cbegin(), filter.tracks.cend());
         }
         else {
-            m_filteredTracks = Utils::intersection<Core::Track*>(filter.tracks, m_filteredTracks);
+            m_filteredTracks
+                = Utils::intersection<Core::Track, Core::Track::TrackHash>(filter.tracks, m_filteredTracks);
         }
     }
 
@@ -146,7 +147,7 @@ QMenu* FilterManager::filterHeaderMenu(int index, FilterField* field)
     return menu;
 }
 
-void FilterManager::tracksFiltered(const Core::TrackPtrList& tracks)
+void FilterManager::tracksFiltered(const Core::TrackList& tracks)
 {
     m_filteredTracks = tracks;
     emit filteredTracks();
@@ -156,5 +157,6 @@ void FilterManager::tracksFiltered(const Core::TrackPtrList& tracks)
 void FilterManager::tracksChanged()
 {
     emit filteredItems(-1);
+    getFilteredTracks();
 }
 } // namespace Fy::Filters

--- a/src/plugins/filters/filtermanager.h
+++ b/src/plugins/filters/filtermanager.h
@@ -47,7 +47,7 @@ public:
     explicit FilterManager(Utils::ThreadManager* threadManager, Core::Library::MusicLibrary* library,
                            FieldRegistry* fieldsRegistry, QObject* parent = nullptr);
 
-    [[nodiscard]] Core::TrackPtrList tracks() const override;
+    [[nodiscard]] Core::TrackList tracks() const override;
     [[nodiscard]] bool hasTracks() const override;
 
     LibraryFilter* registerFilter(const QString& name);
@@ -66,12 +66,12 @@ public:
 signals:
     void fieldChanged(const Fy::Filters::FilterField& field);
     void filterChanged(int index, const QString& name);
-    void filterTracks(const Core::TrackPtrList& tracks, const QString& search);
+    void filterTracks(const Core::TrackList& tracks, const QString& search);
     void filteredItems(int index);
     void filteredTracks();
 
 private:
-    void tracksFiltered(const Core::TrackPtrList& tracks);
+    void tracksFiltered(const Core::TrackList& tracks);
     void tracksChanged();
 
     Utils::ThreadManager* m_threadManager;
@@ -80,7 +80,7 @@ private:
     TrackFilterer m_searchManager;
 
     FieldRegistry* m_fieldsRegistry;
-    Core::TrackPtrList m_filteredTracks;
+    Core::TrackList m_filteredTracks;
     int m_lastFilterIndex;
     FilterStore m_filterStore;
     QString m_searchFilter;

--- a/src/plugins/filters/filtermodel.cpp
+++ b/src/plugins/filters/filtermodel.cpp
@@ -154,7 +154,7 @@ void FilterModel::sort(int column, Qt::SortOrder order)
 //}
 
 // TODO: Implement methods to insert/delete rows
-void FilterModel::reload(const Core::TrackPtrList& tracks)
+void FilterModel::reload(const Core::TrackList& tracks)
 {
     if(!m_field) {
         return;
@@ -172,7 +172,7 @@ void FilterModel::beginReset()
     m_root = std::make_unique<FilterItem>();
 }
 
-void FilterModel::setupModelData(const Core::TrackPtrList& tracks)
+void FilterModel::setupModelData(const Core::TrackList& tracks)
 {
     if(tracks.empty()) {
         return;
@@ -184,7 +184,7 @@ void FilterModel::setupModelData(const Core::TrackPtrList& tracks)
     const auto parsedField = m_parser->parse(m_field->field);
     const auto parsedSort  = m_parser->parse(m_field->sortField);
 
-    for(Core::Track* track : tracks) {
+    for(const Core::Track& track : tracks) {
         const QString field = m_parser->evaluate(parsedField, track);
         const QString sort  = m_parser->evaluate(parsedSort, track);
         if(field.isNull()) {

--- a/src/plugins/filters/filtermodel.h
+++ b/src/plugins/filters/filtermodel.h
@@ -52,11 +52,11 @@ public:
     void sort(int column, Qt::SortOrder order) override;
     //    [[nodiscard]] QModelIndexList match(const QModelIndex& start, int role, const QVariant& value, int hits,
     //                                        Qt::MatchFlags flags) const override;
-    void reload(const Core::TrackPtrList& tracks);
+    void reload(const Core::TrackList& tracks);
 
 private:
     void beginReset();
-    void setupModelData(const Core::TrackPtrList& tracks);
+    void setupModelData(const Core::TrackList& tracks);
     FilterItem* createNode(const QString& title, const QString& sortTitle = {});
     std::vector<FilterItem*> createNodes(const QStringList& titles, const QString& sortTitle = {});
 

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -185,10 +185,10 @@ void FilterWidget::selectionChanged(const QItemSelection& selected, const QItemS
         return;
     }
 
-    Core::TrackPtrList tracks;
+    Core::TrackList tracks;
     for(const auto& index : indexes) {
         if(index.isValid()) {
-            const auto newTracks = index.data(Filters::Constants::Role::Tracks).value<Core::TrackPtrList>();
+            const auto newTracks = index.data(Filters::Constants::Role::Tracks).value<Core::TrackList>();
             tracks.insert(tracks.end(), newTracks.cbegin(), newTracks.cend());
         }
     }

--- a/src/plugins/filters/trackfilterer.cpp
+++ b/src/plugins/filters/trackfilterer.cpp
@@ -29,29 +29,29 @@ bool containsSearch(const QString& text, const QString& search)
 }
 
 // TODO: Support user-defined tags
-bool matchSearch(Core::Track* track, const QString& search)
+bool matchSearch(const Core::Track& track, const QString& search)
 {
     if(search.isEmpty()) {
         return true;
     }
 
-    for(const auto& artist : track->artists()) {
+    for(const QString& artist : track.artists()) {
         if(artist.contains(search, Qt::CaseInsensitive)) {
             return true;
         }
     }
 
-    return (containsSearch(track->title(), search) || containsSearch(track->album(), search)
-            || containsSearch(track->albumArtist(), search));
+    return (containsSearch(track.title(), search) || containsSearch(track.album(), search)
+            || containsSearch(track.albumArtist(), search));
 }
 
 TrackFilterer::TrackFilterer(QObject* parent)
     : Worker{parent}
 { }
 
-void TrackFilterer::filterTracks(const Core::TrackPtrList& tracks, const QString& search)
+void TrackFilterer::filterTracks(const Core::TrackList& tracks, const QString& search)
 {
-    const auto filteredTracks = Utils::filter(tracks, [search](Core::Track* track) {
+    const auto filteredTracks = Utils::filter(tracks, [search](const Core::Track& track) {
         return matchSearch(track, search);
     });
     emit tracksFiltered(filteredTracks);

--- a/src/plugins/filters/trackfilterer.h
+++ b/src/plugins/filters/trackfilterer.h
@@ -38,10 +38,10 @@ class TrackFilterer : public Utils::Worker
 public:
     explicit TrackFilterer(QObject* parent = nullptr);
 
-    void filterTracks(const Core::TrackPtrList& tracks, const QString& search);
+    void filterTracks(const Core::TrackList& tracks, const QString& search);
 
 signals:
-    void tracksFiltered(const Core::TrackPtrList& result);
+    void tracksFiltered(const Core::TrackList& result);
 };
 } // namespace Filters
 } // namespace Fy

--- a/src/utils/helpers.h
+++ b/src/utils/helpers.h
@@ -47,11 +47,11 @@ constexpr bool hasKey(const Ctnr& c, const Key& key)
     return c.count(key);
 }
 
-template <typename T, typename Ctnr>
+template <typename T, typename Hash, typename Ctnr>
 constexpr Ctnr intersection(Ctnr& v1, const Ctnr& v2)
 {
     Ctnr result;
-    std::unordered_set<T> first(v1.cbegin(), v1.cend());
+    std::unordered_set<T, Hash> first(v1.cbegin(), v1.cend());
     for (auto entry : v2)
     {
         if (first.count(entry)) {


### PR DESCRIPTION
Track objects are read in numerous places throughout fooyin including across threads. They are very rarely written to however, and only when directed explicitly by the user (included tracks modified outside fooyin).

This moves track data to a QSharedData struct which is only copied when written to by another instance. Because copy-on-write is accomplished using a reference counter, there is a performance penalty, which is why it's not recommended for data which will frequently change.

In this case, the performance penalty is minimal compared to passing around pointers. This change also removes the multiple containers used to store tracks in the TrackStore, and removes the ambiguity when passing tracks to functions (const& has clearer intent).

