### PR TITLE
Support dropping tracks from outside fooyin

### DIFF
--- a/include/core/library/musiclibrary.h
+++ b/include/core/library/musiclibrary.h
@@ -28,6 +28,19 @@
 namespace Fooyin {
 struct LibraryInfo;
 
+struct ScanRequest
+{
+    enum Type : uint8_t
+    {
+        Tracks = 0,
+        Library,
+    };
+
+    Type type;
+    int id{-1};
+    std::function<void()> cancel;
+};
+
 class FYCORE_EXPORT MusicLibrary : public QObject
 {
     Q_OBJECT
@@ -47,7 +60,9 @@ public:
     virtual void reload(const LibraryInfo& library) = 0;
     virtual void rescan()                           = 0;
 
-    [[nodiscard]] virtual TrackList tracks() const = 0;
+    virtual ScanRequest* scanTracks(const TrackList& tracks) = 0;
+
+    [[nodiscard]] virtual TrackList tracks() const                          = 0;
     [[nodiscard]] virtual TrackList tracksForIds(const TrackIds& ids) const = 0;
 
     virtual void updateTrackMetadata(const TrackList& tracks) = 0;
@@ -55,10 +70,11 @@ public:
     virtual void removeLibrary(int id) = 0;
 
 signals:
-    void scanProgress(int percent);
+    void scanProgress(int id, int percent);
 
     void tracksLoaded(const TrackList& tracks);
     void tracksAdded(const TrackList& tracks);
+    void tracksScanned(const TrackList& tracks);
     void tracksUpdated(const TrackList& tracks);
     void tracksDeleted(const TrackList& tracks);
     void tracksSorted(const TrackList& tracks);

--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -31,6 +31,7 @@ class QMenu;
 class QSize;
 class QColor;
 class QKeySequence;
+class QDir;
 
 namespace Fooyin::Utils {
 namespace File {
@@ -41,6 +42,9 @@ FYUTILS_EXPORT bool exists(const QString& filename);
 FYUTILS_EXPORT QString getParentDirectory(const QString& filename);
 FYUTILS_EXPORT bool createDirectories(const QString& path);
 FYUTILS_EXPORT void openDirectory(const QString& dir);
+FYUTILS_EXPORT QStringList getFilesInDir(const QDir& baseDirectory, const QStringList& fileExtensions = {});
+FYUTILS_EXPORT QStringList getFiles(const QStringList& paths, const QStringList& fileExtensions = {});
+FYUTILS_EXPORT QStringList getFiles(const QList<QUrl>& urls, const QStringList& fileExtensions = {});
 } // namespace File
 
 FYUTILS_EXPORT int randomNumber(int min, int max);

--- a/include/utils/worker.h
+++ b/include/utils/worker.h
@@ -32,18 +32,19 @@ public:
     enum State
     {
         Idle = 0,
-        Running
+        Running,
+        Paused
     };
 
     explicit Worker(QObject* parent = nullptr);
 
     virtual void stopThread();
+    virtual void pauseThread();
     virtual void closeThread();
 
     [[nodiscard]] State state() const;
     void setState(State state);
 
-    [[nodiscard]] bool isRunning();
     [[nodiscard]] bool mayRun() const;
 
 signals:

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -30,7 +30,6 @@
 #include <core/engine/enginehandler.h>
 #include <core/engine/outputplugin.h>
 #include <core/library/librarymanager.h>
-#include <core/library/sortingregistry.h>
 #include <core/plugins/coreplugin.h>
 #include <core/plugins/pluginmanager.h>
 #include <utils/settings/settingsmanager.h>
@@ -44,7 +43,7 @@ struct Application::Private
     PlayerManager* playerManager;
     EngineHandler engine;
     LibraryManager* libraryManager;
-    MusicLibrary* library;
+    UnifiedMusicLibrary* library;
     PlaylistHandler* playlistHandler;
 
     PluginManager pluginManager;
@@ -114,6 +113,7 @@ void Application::shutdown()
     p->engine.shutdown();
     p->playlistHandler->savePlaylists();
     p->pluginManager.shutdown();
+    p->library->cleanupTracks();
     p->database.closeDatabase();
 }
 } // namespace Fooyin

--- a/src/core/database/database.cpp
+++ b/src/core/database/database.cpp
@@ -125,6 +125,9 @@ bool Database::createDatabase()
     checkInsertIndex(u"PlaylistTracksIndex"_s,
                      u"CREATE INDEX PlaylistTracksIndex ON PlaylistTracks(PlaylistID,TrackIndex);"_s);
 
+    module()->insert(u"Libraries"_s, {{u"LibraryID"_s, u"0"_s}, {u"Name"_s, u"No Library"_s}, {u"Path"_s, u""_s}},
+                     "Could not insert default library");
+
     return true;
 }
 

--- a/src/core/database/trackdatabase.cpp
+++ b/src/core/database/trackdatabase.cpp
@@ -266,6 +266,15 @@ bool TrackDatabase::deleteTracks(const TrackList& tracks)
     return (success && (fileCount == static_cast<int>(tracks.size())));
 }
 
+bool TrackDatabase::cleanupTracks()
+{
+    const QString queryText
+        = u"DELETE FROM Tracks WHERE LibraryID = 0 AND TrackID NOT IN (SELECT TrackID FROM PlaylistTracks);"_s;
+    const auto q = module()->runQuery(queryText, u"Cannot cleanup tracks"_s);
+
+    return (!q.hasError());
+}
+
 int TrackDatabase::insertTrack(const Track& track)
 {
     auto bindings = getTrackBindings(track);

--- a/src/core/database/trackdatabase.h
+++ b/src/core/database/trackdatabase.h
@@ -40,6 +40,7 @@ public:
     bool updateTrack(const Track& track);
     bool deleteTrack(int id);
     bool deleteTracks(const TrackList& tracks);
+    bool cleanupTracks();
 
 private:
     int insertTrack(const Track& track);

--- a/src/core/library/librarymanager.cpp
+++ b/src/core/library/librarymanager.cpp
@@ -141,7 +141,7 @@ void LibraryManager::updateLibraryStatus(const LibraryInfo& library)
 
 bool LibraryManager::hasLibrary() const
 {
-    return !p->libraries.empty();
+    return p->libraries.size() > 1;
 }
 
 bool LibraryManager::hasLibrary(int id) const

--- a/src/core/library/libraryscanner.h
+++ b/src/core/library/libraryscanner.h
@@ -48,10 +48,12 @@ signals:
     void progressChanged(int percent);
     void statusChanged(const LibraryInfo& library);
     void scanUpdate(const ScanResult& result);
+    void scannedTracks(const TrackList& tracks);
     void tracksDeleted(const TrackList& tracks);
 
 public slots:
     void scanLibrary(const LibraryInfo& library, const TrackList& tracks);
+    void scanTracks(const TrackList& libraryTracks, const TrackList& tracks);
     void updateTracks(const TrackList& tracks);
 
 private:

--- a/src/core/library/librarythreadhandler.h
+++ b/src/core/library/librarythreadhandler.h
@@ -25,28 +25,34 @@
 
 namespace Fooyin {
 class Database;
+class MusicLibrary;
 struct LibraryInfo;
 struct ScanResult;
+struct ScanRequest;
 
 class LibraryThreadHandler : public QObject
 {
     Q_OBJECT
 
 public:
-    explicit LibraryThreadHandler(Database* database, QObject* parent = nullptr);
+    explicit LibraryThreadHandler(Database* database, MusicLibrary* library, QObject* parent = nullptr);
     ~LibraryThreadHandler() override;
 
-    void stopScanner();
-
     void getAllTracks();
-    void scanLibrary(const LibraryInfo& library, const TrackList& tracks);
-    void libraryRemoved(int id);
+
+    void scanLibrary(const LibraryInfo& library);
+    ScanRequest* scanTracks(const TrackList& tracks);
+
     void saveUpdatedTracks(const TrackList& tracks);
+    void cleanupTracks();
+
+    void libraryRemoved(int id);
 
 signals:
-    void progressChanged(int percent);
+    void progressChanged(int id, int percent);
     void statusChanged(const LibraryInfo& library);
     void scanUpdate(const ScanResult& result);
+    void scannedTracks(const TrackList& tracks);
     void tracksDeleted(const TrackList& tracks);
 
     void gotTracks(const TrackList& result);

--- a/src/core/library/trackdatabasemanager.cpp
+++ b/src/core/library/trackdatabasemanager.cpp
@@ -44,6 +44,11 @@ void TrackDatabaseManager::getAllTracks()
         emit gotTracks(tracks);
     }
 }
+
+void TrackDatabaseManager::cleanupTracks()
+{
+    m_trackDatabase.cleanupTracks();
+}
 } // namespace Fooyin
 
 #include "moc_trackdatabasemanager.cpp"

--- a/src/core/library/trackdatabasemanager.h
+++ b/src/core/library/trackdatabasemanager.h
@@ -36,6 +36,7 @@ public:
     void closeThread() override;
 
     void getAllTracks();
+    void cleanupTracks();
 
 signals:
     void gotTracks(const TrackList& result);

--- a/src/core/library/unifiedmusiclibrary.h
+++ b/src/core/library/unifiedmusiclibrary.h
@@ -42,6 +42,8 @@ public:
     void reload(const LibraryInfo& library) override;
     void rescan() override;
 
+    ScanRequest* scanTracks(const TrackList& tracks) override;
+
     [[nodiscard]] bool hasLibrary() const override;
     [[nodiscard]] bool isEmpty() const override;
 
@@ -51,6 +53,8 @@ public:
     void updateTrackMetadata(const TrackList& tracks) override;
 
     void removeLibrary(int id) override;
+
+    void cleanupTracks();
 
 private:
     struct Private;

--- a/src/gui/librarytree/librarytreewidget.cpp
+++ b/src/gui/librarytree/librarytreewidget.cpp
@@ -277,6 +277,7 @@ LibraryTreeWidget::LibraryTreeWidget(MusicLibrary* library, LibraryTreeGroupRegi
 
     QObject::connect(library, &MusicLibrary::tracksLoaded, this, treeReset);
     QObject::connect(library, &MusicLibrary::tracksAdded, p->model, &LibraryTreeModel::addTracks);
+    QObject::connect(library, &MusicLibrary::tracksScanned, p->model, &LibraryTreeModel::addTracks);
     QObject::connect(library, &MusicLibrary::tracksUpdated, p->model, &LibraryTreeModel::updateTracks);
     QObject::connect(library, &MusicLibrary::tracksDeleted, p->model, &LibraryTreeModel::removeTracks);
     QObject::connect(library, &MusicLibrary::tracksSorted, this, treeReset);

--- a/src/gui/playlist/playlistmodel.cpp
+++ b/src/gui/playlist/playlistmodel.cpp
@@ -205,7 +205,8 @@ bool PlaylistModel::canDropMimeData(const QMimeData* data, Qt::DropAction action
                                     const QModelIndex& parent) const
 {
     if((action == Qt::MoveAction || action == Qt::CopyAction)
-       && (data->hasFormat(Constants::Mime::PlaylistItems) || data->hasFormat(Constants::Mime::TrackIds))) {
+       && (data->hasUrls() || data->hasFormat(Constants::Mime::PlaylistItems)
+           || data->hasFormat(Constants::Mime::TrackIds))) {
         return true;
     }
     return QAbstractItemModel::canDropMimeData(data, action, row, column, parent);

--- a/src/gui/playlist/playlistmodel.h
+++ b/src/gui/playlist/playlistmodel.h
@@ -95,6 +95,7 @@ public:
     void tracksChanged();
 
 signals:
+    void filesDropped(const TrackList& tracks, int index);
     void tracksInserted(const TrackGroups& groups);
     void tracksMoved(const MoveOperation& operation);
     void playlistTracksChanged(int index);

--- a/src/gui/playlist/playlistwidget_p.h
+++ b/src/gui/playlist/playlistwidget_p.h
@@ -68,9 +68,10 @@ public:
 
     void setHeaderHidden(bool showHeader) const;
     void setScrollbarHidden(bool showScrollBar) const;
-
     void selectionChanged() const;
     void playlistTracksChanged(int index) const;
+
+    QCoro::Task<void> scanDroppedTracks(TrackList tracks, int index);
     void tracksInserted(const TrackGroups& tracks) const;
     void tracksRemoved() const;
     void tracksMoved(const MoveOperation& operation) const;

--- a/src/plugins/filters/filtermanager.cpp
+++ b/src/plugins/filters/filtermanager.cpp
@@ -25,7 +25,6 @@
 
 #include <core/library/musiclibrary.h>
 #include <core/library/tracksort.h>
-#include <core/playlist/playlistmanager.h>
 #include <gui/trackselectioncontroller.h>
 #include <utils/async.h>
 
@@ -280,6 +279,7 @@ FilterManager::FilterManager(MusicLibrary* library, TrackSelectionController* tr
     , p{std::make_unique<Private>(this, library, trackSelection, settings)}
 {
     QObject::connect(p->library, &MusicLibrary::tracksAdded, this, &FilterManager::tracksAdded);
+    QObject::connect(p->library, &MusicLibrary::tracksScanned, this, &FilterManager::tracksAdded);
     QObject::connect(p->library, &MusicLibrary::tracksUpdated, this, &FilterManager::tracksUpdated);
     QObject::connect(p->library, &MusicLibrary::tracksDeleted, this, &FilterManager::tracksRemoved);
 

--- a/src/utils/worker.cpp
+++ b/src/utils/worker.cpp
@@ -19,9 +19,6 @@
 
 #include <utils/worker.h>
 
-#include <QAbstractEventDispatcher>
-#include <QThread>
-
 namespace Fooyin {
 Worker::Worker(QObject* parent)
     : QObject{parent}
@@ -31,6 +28,11 @@ Worker::Worker(QObject* parent)
 void Worker::stopThread()
 {
     setState(Idle);
+}
+
+void Worker::pauseThread()
+{
+    setState(Paused);
 }
 
 void Worker::closeThread()
@@ -46,11 +48,6 @@ Worker::State Worker::state() const
 void Worker::setState(State state)
 {
     m_state.store(state, std::memory_order_release);
-}
-
-bool Worker::isRunning()
-{
-    return m_state == Running;
 }
 
 bool Worker::mayRun() const


### PR DESCRIPTION
Allows tracks to be dropped within a playlist from outside fooyin. These tracks will be associated with a default "No Library" library, with an library ID of 0. They will be treated the same as tracks belonging to an added library, but will be removed from the database if they no longer belong to a playlist. They will also not be re-scanned (either automatically or explicitly by the user).

Two types of scan requests can now be made - Library and Tracks. Track scan requests always take priority over library scans (as dropped track scans will keep open a modal dialog until finished).