### PR TITLE
Implement a playlist organiser widget

### DIFF
--- a/include/gui/guiconstants.h
+++ b/include/gui/guiconstants.h
@@ -118,11 +118,13 @@ constexpr auto Clear           = "Edit.Clear";
 constexpr auto Undo            = "Edit.Undo";
 constexpr auto Redo            = "Edit.Redo";
 constexpr auto Remove          = "Edit.Remove";
+constexpr auto Rename          = "Edit.Rename";
 } // namespace Actions
 
 namespace Mime {
-constexpr auto PlaylistItems = "application/x-fooyin-playlistitems";
-constexpr auto TrackIds      = "application/x-fooyin-trackIds";
+constexpr auto PlaylistItems         = "application/x-fooyin-playlistitems";
+constexpr auto TrackIds              = "application/x-fooyin-trackIds";
+constexpr auto PlaylistOrganiserItem = "application/x-fooyin-playlistorganiseritem";
 } // namespace Mime
 
 namespace Page {

--- a/include/gui/guiconstants.h
+++ b/include/gui/guiconstants.h
@@ -124,7 +124,6 @@ constexpr auto Rename          = "Edit.Rename";
 namespace Mime {
 constexpr auto PlaylistItems         = "application/x-fooyin-playlistitems";
 constexpr auto TrackIds              = "application/x-fooyin-trackIds";
-constexpr auto PlaylistOrganiserItem = "application/x-fooyin-playlistorganiseritem";
 } // namespace Mime
 
 namespace Page {

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -80,6 +80,9 @@ set(SOURCES
     playlist/playlistwidget.cpp
     playlist/presetregistry.cpp
     playlist/playlistscriptregistry.cpp
+    playlist/organiser/playlistorganiser.cpp
+    playlist/organiser/playlistorganiseritem.cpp
+    playlist/organiser/playlistorganisermodel.cpp
     quicksetup/quicksetupdialog.cpp
     quicksetup/quicksetupmodel.cpp
     sandbox/expressiontreemodel.cpp

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -32,6 +32,7 @@
 #include "menu/librarymenu.h"
 #include "menu/playbackmenu.h"
 #include "menu/viewmenu.h"
+#include "playlist/organiser/playlistorganiser.h"
 #include "playlist/playlistcontroller.h"
 #include "playlist/playlisttabs.h"
 #include "playlist/playlistwidget.h"
@@ -227,6 +228,14 @@ struct GuiApplication::Private
                                                                          mainWindow.get());
                                              },
                                              u"Playlist Tabs"_s, {"Splitters"});
+
+        factory->registerClass<PlaylistOrganiser>(
+            u"PlaylistOrganiser"_s,
+            [this]() {
+                return new PlaylistOrganiser(actionManager, playlistController.get(), settingsManager,
+                                             mainWindow.get());
+            },
+            u"Playlist Organiser"_s);
 
         factory->registerClass<TabStackWidget>(
             u"TabStack"_s, [this]() { return new TabStackWidget(actionManager, &widgetProvider, mainWindow.get()); },

--- a/src/gui/playlist/organiser/playlistorganiser.cpp
+++ b/src/gui/playlist/organiser/playlistorganiser.cpp
@@ -150,6 +150,7 @@ struct PlaylistOrganiser::Private
         , newPlaylist{new QAction(tr("Create Playlist"))}
         , newPlaylistCmd{actionManager->registerAction(newPlaylist, "PlaylistOrganiser.NewPlaylist", context.context())}
     {
+        organiserTree->setHeaderHidden(true);
         organiserTree->setUniformRowHeights(true);
         organiserTree->setSelectionBehavior(QAbstractItemView::SelectRows);
         organiserTree->setSelectionMode(QAbstractItemView::ExtendedSelection);

--- a/src/gui/playlist/organiser/playlistorganiser.cpp
+++ b/src/gui/playlist/organiser/playlistorganiser.cpp
@@ -1,0 +1,333 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "playlistorganiser.h"
+
+#include "playlist/playlistcontroller.h"
+#include "playlistorganisermodel.h"
+
+#include <core/playlist/playlistmanager.h>
+#include <gui/guiconstants.h>
+#include <utils/actions/actionmanager.h>
+#include <utils/actions/command.h>
+#include <utils/actions/widgetcontext.h>
+#include <utils/crypto.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QContextMenuEvent>
+#include <QMenu>
+#include <QSettings>
+#include <QTreeView>
+#include <QVBoxLayout>
+
+#include <stack>
+
+constexpr auto OrganiserModel = "PlaylistOrganiser/Model";
+constexpr auto OrganiserState = "PlaylistOrganiser/State";
+
+using namespace Qt::Literals::StringLiterals;
+
+namespace {
+QByteArray saveExpandedState(QTreeView* view, QAbstractItemModel* model)
+{
+    QByteArray data;
+    QDataStream stream{&data, QIODeviceBase::WriteOnly};
+    stream.setVersion(QDataStream::Qt_6_5);
+
+    std::stack<QModelIndex> indexesToSave;
+    indexesToSave.emplace();
+
+    while(!indexesToSave.empty()) {
+        const QModelIndex index = indexesToSave.top();
+        indexesToSave.pop();
+
+        if(model->hasChildren(index)) {
+            if(index.isValid()) {
+                stream << view->isExpanded(index);
+            }
+            const int childCount = model->rowCount(index);
+            for(int row{childCount - 1}; row >= 0; --row) {
+                indexesToSave.push(model->index(row, 0, index));
+            }
+        }
+    }
+
+    data = qCompress(data, 9);
+
+    return data;
+}
+
+void restoreExpandedState(QTreeView* view, QAbstractItemModel* model, QByteArray data)
+{
+    if(data.isEmpty()) {
+        return;
+    }
+
+    data = qUncompress(data);
+
+    QDataStream stream{&data, QIODeviceBase::ReadOnly};
+    stream.setVersion(QDataStream::Qt_6_5);
+
+    std::stack<QModelIndex> indexesToSave;
+    indexesToSave.emplace();
+
+    while(!indexesToSave.empty()) {
+        const QModelIndex index = indexesToSave.top();
+        indexesToSave.pop();
+
+        if(model->hasChildren(index)) {
+            if(index.isValid()) {
+                bool expanded;
+                stream >> expanded;
+                view->setExpanded(index, expanded);
+            }
+            const int childCount = model->rowCount(index);
+            for(int row{childCount - 1}; row >= 0; --row) {
+                indexesToSave.push(model->index(row, 0, index));
+            }
+        }
+    }
+}
+} // namespace
+
+namespace Fooyin {
+struct PlaylistOrganiser::Private
+{
+    PlaylistOrganiser* self;
+
+    ActionManager* actionManager;
+    SettingsManager* settings;
+    PlaylistController* playlistController;
+
+    QTreeView* organiserTree;
+    PlaylistOrganiserModel* model;
+
+    WidgetContext context;
+
+    QAction* removePlaylist;
+    Command* removeCmd;
+    QAction* renamePlaylist;
+    Command* renameCmd;
+    QAction* newGroup;
+    Command* newGroupCmd;
+    QAction* newPlaylist;
+    Command* newPlaylistCmd;
+
+    int currentPlaylistId{-1};
+    bool creatingPlaylist{false};
+
+    Private(PlaylistOrganiser* self, ActionManager* actionManager, PlaylistController* playlistController,
+            SettingsManager* settings)
+        : self{self}
+        , actionManager{actionManager}
+        , settings{settings}
+        , playlistController{playlistController}
+        , organiserTree{new QTreeView(self)}
+        , model{new PlaylistOrganiserModel(playlistController->playlistHandler())}
+        , context{self, Context{Id{"Context.PlaylistOrganiser."}.append(Utils::generateRandomHash())}}
+        , removePlaylist{new QAction(tr("Remove"))}
+        , removeCmd{actionManager->registerAction(removePlaylist, Constants::Actions::Remove, context.context())}
+        , renamePlaylist{new QAction(tr("Rename"))}
+        , renameCmd{actionManager->registerAction(renamePlaylist, Constants::Actions::Rename, context.context())}
+        , newGroup{new QAction(tr("New Group"))}
+        , newGroupCmd{actionManager->registerAction(newGroup, "PlaylistOrganiser.NewGroup", context.context())}
+        , newPlaylist{new QAction(tr("Create Playlist"))}
+        , newPlaylistCmd{actionManager->registerAction(newPlaylist, "PlaylistOrganiser.NewPlaylist", context.context())}
+    {
+        organiserTree->setUniformRowHeights(true);
+        organiserTree->setSelectionBehavior(QAbstractItemView::SelectRows);
+        organiserTree->setSelectionMode(QAbstractItemView::ExtendedSelection);
+        organiserTree->setDragEnabled(true);
+        organiserTree->setAcceptDrops(true);
+        organiserTree->setDragDropMode(QAbstractItemView::InternalMove);
+        organiserTree->setDefaultDropAction(Qt::MoveAction);
+        organiserTree->setDropIndicatorShown(true);
+
+        organiserTree->setModel(model);
+
+        actionManager->addContextObject(&context);
+
+        removeCmd->setDefaultShortcut(QKeySequence::Delete);
+        renameCmd->setDefaultShortcut(Qt::Key_F2);
+        newGroupCmd->setDefaultShortcut(QKeySequence::AddTab);
+        newPlaylistCmd->setDefaultShortcut(QKeySequence::New);
+
+        QAction::connect(newGroup, &QAction::triggered, self, [this]() {
+            const auto indexes = organiserTree->selectionModel()->selectedIndexes();
+            createGroup(indexes.empty() ? QModelIndex{} : indexes.front());
+        });
+        QObject::connect(removePlaylist, &QAction::triggered, self,
+                         [this]() { model->removeItems(organiserTree->selectionModel()->selectedIndexes()); });
+        QObject::connect(renamePlaylist, &QAction::triggered, self, [this]() {
+            const auto indexes = organiserTree->selectionModel()->selectedIndexes();
+            organiserTree->edit(indexes.empty() ? QModelIndex{} : indexes.front());
+        });
+        QObject::connect(newPlaylist, &QAction::triggered, self, [this]() {
+            const auto indexes = organiserTree->selectionModel()->selectedIndexes();
+            createPlaylist(indexes.empty() ? QModelIndex{} : indexes.front());
+        });
+    }
+
+    void selectionChanged()
+    {
+        const QModelIndexList selectedIndexes = organiserTree->selectionModel()->selectedIndexes();
+        if(selectedIndexes.empty()) {
+            return;
+        }
+
+        const QModelIndex firstIndex = selectedIndexes.front();
+        if(firstIndex.data(PlaylistOrganiserItem::ItemType).toInt() != PlaylistOrganiserItem::PlaylistItem) {
+            return;
+        }
+
+        auto* playlist       = firstIndex.data(PlaylistOrganiserItem::PlaylistData).value<Playlist*>();
+        const int playlistId = playlist->id();
+
+        if(std::exchange(currentPlaylistId, playlistId) != playlistId) {
+            playlistController->changeCurrentPlaylist(playlist);
+        }
+    }
+
+    void selectCurrentPlaylist(Playlist* playlist)
+    {
+        if(!playlist) {
+            return;
+        }
+
+        const int playlistId = playlist->id();
+        if(std::exchange(currentPlaylistId, playlistId) != playlistId) {
+            const QModelIndex index = model->indexForPlaylist(playlist);
+            if(index.isValid()) {
+                organiserTree->selectionModel()->setCurrentIndex(index, QItemSelectionModel::SelectCurrent);
+            }
+        }
+    }
+
+    void createGroup(const QModelIndex& index) const
+    {
+        QModelIndex parent{index};
+        if(parent.data(PlaylistOrganiserItem::ItemType).toInt() == PlaylistOrganiserItem::PlaylistItem) {
+            parent = parent.parent();
+        }
+        const QModelIndex groupIndex = model->createGroup(parent);
+        organiserTree->edit(groupIndex);
+    }
+
+    void createPlaylist(const QModelIndex& index)
+    {
+        creatingPlaylist = true;
+
+        if(auto* playlist = playlistController->playlistHandler()->createEmptyPlaylist()) {
+            QModelIndex parent{index};
+            if(parent.data(PlaylistOrganiserItem::ItemType).toInt() == PlaylistOrganiserItem::PlaylistItem) {
+                parent = parent.parent();
+            }
+            const QModelIndex playlistIndex = model->createPlaylist(playlist, parent);
+            organiserTree->edit(playlistIndex);
+        }
+
+        creatingPlaylist = false;
+    }
+};
+
+PlaylistOrganiser::PlaylistOrganiser(ActionManager* actionManager, PlaylistController* playlistController,
+                                     SettingsManager* settings, QWidget* parent)
+    : FyWidget{parent}
+    , p{std::make_unique<Private>(this, actionManager, playlistController, settings)}
+{
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    layout->addWidget(p->organiserTree);
+
+    QObject::connect(p->model, &QAbstractItemModel::rowsMoved, this,
+                     [this](const QModelIndex& /*source*/, int /*first*/, int /*last*/, const QModelIndex& target) {
+                         if(target.isValid()) {
+                             p->organiserTree->expand(target);
+                         }
+                     });
+    QObject::connect(p->model, &QAbstractItemModel::rowsInserted, this, [this](const QModelIndex& parent) {
+        if(parent.isValid()) {
+            p->organiserTree->expand(parent);
+        }
+    });
+    QObject::connect(p->organiserTree->selectionModel(), &QItemSelectionModel::selectionChanged, this,
+                     [this]() { p->selectionChanged(); });
+
+    QObject::connect(p->playlistController->playlistHandler(), &PlaylistManager::playlistAdded, this,
+                     [this](Playlist* playlist) {
+                         if(!p->creatingPlaylist) {
+                             p->model->playlistAdded(playlist);
+                         }
+                     });
+    QObject::connect(p->playlistController->playlistHandler(), &PlaylistManager::playlistRemoved, p->model,
+                     &PlaylistOrganiserModel::playlistRemoved);
+    QObject::connect(p->playlistController->playlistHandler(), &PlaylistManager::playlistRenamed, p->model,
+                     &PlaylistOrganiserModel::playlistRenamed);
+    QObject::connect(p->playlistController, &PlaylistController::currentPlaylistChanged, this,
+                     [this](Playlist* playlist) { p->selectCurrentPlaylist(playlist); });
+
+    if(p->model->restoreModel(p->settings->settingsFile()->value(OrganiserModel).toByteArray())) {
+        const auto state = p->settings->settingsFile()->value(OrganiserState).toByteArray();
+        restoreExpandedState(p->organiserTree, p->model, state);
+    }
+    else {
+        p->model->reset();
+    }
+    p->selectCurrentPlaylist(p->playlistController->currentPlaylist());
+}
+
+PlaylistOrganiser::~PlaylistOrganiser()
+{
+    p->settings->settingsFile()->setValue(OrganiserModel, p->model->saveModel());
+    p->settings->settingsFile()->setValue(OrganiserState, saveExpandedState(p->organiserTree, p->model));
+}
+
+QString PlaylistOrganiser::name() const
+{
+    return u"Playlist Organiser"_s;
+}
+
+QString PlaylistOrganiser::layoutName() const
+{
+    return u"PlaylistOrganiser"_s;
+}
+
+void PlaylistOrganiser::contextMenuEvent(QContextMenuEvent* event)
+{
+    auto* menu = new QMenu(this);
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+
+    const QPoint point      = p->organiserTree->viewport()->mapFrom(this, event->pos());
+    const QModelIndex index = p->organiserTree->indexAt(point);
+
+    p->removePlaylist->setEnabled(index.isValid());
+    p->renamePlaylist->setEnabled(index.isValid());
+
+    menu->addAction(p->newPlaylistCmd->action());
+    menu->addAction(p->newGroupCmd->action());
+    menu->addSeparator();
+    menu->addAction(p->renameCmd->action());
+    menu->addAction(p->removeCmd->action());
+
+    menu->popup(event->globalPos());
+}
+} // namespace Fooyin
+
+#include "moc_playlistorganiser.cpp"

--- a/src/gui/playlist/organiser/playlistorganiser.cpp
+++ b/src/gui/playlist/organiser/playlistorganiser.cpp
@@ -287,9 +287,10 @@ PlaylistOrganiser::PlaylistOrganiser(ActionManager* actionManager, PlaylistContr
     if(p->model->restoreModel(p->settings->settingsFile()->value(OrganiserModel).toByteArray())) {
         const auto state = p->settings->settingsFile()->value(OrganiserState).toByteArray();
         restoreExpandedState(p->organiserTree, p->model, state);
+        p->model->populateMissing();
     }
     else {
-        p->model->reset();
+        p->model->populate();
     }
     p->selectCurrentPlaylist(p->playlistController->currentPlaylist());
 }

--- a/src/gui/playlist/organiser/playlistorganiser.h
+++ b/src/gui/playlist/organiser/playlistorganiser.h
@@ -1,0 +1,48 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <gui/fywidget.h>
+
+namespace Fooyin {
+class ActionManager;
+class SettingsManager;
+class PlaylistController;
+
+class PlaylistOrganiser : public FyWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PlaylistOrganiser(ActionManager* actionManager, PlaylistController* playlistController,
+                               SettingsManager* settings, QWidget* parent = nullptr);
+    ~PlaylistOrganiser() override;
+
+    QString name() const override;
+    QString layoutName() const override;
+
+protected:
+    void contextMenuEvent(QContextMenuEvent* event) override;
+
+private:
+    struct Private;
+    std::unique_ptr<Private> p;
+};
+} // namespace Fooyin

--- a/src/gui/playlist/organiser/playlistorganiseritem.cpp
+++ b/src/gui/playlist/organiser/playlistorganiseritem.cpp
@@ -1,0 +1,65 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "playlistorganiseritem.h"
+
+#include <core/playlist/playlist.h>
+
+namespace Fooyin {
+PlaylistOrganiserItem::PlaylistOrganiserItem()
+    : TreeItem{nullptr}
+    , m_type{Root}
+{ }
+
+PlaylistOrganiserItem::PlaylistOrganiserItem(QString title, PlaylistOrganiserItem* parent)
+    : TreeItem{parent}
+    , m_type{GroupItem}
+    , m_title{std::move(title)}
+{ }
+
+PlaylistOrganiserItem::PlaylistOrganiserItem(Playlist* playlist, PlaylistOrganiserItem* parent)
+    : TreeItem{parent}
+    , m_type{PlaylistItem}
+    , m_playlist{playlist}
+{
+    if(playlist) {
+        m_title = playlist->name();
+    }
+}
+
+PlaylistOrganiserItem::Type PlaylistOrganiserItem::type() const
+{
+    return m_type;
+}
+
+QString PlaylistOrganiserItem::title() const
+{
+    return m_title;
+}
+
+Playlist* PlaylistOrganiserItem::playlist() const
+{
+    return m_playlist;
+}
+
+void PlaylistOrganiserItem::setTitle(const QString& title)
+{
+    m_title = title;
+}
+} // namespace Fooyin

--- a/src/gui/playlist/organiser/playlistorganiseritem.cpp
+++ b/src/gui/playlist/organiser/playlistorganiseritem.cpp
@@ -25,12 +25,14 @@ namespace Fooyin {
 PlaylistOrganiserItem::PlaylistOrganiserItem()
     : TreeItem{nullptr}
     , m_type{Root}
+    , m_playlist{nullptr}
 { }
 
 PlaylistOrganiserItem::PlaylistOrganiserItem(QString title, PlaylistOrganiserItem* parent)
     : TreeItem{parent}
     , m_type{GroupItem}
     , m_title{std::move(title)}
+    , m_playlist{nullptr}
 { }
 
 PlaylistOrganiserItem::PlaylistOrganiserItem(Playlist* playlist, PlaylistOrganiserItem* parent)

--- a/src/gui/playlist/organiser/playlistorganiseritem.h
+++ b/src/gui/playlist/organiser/playlistorganiseritem.h
@@ -1,0 +1,61 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <utils/treeitem.h>
+
+#include <QString>
+
+namespace Fooyin {
+class Playlist;
+
+class PlaylistOrganiserItem : public TreeItem<PlaylistOrganiserItem>
+{
+public:
+    enum Type
+    {
+        Root = 0,
+        GroupItem,
+        PlaylistItem
+    };
+
+    enum Data
+    {
+        ItemType = Qt::UserRole,
+        PlaylistData,
+    };
+
+    PlaylistOrganiserItem();
+    PlaylistOrganiserItem(QString title, PlaylistOrganiserItem* parent);
+    PlaylistOrganiserItem(Playlist* playlist, PlaylistOrganiserItem* parent);
+
+    Type type() const;
+    QString title() const;
+    Playlist* playlist() const;
+
+    void setTitle(const QString& title);
+
+private:
+    Type m_type;
+    QString m_title;
+    Playlist* m_playlist;
+};
+
+} // namespace Fooyin

--- a/src/gui/playlist/organiser/playlistorganisermodel.cpp
+++ b/src/gui/playlist/organiser/playlistorganisermodel.cpp
@@ -386,7 +386,7 @@ QModelIndex PlaylistOrganiserModel::indexForPlaylist(Playlist* playlist)
     }
 
     const QString key = playlistKey(playlist->name());
-    if(playlist && p->nodes.contains(key)) {
+    if(p->nodes.contains(key)) {
         return indexOfItem(&p->nodes.at(key));
     }
     return {};

--- a/src/gui/playlist/organiser/playlistorganisermodel.cpp
+++ b/src/gui/playlist/organiser/playlistorganisermodel.cpp
@@ -220,7 +220,7 @@ PlaylistOrganiserModel::PlaylistOrganiserModel(PlaylistManager* playlistManager)
 
 PlaylistOrganiserModel::~PlaylistOrganiserModel() = default;
 
-void PlaylistOrganiserModel::reset()
+void PlaylistOrganiserModel::populate()
 {
     beginResetModel();
     resetRoot();
@@ -229,11 +229,29 @@ void PlaylistOrganiserModel::reset()
     const PlaylistList playlists = p->playlistManager->playlists();
 
     for(const auto& playlist : playlists) {
-        auto* item = &p->nodes.emplace(playlist->name(), PlaylistOrganiserItem{playlist, rootItem()}).first->second;
+        auto* item = &p->nodes.emplace(playlistKey(playlist->name()), PlaylistOrganiserItem{playlist, rootItem()})
+                          .first->second;
         rootItem()->appendChild(item);
     }
 
     endResetModel();
+}
+
+void PlaylistOrganiserModel::populateMissing()
+{
+    const PlaylistList playlists = p->playlistManager->playlists();
+
+    for(const auto& playlist : playlists) {
+        const QString key = playlistKey(playlist->name());
+        if(!p->nodes.contains(key)) {
+            const int row = rowCount({});
+
+            beginInsertRows({}, row, row);
+            auto* item = &p->nodes.emplace(key, PlaylistOrganiserItem{playlist, rootItem()}).first->second;
+            rootItem()->appendChild(item);
+            endInsertRows();
+        }
+    }
 }
 
 QByteArray PlaylistOrganiserModel::saveModel()

--- a/src/gui/playlist/organiser/playlistorganisermodel.cpp
+++ b/src/gui/playlist/organiser/playlistorganisermodel.cpp
@@ -1,0 +1,630 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "playlistorganisermodel.h"
+
+#include <core/playlist/playlistmanager.h>
+#include <gui/guiconstants.h>
+
+#include <QIODevice>
+#include <QMimeData>
+
+#include <stack>
+
+using namespace Qt::Literals::StringLiterals;
+
+namespace {
+bool cmpTrackIndices(const QModelIndex& index1, const QModelIndex& index2)
+{
+    QModelIndex item1{index1};
+    QModelIndex item2{index2};
+
+    QModelIndexList item1Parents;
+    QModelIndexList item2Parents;
+    const QModelIndex root;
+
+    while(item1.parent() != item2.parent()) {
+        if(item1.parent() != root) {
+            item1Parents.push_back(item1);
+            item1 = item1.parent();
+        }
+        if(item2.parent() != root) {
+            item2Parents.push_back(item2);
+            item2 = item2.parent();
+        }
+    }
+    if(item1.row() == item2.row()) {
+        return item1Parents.size() < item2Parents.size();
+    }
+    return item1.row() < item2.row();
+}
+
+struct cmpIndexes
+{
+    bool operator()(const QModelIndex& index1, const QModelIndex& index2) const
+    {
+        return cmpTrackIndices(index1, index2);
+    }
+};
+
+using TrackIndexRangeList = std::vector<QModelIndexList>;
+
+TrackIndexRangeList determineTrackIndexGroups(const QModelIndexList& indexes)
+{
+    TrackIndexRangeList indexGroups;
+
+    QModelIndexList sortedIndexes{indexes};
+    std::ranges::sort(sortedIndexes, cmpTrackIndices);
+
+    auto startOfSequence = sortedIndexes.cbegin();
+    while(startOfSequence != sortedIndexes.cend()) {
+        auto endOfSequence
+            = std::adjacent_find(startOfSequence, sortedIndexes.cend(), [](const auto& lhs, const auto& rhs) {
+                  return lhs.parent() != rhs.parent() || rhs.row() != lhs.row() + 1;
+              });
+        if(endOfSequence != sortedIndexes.cend()) {
+            std::advance(endOfSequence, 1);
+        }
+
+        indexGroups.emplace_back(startOfSequence, endOfSequence);
+
+        startOfSequence = endOfSequence;
+    }
+
+    return indexGroups;
+}
+
+QString groupKey(const QString& title)
+{
+    static const QString prefix = "Group.";
+    return prefix + title;
+}
+
+QString playlistKey(const QString& name)
+{
+    static const QString prefix = "Playlist.";
+    return prefix + name;
+}
+} // namespace
+
+namespace Fooyin {
+struct PlaylistOrganiserModel::Private
+{
+    PlaylistOrganiserModel* self;
+
+    PlaylistManager* playlistManager;
+
+    std::unordered_map<QString, PlaylistOrganiserItem> nodes;
+
+    explicit Private(PlaylistOrganiserModel* self, PlaylistManager* playlistManager)
+        : self{self}
+        , playlistManager{playlistManager}
+    { }
+
+    QByteArray saveIndexes(const QModelIndexList& indexes) const
+    {
+        QByteArray result;
+        QDataStream stream(&result, QIODevice::WriteOnly);
+
+        for(const QModelIndex& index : indexes) {
+            if(!index.isValid()) {
+                continue;
+            }
+            auto* item        = self->itemForIndex(index);
+            const QString key = item->type() == PlaylistOrganiserItem::GroupItem ? groupKey(item->title())
+                                                                                 : playlistKey(item->title());
+            stream << key;
+        }
+        return result;
+    }
+
+    QModelIndexList restoreIndexes(QByteArray data)
+    {
+        QModelIndexList result;
+        QDataStream stream(&data, QIODevice::ReadOnly);
+
+        while(!stream.atEnd()) {
+            QString key;
+            stream >> key;
+            if(nodes.contains(key)) {
+                result.push_back(self->indexOfItem(&nodes.at(key)));
+            }
+        }
+        return result;
+    }
+
+    void recurseSaveModel(QDataStream& stream, PlaylistOrganiserItem* parent)
+    {
+        int itemType;
+        stream >> itemType;
+
+        PlaylistOrganiserItem* currParent{parent};
+
+        if(itemType == static_cast<int>(PlaylistOrganiserItem::PlaylistItem)) {
+            int playlistId;
+            stream >> playlistId;
+            if(Playlist* playlist = playlistManager->playlistById(playlistId)) {
+                auto* item = &nodes.emplace(playlistKey(playlist->name()), PlaylistOrganiserItem{playlist, currParent})
+                                  .first->second;
+                currParent->appendChild(item);
+            }
+        }
+        else if(itemType == static_cast<int>(PlaylistOrganiserItem::GroupItem)) {
+            QString title;
+            stream >> title;
+            auto* item = &nodes.emplace(groupKey(title), PlaylistOrganiserItem{title, currParent}).first->second;
+            currParent->appendChild(item);
+            currParent = item;
+        }
+
+        if(itemType != static_cast<int>(PlaylistOrganiserItem::PlaylistItem)) {
+            qsizetype childCount;
+            stream >> childCount;
+            for(qsizetype row{0}; row < childCount; ++row) {
+                recurseSaveModel(stream, currParent);
+            }
+        }
+    }
+
+    QString findUniqueName(const QString& name) const
+    {
+        return Utils::findUniqueString(name, nodes, [](const auto& pair) { return pair.second.title(); });
+    }
+
+    void deleteNodes(PlaylistOrganiserItem* node)
+    {
+        if(!node) {
+            return;
+        }
+
+        const int count = node->childCount();
+        if(count > 0) {
+            for(int row{0}; row < count; ++row) {
+                if(PlaylistOrganiserItem* child = node->child(row)) {
+                    deleteNodes(child);
+                }
+            }
+        }
+
+        if(node->type() == PlaylistOrganiserItem::GroupItem) {
+            nodes.erase(groupKey(node->title()));
+        }
+        else if(node->type() == PlaylistOrganiserItem::PlaylistItem) {
+            nodes.erase(playlistKey(node->title()));
+            playlistManager->removePlaylist(node->playlist()->id());
+        }
+    }
+};
+
+PlaylistOrganiserModel::PlaylistOrganiserModel(PlaylistManager* playlistManager)
+    : p{std::make_unique<Private>(this, playlistManager)}
+{ }
+
+PlaylistOrganiserModel::~PlaylistOrganiserModel() = default;
+
+void PlaylistOrganiserModel::reset()
+{
+    beginResetModel();
+    resetRoot();
+    p->nodes.clear();
+
+    const PlaylistList playlists = p->playlistManager->playlists();
+
+    for(const auto& playlist : playlists) {
+        auto* item = &p->nodes.emplace(playlist->name(), PlaylistOrganiserItem{playlist, rootItem()}).first->second;
+        rootItem()->appendChild(item);
+    }
+
+    endResetModel();
+}
+
+QByteArray PlaylistOrganiserModel::saveModel()
+{
+    QByteArray data;
+    QDataStream stream{&data, QIODeviceBase::WriteOnly};
+    stream.setVersion(QDataStream::Qt_6_5);
+
+    std::stack<PlaylistOrganiserItem*> itemsToSave;
+    itemsToSave.push(rootItem());
+
+    while(!itemsToSave.empty()) {
+        PlaylistOrganiserItem* item = itemsToSave.top();
+        itemsToSave.pop();
+
+        stream << static_cast<int>(item->type());
+
+        if(item->type() == PlaylistOrganiserItem::PlaylistItem) {
+            stream << item->playlist()->id();
+        }
+        else if(item->type() == PlaylistOrganiserItem::GroupItem) {
+            stream << item->title();
+        }
+
+        if(item->type() != PlaylistOrganiserItem::PlaylistItem) {
+            const auto children = item->children();
+            stream << static_cast<qsizetype>(children.size());
+            for(PlaylistOrganiserItem* child : children | std::views::reverse) {
+                itemsToSave.push(child);
+            }
+        }
+    }
+
+    data = qCompress(data, 9);
+
+    return data;
+}
+
+bool PlaylistOrganiserModel::restoreModel(QByteArray data)
+{
+    if(data.isEmpty()) {
+        return false;
+    }
+
+    data = qUncompress(data);
+
+    QDataStream stream{&data, QIODeviceBase::ReadOnly};
+    stream.setVersion(QDataStream::Qt_6_5);
+
+    beginResetModel();
+    resetRoot();
+    p->nodes.clear();
+
+    while(!stream.atEnd()) {
+        p->recurseSaveModel(stream, rootItem());
+    }
+
+    endResetModel();
+
+    return true;
+}
+
+QModelIndex PlaylistOrganiserModel::createGroup(const QModelIndex& parent)
+{
+    auto* parentItem    = itemForIndex(parent);
+    const QString title = p->findUniqueName(u"New Group"_s);
+    auto* item          = &p->nodes.emplace(groupKey(title), PlaylistOrganiserItem{title, parentItem}).first->second;
+
+    const int row = parentItem->childCount();
+    beginInsertRows(parent, row, row);
+    parentItem->appendChild(item);
+    endInsertRows();
+
+    return index(row, 0, parent);
+}
+
+QModelIndex PlaylistOrganiserModel::createPlaylist(Playlist* playlist, const QModelIndex& parent)
+{
+    auto* parentItem = itemForIndex(parent);
+    auto* item
+        = &p->nodes.emplace(playlistKey(playlist->name()), PlaylistOrganiserItem{playlist, parentItem}).first->second;
+
+    const int row = parentItem->childCount();
+    beginInsertRows(parent, row, row);
+    parentItem->appendChild(item);
+    endInsertRows();
+
+    return index(row, 0, parent);
+}
+
+void PlaylistOrganiserModel::playlistAdded(Playlist* playlist)
+{
+    beginInsertRows({}, rowCount({}), rowCount({}));
+    auto* item
+        = &p->nodes.emplace(playlistKey(playlist->name()), PlaylistOrganiserItem{playlist, rootItem()}).first->second;
+    rootItem()->appendChild(item);
+    endInsertRows();
+}
+
+void PlaylistOrganiserModel::playlistRenamed(Playlist* playlist)
+{
+    if(!playlist) {
+        return;
+    }
+
+    const auto playlistIt = std::ranges::find_if(std::as_const(p->nodes), [playlist](const auto& pair) {
+        return pair.second.type() == PlaylistOrganiserItem::PlaylistItem
+            && pair.second.playlist()->id() == playlist->id();
+    });
+
+    if(playlistIt != p->nodes.end()) {
+        auto playlistItem  = p->nodes.extract(playlistIt);
+        playlistItem.key() = playlistKey(playlist->name());
+
+        auto* item = &p->nodes.insert(std::move(playlistItem)).position->second;
+        item->setTitle(playlist->name());
+
+        const QModelIndex index = indexForPlaylist(playlist);
+        emit dataChanged(index, index, {Qt::DisplayRole});
+    }
+}
+
+void PlaylistOrganiserModel::playlistRemoved(Playlist* playlist)
+{
+    if(!playlist) {
+        return;
+    }
+
+    const QString key = playlistKey(playlist->name());
+    if(!p->nodes.contains(key)) {
+        return;
+    }
+
+    const auto* item = &p->nodes.at(key);
+    const int row    = item->row();
+    auto* parent     = item->parent();
+
+    beginRemoveRows(indexOfItem(parent), row, row);
+    parent->removeChild(row);
+    parent->resetChildren();
+    endRemoveRows();
+
+    p->nodes.erase(key);
+}
+
+QModelIndex PlaylistOrganiserModel::indexForPlaylist(Playlist* playlist)
+{
+    if(!playlist) {
+        return {};
+    }
+
+    const QString key = playlistKey(playlist->name());
+    if(playlist && p->nodes.contains(key)) {
+        return indexOfItem(&p->nodes.at(key));
+    }
+    return {};
+}
+
+Qt::ItemFlags PlaylistOrganiserModel::flags(const QModelIndex& index) const
+{
+    Qt::ItemFlags defaultFlags = QAbstractItemModel::flags(index);
+
+    const auto type = index.data(PlaylistOrganiserItem::ItemType).toInt();
+
+    if(index.isValid()) {
+        defaultFlags |= Qt::ItemIsDragEnabled | Qt::ItemIsEditable;
+    }
+    if(type == PlaylistOrganiserItem::PlaylistItem) {
+        defaultFlags |= Qt::ItemNeverHasChildren;
+    }
+    else {
+        defaultFlags |= Qt::ItemIsDropEnabled;
+    }
+
+    return defaultFlags;
+}
+
+QVariant PlaylistOrganiserModel::headerData(int /*section*/, Qt::Orientation orientation, int role) const
+{
+    if(orientation == Qt::Orientation::Vertical) {
+        return {};
+    }
+
+    if(role == Qt::TextAlignmentRole) {
+        return (Qt::AlignHCenter);
+    }
+
+    if(role != Qt::DisplayRole) {
+        return {};
+    }
+
+    return "Playlist Organiser";
+}
+
+bool PlaylistOrganiserModel::hasChildren(const QModelIndex& parent) const
+{
+    return parent.data(PlaylistOrganiserItem::ItemType).toInt() != PlaylistOrganiserItem::PlaylistItem;
+}
+
+QVariant PlaylistOrganiserModel::data(const QModelIndex& index, int role) const
+{
+    if(role != Qt::DisplayRole && role != Qt::EditRole && role != PlaylistOrganiserItem::ItemType
+       && role != PlaylistOrganiserItem::PlaylistData) {
+        return {};
+    }
+
+    if(!checkIndex(index, CheckIndexOption::IndexIsValid)) {
+        return {};
+    }
+
+    auto* item      = itemForIndex(index);
+    const auto type = item->type();
+
+    if(role == PlaylistOrganiserItem::ItemType) {
+        return QVariant::fromValue(item->type());
+    }
+
+    if(role == PlaylistOrganiserItem::PlaylistData) {
+        return QVariant::fromValue(item->playlist());
+    }
+
+    if(type == PlaylistOrganiserItem::PlaylistItem) {
+        return item->title();
+    }
+    if(type == PlaylistOrganiserItem::GroupItem) {
+        if(role == Qt::DisplayRole) {
+            return QString{"%1 [%2]"}.arg(item->title()).arg(item->childCount());
+        }
+        return item->title();
+    }
+
+    return {};
+}
+
+bool PlaylistOrganiserModel::setData(const QModelIndex& index, const QVariant& value, int role)
+{
+    if(role != Qt::EditRole) {
+        return false;
+    }
+
+    auto* item      = itemForIndex(index);
+    const auto type = item->type();
+
+    if(type == PlaylistOrganiserItem::PlaylistItem) {
+        const QString name = value.toString();
+        if(item->title() != name) {
+            p->playlistManager->renamePlaylist(item->playlist()->id(), name);
+        }
+    }
+    else if(type == PlaylistOrganiserItem::GroupItem) {
+        const QString oldTitle = item->title();
+        const QString title    = value.toString();
+        if(oldTitle != title) {
+            const QString newTitle = p->findUniqueName(title);
+            item->setTitle(newTitle);
+
+            auto groupItem  = p->nodes.extract(groupKey(oldTitle));
+            groupItem.key() = groupKey(newTitle);
+            p->nodes.insert(std::move(groupItem));
+        }
+    }
+
+    emit dataChanged(index, index, {Qt::DisplayRole});
+
+    return true;
+}
+
+QStringList PlaylistOrganiserModel::mimeTypes() const
+{
+    return {Constants::Mime::PlaylistOrganiserItem};
+}
+
+bool PlaylistOrganiserModel::canDropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column,
+                                             const QModelIndex& parent) const
+{
+    if(action == Qt::MoveAction && data->hasFormat(Constants::Mime::PlaylistOrganiserItem)) {
+        return true;
+    }
+    return QAbstractItemModel::canDropMimeData(data, action, row, column, parent);
+}
+
+Qt::DropActions PlaylistOrganiserModel::supportedDropActions() const
+{
+    return Qt::MoveAction;
+}
+
+Qt::DropActions PlaylistOrganiserModel::supportedDragActions() const
+{
+    return Qt::MoveAction;
+}
+
+QMimeData* PlaylistOrganiserModel::mimeData(const QModelIndexList& indexes) const
+{
+    auto* mimeData = new QMimeData();
+    mimeData->setData(Constants::Mime::PlaylistOrganiserItem, p->saveIndexes(indexes));
+    return mimeData;
+}
+
+bool PlaylistOrganiserModel::dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column,
+                                          const QModelIndex& parent)
+{
+    if(!canDropMimeData(data, action, row, column, parent)) {
+        return false;
+    }
+
+    const QModelIndexList indexes = p->restoreIndexes(data->data(Constants::Mime::PlaylistOrganiserItem));
+
+    const auto indexGroups = determineTrackIndexGroups(indexes);
+
+    if(row < 0) {
+        row = rowCount(parent);
+    }
+
+    for(const auto& group : indexGroups) {
+        const auto children = std::views::transform(std::as_const(group),
+                                                    [this](const QModelIndex& index) { return itemForIndex(index); });
+
+        auto* sourceParent       = children.front()->parent();
+        const QModelIndex source = indexOfItem(sourceParent);
+        auto* targetParent       = itemForIndex(parent);
+
+        int currRow{row};
+        const int firstRow = children.front()->row();
+        const int lastRow  = static_cast<int>(firstRow + children.size()) - 1;
+
+        if(source == parent && currRow >= firstRow && currRow <= lastRow + 1) {
+            continue;
+        }
+
+        beginMoveRows(source, firstRow, lastRow, parent, row);
+
+        for(PlaylistOrganiserItem* childItem : children) {
+            childItem->resetRow();
+            const int oldRow = childItem->row();
+            if(oldRow < currRow) {
+                targetParent->insertChild(currRow, childItem);
+                sourceParent->removeChild(oldRow);
+
+                if(source != parent) {
+                    ++currRow;
+                }
+            }
+            else {
+                sourceParent->removeChild(oldRow);
+                targetParent->insertChild(currRow, childItem);
+
+                ++currRow;
+            }
+        }
+        sourceParent->resetChildren();
+        targetParent->resetChildren();
+
+        endMoveRows();
+
+        row = currRow;
+    }
+
+    rootItem()->resetChildren();
+
+    return true;
+}
+
+void PlaylistOrganiserModel::removeItems(const QModelIndexList& indexes)
+{
+    if(indexes.empty()) {
+        return;
+    }
+
+    const auto indexGroups = determineTrackIndexGroups(indexes);
+
+    for(const auto& group : indexGroups) {
+        const auto children = std::views::transform(std::as_const(group),
+                                                    [this](const QModelIndex& index) { return itemForIndex(index); });
+
+        const QModelIndex parent = group.constFirst().parent();
+        auto* parentItem         = children.front()->parent();
+
+        const int firstRow = children.front()->row();
+        int lastRow        = static_cast<int>(firstRow + children.size()) - 1;
+
+        beginRemoveRows(parent, firstRow, lastRow);
+        while(lastRow >= firstRow) {
+            parentItem->removeChild(lastRow);
+            --lastRow;
+        }
+        parentItem->resetChildren();
+        endRemoveRows();
+
+        for(auto* child : children) {
+            p->deleteNodes(child);
+        }
+    }
+}
+} // namespace Fooyin
+
+#include "moc_playlistorganisermodel.cpp"

--- a/src/gui/playlist/organiser/playlistorganisermodel.cpp
+++ b/src/gui/playlist/organiser/playlistorganisermodel.cpp
@@ -411,23 +411,6 @@ Qt::ItemFlags PlaylistOrganiserModel::flags(const QModelIndex& index) const
     return defaultFlags;
 }
 
-QVariant PlaylistOrganiserModel::headerData(int /*section*/, Qt::Orientation orientation, int role) const
-{
-    if(orientation == Qt::Orientation::Vertical) {
-        return {};
-    }
-
-    if(role == Qt::TextAlignmentRole) {
-        return (Qt::AlignHCenter);
-    }
-
-    if(role != Qt::DisplayRole) {
-        return {};
-    }
-
-    return "Playlist Organiser";
-}
-
 bool PlaylistOrganiserModel::hasChildren(const QModelIndex& parent) const
 {
     return parent.data(PlaylistOrganiserItem::ItemType).toInt() != PlaylistOrganiserItem::PlaylistItem;

--- a/src/gui/playlist/organiser/playlistorganisermodel.cpp
+++ b/src/gui/playlist/organiser/playlistorganisermodel.cpp
@@ -27,6 +27,8 @@
 
 #include <stack>
 
+constexpr auto OrganiserItems = "application/x-fooyin-playlistorganiseritems";
+
 using namespace Qt::Literals::StringLiterals;
 
 namespace {
@@ -501,13 +503,13 @@ bool PlaylistOrganiserModel::setData(const QModelIndex& index, const QVariant& v
 
 QStringList PlaylistOrganiserModel::mimeTypes() const
 {
-    return {Constants::Mime::PlaylistOrganiserItem};
+    return {OrganiserItems};
 }
 
 bool PlaylistOrganiserModel::canDropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column,
                                              const QModelIndex& parent) const
 {
-    if(action == Qt::MoveAction && data->hasFormat(Constants::Mime::PlaylistOrganiserItem)) {
+    if(action == Qt::MoveAction && data->hasFormat(OrganiserItems)) {
         return true;
     }
     return QAbstractItemModel::canDropMimeData(data, action, row, column, parent);
@@ -526,7 +528,7 @@ Qt::DropActions PlaylistOrganiserModel::supportedDragActions() const
 QMimeData* PlaylistOrganiserModel::mimeData(const QModelIndexList& indexes) const
 {
     auto* mimeData = new QMimeData();
-    mimeData->setData(Constants::Mime::PlaylistOrganiserItem, p->saveIndexes(indexes));
+    mimeData->setData(OrganiserItems, p->saveIndexes(indexes));
     return mimeData;
 }
 
@@ -537,7 +539,7 @@ bool PlaylistOrganiserModel::dropMimeData(const QMimeData* data, Qt::DropAction 
         return false;
     }
 
-    const QModelIndexList indexes = p->restoreIndexes(data->data(Constants::Mime::PlaylistOrganiserItem));
+    const QModelIndexList indexes = p->restoreIndexes(data->data(OrganiserItems));
 
     const auto indexGroups = determineTrackIndexGroups(indexes);
 

--- a/src/gui/playlist/organiser/playlistorganisermodel.h
+++ b/src/gui/playlist/organiser/playlistorganisermodel.h
@@ -35,7 +35,8 @@ public:
     explicit PlaylistOrganiserModel(PlaylistManager* playlistManager);
     ~PlaylistOrganiserModel() override;
 
-    void reset();
+    void populate();
+    void populateMissing();
     QByteArray saveModel();
     bool restoreModel(QByteArray data);
 

--- a/src/gui/playlist/organiser/playlistorganisermodel.h
+++ b/src/gui/playlist/organiser/playlistorganisermodel.h
@@ -49,7 +49,6 @@ public:
     QModelIndex indexForPlaylist(Playlist* playlist);
 
     Qt::ItemFlags flags(const QModelIndex& index) const override;
-    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
     bool hasChildren(const QModelIndex& parent) const override;
     QVariant data(const QModelIndex& index, int role) const override;
     bool setData(const QModelIndex& index, const QVariant& value, int role) override;

--- a/src/gui/playlist/organiser/playlistorganisermodel.h
+++ b/src/gui/playlist/organiser/playlistorganisermodel.h
@@ -1,0 +1,72 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "playlistorganiseritem.h"
+
+#include <utils/treemodel.h>
+
+namespace Fooyin {
+class Playlist;
+class PlaylistManager;
+
+class PlaylistOrganiserModel : public TreeModel<PlaylistOrganiserItem>
+{
+    Q_OBJECT
+
+public:
+    explicit PlaylistOrganiserModel(PlaylistManager* playlistManager);
+    ~PlaylistOrganiserModel() override;
+
+    void reset();
+    QByteArray saveModel();
+    bool restoreModel(QByteArray data);
+
+    QModelIndex createGroup(const QModelIndex& parent);
+    QModelIndex createPlaylist(Playlist* playlist, const QModelIndex& parent);
+
+    void playlistAdded(Playlist* playlist);
+    void playlistRenamed(Playlist* playlist);
+    void playlistRemoved(Playlist* playlist);
+
+    QModelIndex indexForPlaylist(Playlist* playlist);
+
+    Qt::ItemFlags flags(const QModelIndex& index) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+    bool hasChildren(const QModelIndex& parent) const override;
+    QVariant data(const QModelIndex& index, int role) const override;
+    bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+
+    [[nodiscard]] QStringList mimeTypes() const override;
+    [[nodiscard]] bool canDropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column,
+                                       const QModelIndex& parent) const override;
+    Qt::DropActions supportedDropActions() const override;
+    Qt::DropActions supportedDragActions() const override;
+    [[nodiscard]] QMimeData* mimeData(const QModelIndexList& indexes) const override;
+    bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column,
+                      const QModelIndex& parent) override;
+
+    void removeItems(const QModelIndexList& indexes);
+
+private:
+    struct Private;
+    std::unique_ptr<Private> p;
+};
+} // namespace Fooyin


### PR DESCRIPTION
Adds a tree-based widget to control and organise fooyin's playlists. It offers the same level of control of playlists as PlaylistTabs, but adds the ability to group playlists into a nested structure. This structure is saved and restored at startup.