### PR TITLE
Use QCoro library to remove dependency on nested QEventLoop

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,39 +16,40 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
-    - name: Update repositories
-      run: sudo apt update -y
-    - name: Install packages
-      env:
-        DEBIAN_FRONTEND: noninteractive
-      run: >
-        sudo apt install -y
-        libcppunit-dev
-        libmpv-dev
-        libgtest-dev
-        zlib1g-dev
-    - name: Checkout TagLib
-      uses: actions/checkout@v3
-      with:
-        repository: taglib/taglib
-        path: taglib
-        submodules: recursive
-    - name: Configure TagLib
-      run: cmake -B taglib/build -S taglib -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_BINDINGS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-    - name: Build TagLib
-      run: cmake --build taglib/build
-    - name: Install TagLib
-      run: sudo cmake --install taglib/build
-    - name: Install GTest
-      run: cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3.2.1
-      with:
-        version: '6.5.1'
-    - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}  -DBUILD_TESTS=${{env.BUILD_TESTS}}
-    - name: Build
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-    - name: Run GTest
-      run: ${{github.workspace}}/build/tests/test_scriptparser
+      - uses: actions/checkout@v3
+      - name: Update repositories
+        run: sudo apt update -y
+      - name: Install packages
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: >
+          sudo apt install -y
+          libcppunit-dev
+          libmpv-dev
+          libgtest-dev
+          qcoro-qt6-dev
+          zlib1g-dev
+      - name: Checkout TagLib
+        uses: actions/checkout@v3
+        with:
+          repository: taglib/taglib
+          path: taglib
+          submodules: recursive
+      - name: Configure TagLib
+        run: cmake -B taglib/build -S taglib -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_BINDINGS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+      - name: Build TagLib
+        run: cmake --build taglib/build
+      - name: Install TagLib
+        run: sudo cmake --install taglib/build
+      - name: Install GTest
+        run: cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3.2.1
+        with:
+          version: '6.5.1'
+      - name: Configure CMake
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}  -DBUILD_TESTS=${{env.BUILD_TESTS}}
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      - name: Run GTest
+        run: ${{github.workspace}}/build/tests/test_scriptparser

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,23 +40,23 @@ jobs:
         run: cmake --build taglib/build
       - name: Install TagLib
         run: sudo cmake --install taglib/build
-      - name: Checkout QCoro
-        uses: actions/checkout@v3
-        with:
-          repository: danvratil/qcoro
-          path: qcoro
-      - name: Configure QCoro
-        run: cmake -B qcoro/build -S qcoro -DBUILD_TESTING=OFF -DQCORO_BUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=OM -DQCORO_WITH_QTWEBSOCKETS=OFF -DQCORO_DISABLE_DEPRECATED_TASK_H=ON
-      - name: Build QCoro
-        run: cmake --build qcoro/build
-      - name: Install QCoro
-        run: sudo cmake --install qcoro/build
       - name: Install GTest
         run: cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
       - name: Install Qt
         uses: jurplel/install-qt-action@v3.2.1
         with:
           version: '6.5.1'
+      - name: Checkout QCoro
+        uses: actions/checkout@v3
+        with:
+          repository: danvratil/qcoro
+          path: qcoro
+      - name: Configure QCoro
+        run: cmake -B qcoro/build -S qcoro -DBUILD_TESTING=OFF -DQCORO_BUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=OM -DUSE_QT_VERSION=6 -DQCORO_WITH_QTWEBSOCKETS=OFF -DQCORO_DISABLE_DEPRECATED_TASK_H=ON
+      - name: Build QCoro
+        run: cmake --build qcoro/build
+      - name: Install QCoro
+        run: sudo cmake --install qcoro/build
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}  -DBUILD_TESTS=${{env.BUILD_TESTS}}
       - name: Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -26,23 +26,7 @@ jobs:
           sudo apt install -y
           libcppunit-dev
           libmpv-dev
-          libgtest-dev
-          qcoro-qt6-dev
           zlib1g-dev
-      - name: Checkout TagLib
-        uses: actions/checkout@v3
-        with:
-          repository: taglib/taglib
-          path: taglib
-          submodules: recursive
-      - name: Configure TagLib
-        run: cmake -B taglib/build -S taglib -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_BINDINGS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-      - name: Build TagLib
-        run: cmake --build taglib/build
-      - name: Install TagLib
-        run: sudo cmake --install taglib/build
-      - name: Install GTest
-        run: cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
       - name: Install Qt
         uses: jurplel/install-qt-action@v3.2.1
         with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -26,7 +26,33 @@ jobs:
           sudo apt install -y
           libcppunit-dev
           libmpv-dev
+          libgtest-dev
           zlib1g-dev
+      - name: Checkout TagLib
+        uses: actions/checkout@v3
+        with:
+          repository: taglib/taglib
+          path: taglib
+          submodules: recursive
+      - name: Configure TagLib
+        run: cmake -B taglib/build -S taglib -DBUILD_TESTING=OFF -DBUILD_EXAMPLES=OFF -DBUILD_BINDINGS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+      - name: Build TagLib
+        run: cmake --build taglib/build
+      - name: Install TagLib
+        run: sudo cmake --install taglib/build
+      - name: Checkout QCoro
+        uses: actions/checkout@v3
+        with:
+          repository: danvratil/qcoro
+          path: qcoro
+      - name: Configure QCoro
+        run: cmake -B qcoro/build -S qcoro -DBUILD_TESTING=OFF -DQCORO_BUILD_EXAMPLES=OFF -DBUILD_SHARED_LIBS=OM -DQCORO_WITH_QTWEBSOCKETS=OFF -DQCORO_DISABLE_DEPRECATED_TASK_H=ON
+      - name: Build QCoro
+        run: cmake --build qcoro/build
+      - name: Install QCoro
+        run: sudo cmake --install qcoro/build
+      - name: Install GTest
+        run: cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
       - name: Install Qt
         uses: jurplel/install-qt-action@v3.2.1
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ find_package(Qt6Gui REQUIRED)
 find_package(Qt6Sql REQUIRED)
 find_package(Qt6Concurrent REQUIRED)
 
+find_package(QCoro6 REQUIRED COMPONENTS Core)
+qcoro_enable_coroutines()
+
 find_package(Taglib REQUIRED taglib>=1.12)
 find_package(Libmpv REQUIRED)
 
@@ -70,12 +73,7 @@ add_subdirectory(src)
 
 target_link_libraries(
     fooyin_lib
-    PUBLIC Qt6::Core
-           Qt6::Gui
-           Qt6::Widgets
-           Qt6::Sql
-           Qt6::Concurrent
-           fooyin::core
+    PUBLIC fooyin::core
            fooyin::gui
            fooyin::utils
     # ${SDL2_LIBRARIES} ${FFMPEG_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ CPMFindPackage(
   GITHUB_REPOSITORY taglib/taglib
   GIT_TAG master
   OPTIONS "CMAKE_BUILD_TYPE Release"
+          "BUILD_SHARED_LIBS ON"
           "BUILD_TESTING OFF"
           "BUILD_EXAMPLES OFF"
           "BUILD_BINDINGS OFF"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,15 +12,16 @@ project(
 
 set(DATABASE_VERSION "0.6.3")
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
 include(cmake/CheckLevel.cmake)
+include(cmake/CPM.cmake)
+include(cmake/Fooyin.cmake)
 
 include(FeatureSummary)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Fooyin.cmake)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE
@@ -32,16 +33,30 @@ endif()
 fooyin_option(FOOYIN_STATIC "Build fooyin libraries as static." OFF)
 fooyin_option(BUILD_TESTS "Build fooyin tests." OFF)
 
-find_package(Qt6Core REQUIRED)
-find_package(Qt6Widgets REQUIRED)
-find_package(Qt6Gui REQUIRED)
-find_package(Qt6Sql REQUIRED)
-find_package(Qt6Concurrent REQUIRED)
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets Gui Sql Concurrent)
 
-find_package(QCoro6 REQUIRED COMPONENTS Core)
+CPMFindPackage(
+  NAME Taglib
+  VERSION 1.12
+  GITHUB_REPOSITORY taglib/taglib
+  GIT_TAG master
+  OPTIONS "BUILD_TESTING OFF"
+          "CMAKE_POSITION_INDEPENDENT_CODE ON"
+)
+
+CPMFindPackage(
+  NAME QCoro6
+  VERSION 0.9
+  GITHUB_REPOSITORY danvratil/qcoro
+  GIT_TAG v0.9.0
+  FIND_PACKAGE_ARGUMENTS "COMPONENTS Core"
+  OPTIONS "BUILD_TESTING OFF"
+          "BUILD_SHARED_LIBS ON"
+          "QCORO_WITH_QTWEBSOCKETS OFF"
+          "QCORO_DISABLE_DEPRECATED_TASK_H ON"
+)
 qcoro_enable_coroutines()
 
-find_package(Taglib REQUIRED taglib>=1.12)
 find_package(Libmpv REQUIRED)
 
 # find_package(FFmpeg COMPONENTS AVCODEC AVFORMAT AVUTIL AVDEVICE AVFILTER
@@ -57,11 +72,7 @@ target_include_directories(
     PUBLIC "${PROJECT_BINARY_DIR}/app"
 )
 
-add_library(
-    fooyin_lib
-    OBJECT src/app/application.cpp
-           src/app/singleinstance.cpp
-)
+add_library(fooyin_lib OBJECT src/app/application.cpp src/app/singleinstance.cpp)
 add_library(fooyin::lib ALIAS fooyin_lib)
 
 target_include_directories(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ CPMFindPackage(
           "BUILD_BINDINGS OFF"
           "CMAKE_POSITION_INDEPENDENT_CODE ON"
 )
+add_library(Taglib::Taglib ALIAS tag)
 
 CPMFindPackage(
   NAME QCoro6
@@ -163,5 +164,3 @@ install(
 # ---- Fooyin install ----
 
 install(TARGETS fooyin_exe RUNTIME COMPONENT fooyin_runtime)
-
-feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ set(DATABASE_VERSION "0.6.3")
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 include(cmake/CheckLevel.cmake)
-include(cmake/CPM.cmake)
 include(cmake/Fooyin.cmake)
 
 include(FeatureSummary)
@@ -33,35 +32,19 @@ endif()
 fooyin_option(FOOYIN_STATIC "Build fooyin libraries as static." OFF)
 fooyin_option(BUILD_TESTS "Build fooyin tests." OFF)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Widgets Gui Sql Concurrent)
-
-CPMFindPackage(
-  NAME Taglib
-  VERSION 1.12
-  GITHUB_REPOSITORY taglib/taglib
-  GIT_TAG master
-  OPTIONS "CMAKE_BUILD_TYPE Release"
-          "BUILD_SHARED_LIBS ON"
-          "BUILD_TESTING OFF"
-          "BUILD_EXAMPLES OFF"
-          "BUILD_BINDINGS OFF"
-          "CMAKE_POSITION_INDEPENDENT_CODE ON"
+find_package(
+    Qt6 REQUIRED
+    COMPONENTS Core
+               Widgets
+               Gui
+               Sql
+               Concurrent
 )
-add_library(Taglib::Taglib ALIAS tag)
 
-CPMFindPackage(
-  NAME QCoro6
-  VERSION 0.9
-  GITHUB_REPOSITORY danvratil/qcoro
-  GIT_TAG v0.9.0
-  FIND_PACKAGE_ARGUMENTS "COMPONENTS Core"
-  OPTIONS "BUILD_TESTING OFF"
-          "BUILD_SHARED_LIBS ON"
-          "QCORO_WITH_QTWEBSOCKETS OFF"
-          "QCORO_DISABLE_DEPRECATED_TASK_H ON"
-)
+find_package(QCoro6 REQUIRED COMPONENTS Core)
 qcoro_enable_coroutines()
 
+find_package(Taglib REQUIRED taglib>=1.12)
 find_package(Libmpv REQUIRED)
 
 # find_package(FFmpeg COMPONENTS AVCODEC AVFORMAT AVUTIL AVDEVICE AVFILTER
@@ -101,14 +84,7 @@ target_compile_options(fooyin_lib PRIVATE -Werror -Wall -Wextra -Wpedantic)
 # ---- Fooyin testing ----
 
 if(BUILD_TESTS)
-    CPMFindPackage(
-            NAME GTest
-            VERSION 1.13.0
-            GITHUB_REPOSITORY google/googletest
-            GIT_TAG v1.14.0
-            OPTIONS "gtest_force_shared_crt ON"
-                    "BUILD_TESTING OFF"
-    )
+    find_package(GTest)
     add_subdirectory(tests)
 endif()
 
@@ -165,3 +141,5 @@ install(
 # ---- Fooyin install ----
 
 install(TARGETS fooyin_exe RUNTIME COMPONENT fooyin_runtime)
+
+feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,10 @@ CPMFindPackage(
   VERSION 1.12
   GITHUB_REPOSITORY taglib/taglib
   GIT_TAG master
-  OPTIONS "BUILD_TESTING OFF"
+  OPTIONS "CMAKE_BUILD_TYPE Release"
+          "BUILD_TESTING OFF"
+          "BUILD_EXAMPLES OFF"
+          "BUILD_BINDINGS OFF"
           "CMAKE_POSITION_INDEPENDENT_CODE ON"
 )
 
@@ -96,7 +99,14 @@ target_compile_options(fooyin_lib PRIVATE -Werror -Wall -Wextra -Wpedantic)
 # ---- Fooyin testing ----
 
 if(BUILD_TESTS)
-    find_package(GTest)
+    CPMFindPackage(
+            NAME GTest
+            VERSION 1.13.0
+            GITHUB_REPOSITORY google/googletest
+            GIT_TAG v1.14.0
+            OPTIONS "gtest_force_shared_crt ON"
+                    "BUILD_TESTING OFF"
+    )
     add_subdirectory(tests)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -23,24 +23,24 @@ allowing for a wide range of visualisations to be built.
 
 ## Features
 
-  - [x] Fully customisable layout
-  - [x] Filter and search collection
-  - [x] Plugin system
-  - [x] Playlist support
-  - [ ] Tag editing
-  - [ ] FFmpeg backend
-  - [ ] Visualisations
-  - [ ] Lyrics support
-  - [ ] Lyric querying
-  - [ ] Last.fm integration
-  - [ ] Discogs integration
+-  [x] Fully customisable layout
+-  [x] Filter and search collection
+-  [x] Plugin system
+-  [x] Playlist support
+-  [ ] Tag editing
+-  [ ] FFmpeg backend
+-  [ ] Visualisations
+-  [ ] Lyrics support
+-  [ ] Lyric querying
+-  [ ] Last.fm integration
+-  [ ] Discogs integration
 
 ## Requirements
 
-  - Qt6
-  - QCoro
-  - Taglib (>=1.12)
-  - Libmpv (mpv)
+-  Qt6
+-  QCoro
+-  Taglib (>=1.12)
+-  Libmpv (mpv)
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,41 +1,49 @@
-<p align="center">
+<!-- <p align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ludouzi/fooyin/master/data/images/logo-dark.svg">
   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ludouzi/fooyin/master/data/images/logo.svg">
   <img alt="Fooyin logo." align="center" width=35% src="https://raw.githubusercontent.com/ludouzi/fooyin/master/data/images/logo.svg">
 </picture>
-</p>
+</p> -->
 
-#
-Fooyin is a customisable music player for linux. It has not yet reached a stable release so bugs and breaking changes should be expected.
+# Fooyin
 
-Fooyin features a _layout editing mode_ in which the entire user interface can be customised, starting from a blank state or a default layout.
-The engine backend is currently based on mpv, though this will change to ffmpeg at a later date, allowing for a wide range of visualisations to be built.
+Fooyin is a customisable music player for linux.
+
+Fooyin features a _layout editing mode_
+in which the entire user interface can be customised,
+starting from a blank state or a default layout.
+The engine backend is currently based on mpv,
+though this will change to ffmpeg at a later date,
+allowing for a wide range of visualisations to be built.
 
 <p align="center">
 <img src="data/images/editing.png" width="70%" style="vertical-align:middle">
 </p>
 
 ## Features
-- [x] Fully customisable layout
-- [x] Filter and search collection
-- [x] Plugin system
-- [x] Playlist support
-- [ ] Tag editing
-- [ ] FFmpeg backend
-- [ ] Visualisations
-- [ ] Lyrics support
-- [ ] Lyric querying
-- [ ] Last.fm integration
-- [ ] Discogs integration
+
+  - [x] Fully customisable layout
+  - [x] Filter and search collection
+  - [x] Plugin system
+  - [x] Playlist support
+  - [ ] Tag editing
+  - [ ] FFmpeg backend
+  - [ ] Visualisations
+  - [ ] Lyrics support
+  - [ ] Lyric querying
+  - [ ] Last.fm integration
+  - [ ] Discogs integration
 
 ## Requirements
-- Qt6
-- QCoro
-- Taglib (>=1.12)
-- Libmpv (mpv)
+
+  - Qt6
+  - QCoro
+  - Taglib (>=1.12)
+  - Libmpv (mpv)
 
 ## Setup
+
 ```
 git clone git@github.com:ludouzi/fooyin.git
 cd fooyin && mkdir build && cd build

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ The engine backend is currently based on mpv, though this will change to ffmpeg 
 - [ ] Discogs integration
 
 ## Requirements
-- Compiler with support for C++20
 - Qt6
-- Taglib (1.12)
+- QCoro
+- Taglib (>=1.12)
 - Libmpv (mpv)
 
 ## Setup

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set(CPM_DOWNLOAD_VERSION 0.38.5)
+set(CPM_HASH_SUM "192aa0ccdc57dfe75bd9e4b176bf7fb5692fd2b3e3f7b09c74856fc39572b31c")
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/cmake/FindTaglib.cmake
+++ b/cmake/FindTaglib.cmake
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2006 Laurent Montel <montel@kde.org>
 # SPDX-FileCopyrightText: 2019 Heiko Becker <heirecka@exherbo.org>
 # SPDX-FileCopyrightText: 2020 Elvis Angelaccio <elvis.angelaccio@kde.org>
-# SPDX-FileCopyrightText: 2022 Luke Taylor <LukeT1@proton.me>
+# SPDX-FileCopyrightText: 2023 Luke Taylor <LukeT1@proton.me>
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
@@ -79,10 +79,10 @@ find_package_handle_standard_args(
   REQUIRED_VARS TAGLIB_LIBRARIES TAGLIB_INCLUDE_DIRS
   VERSION_VAR TAGLIB_VERSION)
 
-if(TAGLIB_FOUND AND NOT TARGET Taglib::Taglib)
-  add_library(Taglib::Taglib UNKNOWN IMPORTED)
+if(TAGLIB_FOUND AND NOT TARGET tag)
+  add_library(tag UNKNOWN IMPORTED)
   set_target_properties(
-    Taglib::Taglib
+    tag
     PROPERTIES IMPORTED_LOCATION "${TAGLIB_LIBRARIES}"
                INTERFACE_INCLUDE_DIRECTORIES "${TAGLIB_INCLUDE_DIRS}")
 endif()

--- a/cmake/FindTaglib.cmake
+++ b/cmake/FindTaglib.cmake
@@ -79,10 +79,10 @@ find_package_handle_standard_args(
   REQUIRED_VARS TAGLIB_LIBRARIES TAGLIB_INCLUDE_DIRS
   VERSION_VAR TAGLIB_VERSION)
 
-if(TAGLIB_FOUND AND NOT TARGET tag)
-  add_library(tag UNKNOWN IMPORTED)
+if(TAGLIB_FOUND AND NOT TARGET Taglib::Taglib)
+  add_library(Taglib::Taglib UNKNOWN IMPORTED)
   set_target_properties(
-    tag
+    Taglib::Taglib
     PROPERTIES IMPORTED_LOCATION "${TAGLIB_LIBRARIES}"
                INTERFACE_INCLUDE_DIRECTORIES "${TAGLIB_INCLUDE_DIRS}")
 endif()

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -103,7 +103,7 @@ target_link_libraries(
            Qt6::Widgets
            Qt6::Sql
            Qt6::Concurrent
-           QCoro6::Core
+           QCoro::Core
     PRIVATE Taglib::Taglib
             Libmpv::Libmpv
             fooyin::version

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -102,6 +102,7 @@ target_link_libraries(
            Qt6::Widgets
            Qt6::Sql
            Qt6::Concurrent
+           QCoro::Core
     PRIVATE Taglib::Taglib
             Libmpv::Libmpv
             fooyin::version

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -102,8 +102,8 @@ target_link_libraries(
            Qt6::Widgets
            Qt6::Sql
            Qt6::Concurrent
-           QCoro::Core
-    PRIVATE Taglib::Taglib
+           QCoro6::Core
+    PRIVATE tag
             Libmpv::Libmpv
             fooyin::version
             fooyin::utils

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -103,7 +103,7 @@ target_link_libraries(
            Qt6::Sql
            Qt6::Concurrent
            QCoro6::Core
-    PRIVATE tag
+    PRIVATE Taglib::Taglib
             Libmpv::Libmpv
             fooyin::version
             fooyin::utils

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -85,6 +85,7 @@ target_include_directories(
             "${CMAKE_BINARY_DIR}/src"
             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
     PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>"
+           "${Taglib_SOURCE_DIR}/taglib"
 )
 
 set_target_properties(

--- a/src/core/library/unifiedmusiclibrary.cpp
+++ b/src/core/library/unifiedmusiclibrary.cpp
@@ -32,7 +32,7 @@
 #include <QDir>
 #include <QTimer>
 
-#include <QCoro/QCoroCore>
+#include <QCoroCore>
 
 #include <ranges>
 #include <vector>

--- a/src/core/library/unifiedmusiclibrary.cpp
+++ b/src/core/library/unifiedmusiclibrary.cpp
@@ -29,9 +29,10 @@
 #include <utils/helpers.h>
 #include <utils/settings/settingsmanager.h>
 
-#include <QCoroCore>
 #include <QDir>
 #include <QTimer>
+
+#include <QCoro/QCoroCore>
 
 #include <ranges>
 #include <vector>

--- a/src/core/library/unifiedmusiclibrary.cpp
+++ b/src/core/library/unifiedmusiclibrary.cpp
@@ -29,22 +29,24 @@
 #include <utils/helpers.h>
 #include <utils/settings/settingsmanager.h>
 
+#include <QCoroCore>
+#include <QDir>
 #include <QTimer>
 
 #include <ranges>
 #include <vector>
 
 namespace Fy::Core::Library {
-TrackList recalSortFields(const QString& sort, const TrackList& tracks)
+QCoro::Task<TrackList> recalSortFields(QString sort, TrackList tracks)
 {
-    return Utils::asyncExec<TrackList>([&sort, &tracks]() {
+    co_return co_await Utils::asyncExec([&sort, &tracks]() {
         return Sorting::calcSortFields(sort, tracks);
     });
 }
 
-TrackList resortTracks(const TrackList& tracks)
+QCoro::Task<TrackList> resortTracks(TrackList tracks)
 {
-    return Utils::asyncExec<TrackList>([&tracks]() {
+    co_return co_await Utils::asyncExec([&tracks]() {
         return Sorting::sortTracks(tracks);
     });
 }
@@ -136,10 +138,10 @@ void UnifiedMusicLibrary::saveTracks(const TrackList& tracks)
     emit tracksUpdated(tracks);
 }
 
-void UnifiedMusicLibrary::changeSort(const QString& sort)
+QCoro::Task<void> UnifiedMusicLibrary::changeSort(QString sort)
 {
-    const TrackList recalTracks  = recalSortFields(sort, m_tracks);
-    const TrackList sortedTracks = resortTracks(recalTracks);
+    const TrackList recalTracks  = co_await recalSortFields(sort, m_tracks);
+    const TrackList sortedTracks = co_await resortTracks(recalTracks);
     m_tracks                     = sortedTracks;
 
     emit tracksSorted(m_tracks);
@@ -161,13 +163,13 @@ void UnifiedMusicLibrary::getAllTracks()
     emit loadAllTracks();
 }
 
-void UnifiedMusicLibrary::loadTracks(const TrackList& tracks)
+QCoro::Task<void> UnifiedMusicLibrary::loadTracks(TrackList tracks)
 {
-    addTracks(tracks);
+    co_await addTracks(tracks);
     emit tracksLoaded(m_tracks);
 }
 
-TrackList UnifiedMusicLibrary::addTracks(const TrackList& tracks)
+QCoro::Task<TrackList> UnifiedMusicLibrary::addTracks(TrackList tracks)
 {
     m_tracks.reserve(m_tracks.size() + tracks.size());
 
@@ -177,7 +179,7 @@ TrackList UnifiedMusicLibrary::addTracks(const TrackList& tracks)
         libraryDirs.emplace(id, QDir{info.path});
     }
 
-    TrackList newTracks = recalSortFields(m_settings->value<Settings::LibrarySortScript>(), tracks);
+    TrackList newTracks = co_await recalSortFields(m_settings->value<Settings::LibrarySortScript>(), tracks);
     for(Track& track : newTracks) {
         const int libraryId = track.libraryId();
         if(libraryDirs.contains(libraryId)) {
@@ -186,21 +188,21 @@ TrackList UnifiedMusicLibrary::addTracks(const TrackList& tracks)
     }
     std::ranges::copy(newTracks, std::back_inserter(m_tracks));
 
-    m_tracks = resortTracks(m_tracks);
+    m_tracks = co_await resortTracks(m_tracks);
 
-    return newTracks;
+    co_return newTracks;
 }
 
-void UnifiedMusicLibrary::newTracks(const TrackList& tracks)
+QCoro::Task<void> UnifiedMusicLibrary::newTracks(TrackList tracks)
 {
-    TrackList newTracks = addTracks(tracks);
+    TrackList newTracks = co_await addTracks(tracks);
     emit tracksAdded(newTracks);
 }
 
-void UnifiedMusicLibrary::updateTracks(const TrackList& tracks)
+QCoro::Task<void> UnifiedMusicLibrary::updateTracks(TrackList tracks)
 {
-    TrackList updatedTracks = recalSortFields(m_settings->value<Settings::LibrarySortScript>(), tracks);
-    updatedTracks           = resortTracks(updatedTracks);
+    TrackList updatedTracks = co_await recalSortFields(m_settings->value<Settings::LibrarySortScript>(), tracks);
+    updatedTracks           = co_await resortTracks(updatedTracks);
 
     std::ranges::for_each(updatedTracks, [this](const Track& track) {
         std::ranges::replace_if(
@@ -211,7 +213,7 @@ void UnifiedMusicLibrary::updateTracks(const TrackList& tracks)
             track);
     });
 
-    m_tracks = resortTracks(m_tracks);
+    m_tracks = co_await resortTracks(m_tracks);
 
     emit tracksUpdated(updatedTracks);
 }

--- a/src/core/library/unifiedmusiclibrary.h
+++ b/src/core/library/unifiedmusiclibrary.h
@@ -23,7 +23,7 @@
 #include "librarythreadhandler.h"
 #include "musiclibrary.h"
 
-#include <QCoroCore>
+#include <QCoro/QCoroTask>
 
 namespace Fy {
 

--- a/src/core/library/unifiedmusiclibrary.h
+++ b/src/core/library/unifiedmusiclibrary.h
@@ -23,6 +23,8 @@
 #include "librarythreadhandler.h"
 #include "musiclibrary.h"
 
+#include <QCoroTask>
+
 namespace Fy {
 
 namespace Utils {
@@ -57,16 +59,16 @@ public:
 
     void saveTracks(const Core::TrackList& tracks) override;
 
-    void changeSort(const QString& sort);
+    QCoro::Task<void> changeSort(QString sort);
 
     void removeLibrary(int id) override;
 
 private:
     void getAllTracks();
-    void loadTracks(const TrackList& tracks);
-    TrackList addTracks(const TrackList& tracks);
-    void newTracks(const TrackList& tracks);
-    void updateTracks(const TrackList& tracks);
+    QCoro::Task<void> loadTracks(TrackList tracks);
+    QCoro::Task<TrackList> addTracks(TrackList tracks);
+    QCoro::Task<void> newTracks(TrackList tracks);
+    QCoro::Task<void> updateTracks(TrackList tracks);
     void removeTracks(const TrackList& tracks);
 
     void libraryStatusChanged(const LibraryInfo& library);

--- a/src/core/library/unifiedmusiclibrary.h
+++ b/src/core/library/unifiedmusiclibrary.h
@@ -23,7 +23,7 @@
 #include "librarythreadhandler.h"
 #include "musiclibrary.h"
 
-#include <QCoroTask>
+#include <QCoroCore>
 
 namespace Fy {
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -87,6 +87,7 @@ set(SOURCES
     quicksetup/quicksetupdialog.cpp
     quicksetup/quicksetupmodel.h
     quicksetup/quicksetupmodel.cpp
+    search/searchcontroller.cpp
     search/searchwidget.cpp
     settings/generalpage.h
     settings/generalpage.cpp
@@ -117,8 +118,7 @@ set(SOURCES
     widgets/splitterwidget.cpp
 )
 
-add_library(fooyin_gui ${FOOYIN_LIBRARY_TYPE} ${SOURCES}
-    search/searchcontroller.h search/searchcontroller.cpp)
+add_library(fooyin_gui ${FOOYIN_LIBRARY_TYPE} ${SOURCES})
 add_library(fooyin::gui ALIAS fooyin_gui)
 
 target_include_directories(

--- a/src/gui/librarytree/librarytreewidget.cpp
+++ b/src/gui/librarytree/librarytreewidget.cpp
@@ -36,7 +36,7 @@
 #include <QTreeView>
 #include <QVBoxLayout>
 
-#include <QCoroCore>
+#include <QCoro/QCoroCore>
 
 namespace Fy::Gui::Widgets {
 void getLowestIndexes(const QTreeView* treeView, const QModelIndex& index, QModelIndexList& bottomIndexes)

--- a/src/gui/playlist/playlistwidget.cpp
+++ b/src/gui/playlist/playlistwidget.cpp
@@ -46,7 +46,7 @@
 #include <QMenu>
 #include <QScrollBar>
 
-#include <QCoroCore>
+#include <QCoro/QCoroCore>
 
 namespace Fy::Gui::Widgets::Playlist {
 struct PlaylistWidget::Private : QObject

--- a/src/gui/playlist/playlistwidget.cpp
+++ b/src/gui/playlist/playlistwidget.cpp
@@ -35,9 +35,9 @@
 #include <core/playlist/playlisthandler.h>
 
 #include <utils/actions/actioncontainer.h>
+#include <utils/async.h>
 #include <utils/headerview.h>
 #include <utils/settings/settingsdialogcontroller.h>
-#include <utils/settings/settingsmanager.h>
 
 #include <QActionGroup>
 #include <QHBoxLayout>
@@ -45,6 +45,8 @@
 #include <QKeyEvent>
 #include <QMenu>
 #include <QScrollBar>
+
+#include <QCoroCore>
 
 namespace Fy::Gui::Widgets::Playlist {
 struct PlaylistWidget::Private : QObject
@@ -352,12 +354,14 @@ struct PlaylistWidget::Private : QObject
         menu->popup(widget->mapToGlobal(pos));
     }
 
-    void changeSort(const QString& script)
+    QCoro::Task<void> changeSort(QString script) const
     {
         /* if(playlistView->selectionModel()->hasSelection()) { }
          else*/
         if(auto playlist = controller->currentPlaylist()) {
-            const auto sortedTracks = Core::Library::Sorting::calcSortTracks(script, playlist->tracks());
+            const auto sortedTracks = co_await Utils::asyncExec([&script, &playlist]() {
+                return Core::Library::Sorting::calcSortTracks(script, playlist->tracks());
+            });
             playlist->replaceTracks(sortedTracks);
             controller->playlistHandler()->replacePlaylistTracks(playlist->id(), sortedTracks);
             changePlaylist(*playlist);

--- a/src/plugins/filters/filtermanager.cpp
+++ b/src/plugins/filters/filtermanager.cpp
@@ -34,7 +34,7 @@
 #include <QActionGroup>
 #include <QMenu>
 
-#include <QCoro/QCoroCore>
+#include <QCoroCore>
 
 namespace Fy::Filters {
 bool containsSearch(const QString& text, const QString& search)

--- a/src/plugins/filters/filtermanager.cpp
+++ b/src/plugins/filters/filtermanager.cpp
@@ -34,6 +34,8 @@
 #include <QActionGroup>
 #include <QMenu>
 
+#include <QCoro/QCoroCore>
+
 namespace Fy::Filters {
 bool containsSearch(const QString& text, const QString& search)
 {

--- a/src/plugins/filters/filtermanager.h
+++ b/src/plugins/filters/filtermanager.h
@@ -23,7 +23,7 @@
 
 #include <QObject>
 
-#include <QCoro/QCoroTask>
+#include <QCoroTask>
 
 namespace Fy {
 namespace Utils {

--- a/src/plugins/filters/filtermanager.h
+++ b/src/plugins/filters/filtermanager.h
@@ -22,7 +22,8 @@
 #include <core/models/trackfwd.h>
 
 #include <QObject>
-#include <QCoroCore>
+
+#include <QCoro/QCoroTask>
 
 namespace Fy {
 namespace Utils {

--- a/src/plugins/filters/filtermanager.h
+++ b/src/plugins/filters/filtermanager.h
@@ -22,6 +22,7 @@
 #include <core/models/trackfwd.h>
 
 #include <QObject>
+#include <QCoroCore>
 
 namespace Fy {
 namespace Utils {
@@ -67,7 +68,7 @@ signals:
     void tracksUpdated(const Core::TrackList& tracks);
 
 public slots:
-    void searchChanged(const QString& search);
+    QCoro::Task<void> searchChanged(QString search);
 
 private:
     struct Private;

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -29,7 +29,6 @@
 #include <core/player/playermanager.h>
 
 #include <utils/actions/actioncontainer.h>
-#include <utils/async.h>
 #include <utils/enumhelper.h>
 #include <utils/settings/settingsmanager.h>
 

--- a/src/plugins/filters/filterwidget.h
+++ b/src/plugins/filters/filterwidget.h
@@ -36,8 +36,7 @@ class FilterWidget : public Gui::Widgets::FyWidget
     Q_OBJECT
 
 public:
-    explicit FilterWidget(Utils::SettingsManager* settings,
-                          QWidget* parent = nullptr);
+    explicit FilterWidget(Utils::SettingsManager* settings, QWidget* parent = nullptr);
     ~FilterWidget() override;
 
     void setupConnections();

--- a/src/utils/async.h
+++ b/src/utils/async.h
@@ -19,22 +19,12 @@
 
 #pragma once
 
-#include <QFuture>
-#include <QFutureWatcher>
 #include <QtConcurrent>
 
 namespace Fy::Utils {
-template <typename Ret, typename Func>
-Ret asyncExec(Func&& func)
+template <typename Func>
+auto asyncExec(Func&& func)
 {
-    QFuture<Ret> future = QtConcurrent::run(std::forward<Func>(func));
-    QFutureWatcher<Ret> watcher;
-    watcher.setFuture(future);
-
-    QEventLoop eventLoop;
-    QObject::connect(&watcher, &QFutureWatcher<Ret>::finished, &eventLoop, &QEventLoop::quit);
-    eventLoop.exec();
-
-    return future.result();
+    return QtConcurrent::run(std::forward<Func>(func));
 }
 } // namespace Fy::Utils


### PR DESCRIPTION
Makes use of the QCoro library, bringing support for coroutines. The use of the nested QEventLoop in Utils::asyncExec has now been removed and replaced with a simple call to QtConcurrent::run.

Resolves #20 