### PR TITLE
Support multiple columns in filter widgets

### DIFF
--- a/src/plugins/filters/CMakeLists.txt
+++ b/src/plugins/filters/CMakeLists.txt
@@ -28,7 +28,7 @@ project(
 
 create_fooyin_plugin(
     fooyin_filters
-    SOURCES fieldregistry.cpp
+    SOURCES filtercolumnregistry.cpp
             filtersplugin.cpp
             filterdelegate.cpp
             filteritem.cpp
@@ -38,9 +38,9 @@ create_fooyin_plugin(
             filterview.cpp
             filterwidget.cpp
             filterstore.cpp
-            settings/fieldmodel.cpp
+            settings/filterscolumnmodel.cpp
             settings/filtersettings.cpp
-            settings/filtersfieldspage.cpp
+            settings/filterscolumnpage.cpp
             settings/filtersgeneralpage.cpp
 )
 

--- a/src/plugins/filters/filtercolumnregistry.cpp
+++ b/src/plugins/filters/filtercolumnregistry.cpp
@@ -17,29 +17,29 @@
  *
  */
 
-#include "fieldregistry.h"
+#include "filtercolumnregistry.h"
 
 namespace {
-void loadDefaults(Fooyin::Filters::FieldRegistry* registry)
+void loadDefaults(Fooyin::Filters::FilterColumnRegistry* registry)
 {
-    registry->addItem({.id = 0, .index = 0, .name = "Genre", .field = "%<genre>%", .sortField = ""});
-    registry->addItem({.id = 1, .index = 1, .name = "Album Artist", .field = "%albumartist%", .sortField = ""});
-    registry->addItem({.id = 2, .index = 2, .name = "Artist", .field = "%<artist>%", .sortField = ""});
-    registry->addItem({.id = 3, .index = 3, .name = "Album", .field = "%album%", .sortField = ""});
+    registry->addItem({.id = 0, .index = 0, .name = "Genre", .field = "%<genre>%"});
+    registry->addItem({.id = 1, .index = 1, .name = "Album Artist", .field = "%albumartist%"});
+    registry->addItem({.id = 2, .index = 2, .name = "Artist", .field = "%<artist>%"});
+    registry->addItem({.id = 3, .index = 3, .name = "Album", .field = "%album%"});
 }
 } // namespace
 
 namespace Fooyin::Filters {
-FieldRegistry::FieldRegistry(SettingsManager* settings, QObject* parent)
+FilterColumnRegistry::FilterColumnRegistry(SettingsManager* settings, QObject* parent)
     : ItemRegistry{settings, parent}
 {
     QObject::connect(this, &RegistryBase::itemChanged, this, [this](int id) {
         const auto field = itemById(id);
-        emit fieldChanged(field);
+        emit columnChanged(field);
     });
 }
 
-void FieldRegistry::loadItems()
+void FilterColumnRegistry::loadItems()
 {
     ItemRegistry::loadItems();
 
@@ -49,4 +49,4 @@ void FieldRegistry::loadItems()
 }
 } // namespace Fooyin::Filters
 
-#include "moc_fieldregistry.cpp"
+#include "moc_filtercolumnregistry.cpp"

--- a/src/plugins/filters/filtercolumnregistry.h
+++ b/src/plugins/filters/filtercolumnregistry.h
@@ -19,19 +19,26 @@
 
 #pragma once
 
-#include <utils/settings/settingspage.h>
+#include "filterfwd.h"
+#include "settings/filtersettings.h"
+
+#include <utils/itemregistry.h>
 
 namespace Fooyin {
-class ActionManager;
 class SettingsManager;
 
 namespace Filters {
-class FieldRegistry;
-
-class FiltersFieldsPage : public SettingsPage
+class FilterColumnRegistry : public ItemRegistry<FilterColumn, Settings::Filters::FilterColumns>
 {
+    Q_OBJECT
+
 public:
-    explicit FiltersFieldsPage(ActionManager* actionManager, FieldRegistry* fieldsRegistry, SettingsManager* settings);
+    explicit FilterColumnRegistry(SettingsManager* settings, QObject* parent = nullptr);
+
+    void loadItems() override;
+
+signals:
+    void columnChanged(const FilterColumn& field);
 };
 } // namespace Filters
 } // namespace Fooyin

--- a/src/plugins/filters/filterfwd.h
+++ b/src/plugins/filters/filterfwd.h
@@ -70,18 +70,16 @@ struct FilterOptions
     }
 };
 
-struct FilterField
+struct FilterColumn
 {
     int id{-1};
     int index{-1};
     QString name;
     QString field;
-    QString sortField;
 
-    bool operator==(const FilterField& other) const
+    bool operator==(const FilterColumn& other) const
     {
-        return std::tie(id, index, name, field, sortField)
-            == std::tie(other.id, other.index, other.name, other.field, other.sortField);
+        return std::tie(id, index, name, field) == std::tie(other.id, other.index, other.name, other.field);
     }
 
     [[nodiscard]] bool isValid() const
@@ -89,33 +87,39 @@ struct FilterField
         return id >= 0 && !name.isEmpty() && !field.isEmpty();
     }
 
-    friend QDataStream& operator<<(QDataStream& stream, const FilterField& field)
+    friend QDataStream& operator<<(QDataStream& stream, const FilterColumn& field)
     {
         stream << field.id;
         stream << field.index;
         stream << field.name;
         stream << field.field;
-        stream << field.sortField;
         return stream;
     }
 
-    friend QDataStream& operator>>(QDataStream& stream, FilterField& field)
+    friend QDataStream& operator>>(QDataStream& stream, FilterColumn& field)
     {
         stream >> field.id;
         stream >> field.index;
         stream >> field.name;
         stream >> field.field;
-        stream >> field.sortField;
         return stream;
     }
 };
+using FilterColumnList = std::vector<FilterColumn>;
 
 struct LibraryFilter
 {
-    FilterField field;
+    FilterColumnList columns;
+    bool multipleColumns{false};
     int index{-1};
     TrackList tracks;
+
+    bool hasColumn(int id) const
+    {
+        return std::ranges::any_of(columns, [id](const FilterColumn& column) { return column.id == id; });
+    }
 };
 
 using FilterList = std::vector<LibraryFilter>;
+using ColumnIds  = std::vector<int>;
 } // namespace Fooyin::Filters

--- a/src/plugins/filters/filteritem.h
+++ b/src/plugins/filters/filteritem.h
@@ -22,7 +22,7 @@
 #include <core/trackfwd.h>
 #include <utils/treeitem.h>
 
-#include <QObject>
+#include <QStringList>
 
 namespace Fooyin::Filters {
 class FilterItem;
@@ -32,34 +32,29 @@ class FilterItem : public TreeItem<FilterItem>
 public:
     enum FilterItemRole
     {
-        Title = Qt::UserRole,
-        Tracks,
-        Sorting,
-        AllNode
+        Tracks = Qt::UserRole,
     };
 
     FilterItem() = default;
-    explicit FilterItem(QString title, QString sortTitle, FilterItem* parent, bool isAllNode = false);
+    explicit FilterItem(QString key, QStringList columns, FilterItem* parent);
 
-    [[nodiscard]] QString title() const;
-    [[nodiscard]] QString sortTitle() const;
+    [[nodiscard]] QString key() const;
+    [[nodiscard]] QStringList columns() const;
+    [[nodiscard]] QString column(int column) const;
     [[nodiscard]] TrackList tracks() const;
     [[nodiscard]] int trackCount() const;
 
-    void setTitle(const QString& title);
+    void setColumns(const QStringList& columns);
 
     void addTrack(const Track& track);
     void addTracks(const TrackList& tracks);
     void removeTrack(const Track& track);
 
-    [[nodiscard]] bool isAllNode() const;
-
-    void sortChildren(Qt::SortOrder order);
+    void sortChildren(int column, Qt::SortOrder order);
 
 private:
-    QString m_title;
-    QString m_sortTitle;
+    QString m_key;
+    QStringList m_columns;
     TrackList m_tracks;
-    bool m_isAllNode;
 };
 } // namespace Fooyin::Filters

--- a/src/plugins/filters/filtermanager.h
+++ b/src/plugins/filters/filtermanager.h
@@ -31,7 +31,7 @@ class MusicLibrary;
 class TrackSelectionController;
 
 namespace Filters {
-class FieldRegistry;
+class FilterColumnRegistry;
 class FilterWidget;
 
 class FilterManager : public QObject
@@ -47,7 +47,7 @@ public:
 
     FilterWidget* createFilter();
 
-    [[nodiscard]] FieldRegistry* fieldRegistry() const;
+    [[nodiscard]] FilterColumnRegistry* columnRegistry() const;
 
 signals:
     void tracksAdded(const TrackList& tracks);

--- a/src/plugins/filters/filtermodel.cpp
+++ b/src/plugins/filters/filtermodel.cpp
@@ -78,7 +78,7 @@ struct FilterModel::Private
     QFont font;
     QColor colour;
 
-    Private(FilterModel* self)
+    explicit Private(FilterModel* self)
         : self{self}
     {
         populator.moveToThread(&populatorThread);

--- a/src/plugins/filters/filtermodel.cpp
+++ b/src/plugins/filters/filtermodel.cpp
@@ -70,16 +70,16 @@ struct FilterModel::Private
     ItemKeyMap nodes;
     TrackIdNodeMap trackParents;
 
-    FilterField field;
+    FilterColumnList columns;
+    int sortColumn{0};
     Qt::SortOrder sortOrder{Qt::AscendingOrder};
 
     int rowHeight{0};
     QFont font;
     QColor colour;
 
-    Private(FilterModel* self, FilterField field)
+    Private(FilterModel* self)
         : self{self}
-        , field{std::move(field)}
     {
         populator.moveToThread(&populatorThread);
     }
@@ -90,7 +90,7 @@ struct FilterModel::Private
         nodes.clear();
         trackParents.clear();
 
-        allNode = FilterItem{QStringLiteral(""), QStringLiteral(""), self->rootItem(), true};
+        allNode = FilterItem{QStringLiteral(""), {}, self->rootItem()};
         self->rootItem()->appendChild(&allNode);
     }
 
@@ -116,15 +116,13 @@ struct FilterModel::Private
                 nodes[key].addTracks(item.tracks());
             }
             else {
-                nodes[key]        = item;
-                FilterItem* child = &nodes.at(key);
-
                 if(!resetting) {
-                    const int row = self->rootItem()->childCount();
-                    self->beginInsertRows({}, row, row);
+                    const int row = allNode.childCount();
+                    self->beginInsertRows(self->indexOfItem(&allNode), row, row);
                 }
 
-                self->rootItem()->appendChild(child);
+                FilterItem* child = &nodes.emplace(key, item).first->second;
+                allNode.appendChild(child);
 
                 if(!resetting) {
                     self->endInsertRows();
@@ -133,15 +131,14 @@ struct FilterModel::Private
         }
         trackParents.merge(data.trackParents);
 
-        self->rootItem()->sortChildren(sortOrder);
-
-        allNode.setTitle(QString{QStringLiteral("All (%1)")}.arg(self->rootItem()->childCount() - 1));
+        allNode.sortChildren(sortColumn, sortOrder);
+        allNode.setColumns({QString{QStringLiteral("All (%1)")}.arg(std::max(0, allNode.childCount() - 1))});
     }
 };
 
-FilterModel::FilterModel(const FilterField& field, QObject* parent)
-    : TableModel{parent}
-    , p{std::make_unique<Private>(this, field)}
+FilterModel::FilterModel(QObject* parent)
+    : TreeModel{parent}
+    , p{std::make_unique<Private>(this)}
 {
     QObject::connect(&p->populator, &FilterPopulator::populated, this,
                      [this](const PendingTreeData& data) { p->batchFinished(data); });
@@ -157,6 +154,11 @@ FilterModel::~FilterModel()
     p->populator.stopThread();
     p->populatorThread.quit();
     p->populatorThread.wait();
+}
+
+int FilterModel::sortColumn() const
+{
+    return p->sortColumn;
 };
 
 Qt::SortOrder FilterModel::sortOrder() const
@@ -164,12 +166,13 @@ Qt::SortOrder FilterModel::sortOrder() const
     return p->sortOrder;
 }
 
-void FilterModel::setSortOrder(Qt::SortOrder order)
+void FilterModel::sortOnColumn(int column, Qt::SortOrder order)
 {
-    p->sortOrder = order;
+    p->sortColumn = column;
+    p->sortOrder  = order;
 
     emit layoutAboutToBeChanged();
-    rootItem()->sortChildren(order);
+    p->allNode.sortChildren(column, order);
     emit layoutChanged();
 }
 
@@ -188,30 +191,43 @@ Qt::ItemFlags FilterModel::flags(const QModelIndex& index) const
     return defaultFlags;
 }
 
+QVariant FilterModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(role != Qt::TextAlignmentRole && role != Qt::DisplayRole) {
+        return {};
+    }
+
+    if(orientation == Qt::Orientation::Vertical) {
+        return {};
+    }
+
+    if(role == Qt::TextAlignmentRole) {
+        return (Qt::AlignHCenter);
+    }
+
+    if(section < 0 || section >= static_cast<int>(p->columns.size())) {
+        return QStringLiteral("Filter");
+    }
+
+    return p->columns.at(section).name;
+}
+
 QVariant FilterModel::data(const QModelIndex& index, int role) const
 {
     if(!checkIndex(index, CheckIndexOption::IndexIsValid)) {
         return {};
     }
 
-    const auto* item = static_cast<FilterItem*>(index.internalPointer());
+    const auto* item = itemForIndex(index);
+    const int col    = index.column();
 
     switch(role) {
         case(Qt::DisplayRole): {
-            const QString& name = item->title();
+            const QString& name = item->column(col);
             return !name.isEmpty() ? name : QStringLiteral("?");
-        }
-        case(FilterItem::Title): {
-            return item->title();
         }
         case(FilterItem::Tracks): {
             return QVariant::fromValue(item->tracks());
-        }
-        case(FilterItem::Sorting): {
-            return item->sortTitle();
-        }
-        case(FilterItem::AllNode): {
-            return item->isAllNode();
         }
         case(Qt::SizeHintRole): {
             return QSize{0, p->rowHeight};
@@ -228,31 +244,9 @@ QVariant FilterModel::data(const QModelIndex& index, int role) const
     }
 }
 
-QVariant FilterModel::headerData(int /*section*/, Qt::Orientation orientation, int role) const
+int FilterModel::columnCount(const QModelIndex& /*parent*/) const
 {
-    if(role != Qt::TextAlignmentRole && role != Qt::DisplayRole) {
-        return {};
-    }
-
-    if(orientation == Qt::Orientation::Vertical) {
-        return {};
-    }
-
-    if(role == Qt::TextAlignmentRole) {
-        return (Qt::AlignHCenter);
-    }
-
-    return p->field.name;
-}
-
-QHash<int, QByteArray> FilterModel::roleNames() const
-{
-    auto roles = QAbstractItemModel::roleNames();
-
-    roles.insert(+FilterItem::Title, "Title");
-    roles.insert(+FilterItem::Sorting, "Sorting");
-
-    return roles;
+    return static_cast<int>(p->columns.size());
 }
 
 QStringList FilterModel::mimeTypes() const
@@ -302,8 +296,10 @@ void FilterModel::addTracks(const TrackList& tracks)
 
     p->populatorThread.start();
 
-    QMetaObject::invokeMethod(
-        &p->populator, [this, tracksToAdd] { p->populator.run(p->field.field, p->field.sortField, tracksToAdd); });
+    QStringList columns;
+    std::ranges::transform(p->columns, std::back_inserter(columns), [](const auto& column) { return column.field; });
+
+    QMetaObject::invokeMethod(&p->populator, [this, columns, tracksToAdd] { p->populator.run(columns, tracksToAdd); });
 }
 
 void FilterModel::updateTracks(const TrackList& tracks)
@@ -337,12 +333,12 @@ void FilterModel::removeTracks(const TrackList& tracks)
             parent->removeChild(row);
             parent->resetChildren();
             endRemoveRows();
-            p->nodes.erase(item->title());
+            p->nodes.erase(item->key());
         }
     }
 }
 
-void FilterModel::reset(const FilterField& field, const TrackList& tracks)
+void FilterModel::reset(const FilterColumnList& columns, const TrackList& tracks)
 {
     if(p->populatorThread.isRunning()) {
         p->populator.stopThread();
@@ -351,11 +347,13 @@ void FilterModel::reset(const FilterField& field, const TrackList& tracks)
         p->populatorThread.start();
     }
 
-    p->field = field;
+    p->columns = columns;
 
     p->resetting = true;
 
-    QMetaObject::invokeMethod(&p->populator,
-                              [this, tracks] { p->populator.run(p->field.field, p->field.sortField, tracks); });
+    QStringList fields;
+    std::ranges::transform(p->columns, std::back_inserter(fields), [](const auto& column) { return column.field; });
+
+    QMetaObject::invokeMethod(&p->populator, [this, fields, tracks] { p->populator.run(fields, tracks); });
 }
 } // namespace Fooyin::Filters

--- a/src/plugins/filters/filtermodel.h
+++ b/src/plugins/filters/filtermodel.h
@@ -19,30 +19,30 @@
 
 #pragma once
 
+#include "filterfwd.h"
 #include "filteritem.h"
 
-#include <core/trackfwd.h>
-#include <utils/tablemodel.h>
+#include <utils/treemodel.h>
 
 namespace Fooyin::Filters {
 struct FilterOptions;
-struct FilterField;
 
-class FilterModel : public TableModel<FilterItem>
+class FilterModel : public TreeModel<FilterItem>
 {
 public:
-    explicit FilterModel(const FilterField& field, QObject* parent = nullptr);
+    explicit FilterModel(QObject* parent = nullptr);
     ~FilterModel() override;
 
+    [[nodiscard]] int sortColumn() const;
     [[nodiscard]] Qt::SortOrder sortOrder() const;
 
-    void setSortOrder(Qt::SortOrder order);
+    void sortOnColumn(int column, Qt::SortOrder order);
     void setAppearance(const FilterOptions& options);
 
     [[nodiscard]] Qt::ItemFlags flags(const QModelIndex& index) const override;
-    [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
     [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
-    [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
+    [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
+    [[nodiscard]] int columnCount(const QModelIndex& parent) const override;
 
     [[nodiscard]] QStringList mimeTypes() const override;
     [[nodiscard]] Qt::DropActions supportedDragActions() const override;
@@ -54,8 +54,8 @@ public:
     void addTracks(const TrackList& tracks);
     void updateTracks(const TrackList& tracks);
     void removeTracks(const TrackList& tracks);
-
-    void reset(const FilterField& field, const TrackList& tracks);
+    
+    void reset(const FilterColumnList& columns, const TrackList& tracks);
 
 private:
     struct Private;

--- a/src/plugins/filters/filterpopulator.h
+++ b/src/plugins/filters/filterpopulator.h
@@ -48,7 +48,7 @@ public:
     FilterPopulator(QObject* parent = nullptr);
     ~FilterPopulator() override;
 
-    void run(const QString& field, const QString& sort, const TrackList& tracks);
+    void run(const QStringList& columns, const TrackList& tracks);
 
 signals:
     void populated(PendingTreeData data);

--- a/src/plugins/filters/filtersplugin.cpp
+++ b/src/plugins/filters/filtersplugin.cpp
@@ -21,8 +21,8 @@
 
 #include "filtermanager.h"
 #include "filterwidget.h"
+#include "settings/filterscolumnpage.h"
 #include "settings/filtersettings.h"
-#include "settings/filtersfieldspage.h"
 #include "settings/filtersgeneralpage.h"
 
 #include <gui/layoutprovider.h>
@@ -47,23 +47,22 @@ struct FiltersPlugin::Private
     std::unique_ptr<FiltersSettings> filterSettings;
 
     std::unique_ptr<FiltersGeneralPage> generalPage;
-    std::unique_ptr<FiltersFieldsPage> fieldsPage;
+    std::unique_ptr<FiltersColumnPage> columnsPage;
 
     void registerLayouts() const
     {
         layoutProvider->registerLayout(R"({"Obsidian":[{"SplitterVertical":{"Children":["StatusBar","SearchBar",{
-            "SplitterHorizontal":{"Children":[{"LibraryFilter":{"Sort":"AscendingOrder","Type":"Album Artist"}},
-            {"LibraryFilter":{"Sort":"AscendingOrder","Type":"Album"}},"Playlist",{
+            "SplitterHorizontal":{"Children":[{"LibraryFilter":{"Columns":"1","Sort":"0|0"}},
+            {"LibraryFilter":{"Columns":"3","Sort":"0|0"}},"Playlist",{
             "SplitterVertical":{"Children":["ArtworkPanel","SelectionInfo"],
             "State":"AAAA/wAAAAEAAAACAAABcgAAAg4A/////wEAAAACAA=="}}],
             "State":"AAAA/wAAAAEAAAAEAAAA+wAAAVoAAAN6AAABcwD/////AQAAAAEA"}},"ControlBar"],
             "State":"AAAA/wAAAAEAAAAEAAAAGQAAABwAAAOEAAAAFAD/////AQAAAAIA"}}]})");
 
         layoutProvider->registerLayout(
-            R"({"Ember":[{"SplitterVertical":{"Children":[{"SplitterHorizontal":{"Children":[{"LibraryFilter":{"Type":"Genre","Sort":"AscendingOrder"}},
-            {"LibraryFilter":{"Type":"Album
-            Artist","Sort":"AscendingOrder"}},{"LibraryFilter":{"Type":"Artist","Sort":"AscendingOrder"}},
-            {"LibraryFilter":{"Type":"Album","Sort":"AscendingOrder"}}],"State":"AAAA/wAAAAEAAAAFAAABAAAAAQAAAAEAAAABAAAAAQAA/////wEAAAABAA=="}},
+            R"({"Ember":[{"SplitterVertical":{"Children":[{"SplitterHorizontal":{"Children":[{"LibraryFilter":{"Columns":"0","Sort":"0|0"}},
+            {"LibraryFilter":{"Columns":"1","Sort":"0|0"}},{"LibraryFilter":{"Columns":"2","Sort":"0|0"}},
+            {"LibraryFilter":{"Columns":"3","Sort":"0|0"}}],"State":"AAAA/wAAAAEAAAAFAAABAAAAAQAAAAEAAAABAAAAAQAA/////wEAAAABAA=="}},
             {"SplitterHorizontal":{"Children":["ControlBar","SearchBar"],"State":"AAAA/wAAAAEAAAADAAAFfgAAAdIAAAC1AP////8BAAAAAQA="}},
             {"SplitterHorizontal":{"Children":[{"SplitterVertical":{"Children":["ArtworkPanel","SelectionInfo"],
             "State":"AAAA/wAAAAEAAAADAAABzAAAAbcAAAAUAP////8BAAAAAgA="}},"Playlist"],"State":"AAAA/wAAAAEAAAADAAABdQAABdsAAAC1AP////8BAAAAAQA="}},
@@ -103,8 +102,8 @@ void FiltersPlugin::initialise(const GuiPluginContext& context)
         QStringLiteral("LibraryFilter"), [this]() { return p->filterManager->createFilter(); }, "Library Filter");
 
     p->generalPage = std::make_unique<FiltersGeneralPage>(p->settings);
-    p->fieldsPage
-        = std::make_unique<FiltersFieldsPage>(p->actionManager, p->filterManager->fieldRegistry(), p->settings);
+    p->columnsPage
+        = std::make_unique<FiltersColumnPage>(p->actionManager, p->filterManager->columnRegistry(), p->settings);
 
     p->registerLayouts();
 }

--- a/src/plugins/filters/filterstore.cpp
+++ b/src/plugins/filters/filterstore.cpp
@@ -35,10 +35,10 @@ LibraryFilter FilterStore::filterByIndex(int index) const
     return {};
 }
 
-LibraryFilter FilterStore::addFilter(const FilterField& field)
+LibraryFilter FilterStore::addFilter(const FilterColumnList& columns)
 {
     LibraryFilter& filter = m_filters.emplace_back();
-    filter.field          = field;
+    filter.columns        = columns;
     filter.index          = static_cast<int>(m_filters.size() - 1);
     return filter;
 }

--- a/src/plugins/filters/filterstore.h
+++ b/src/plugins/filters/filterstore.h
@@ -30,8 +30,8 @@ public:
     [[nodiscard]] FilterList filters() const;
 
     LibraryFilter filterByIndex(int index) const;
-
-    LibraryFilter addFilter(const FilterField& field);
+    
+    LibraryFilter addFilter(const FilterColumnList& columns);
     void updateFilter(const LibraryFilter& filter);
     void removeFilter(int index);
 

--- a/src/plugins/filters/filterview.cpp
+++ b/src/plugins/filters/filterview.cpp
@@ -19,11 +19,9 @@
 
 #include "filterview.h"
 
-#include <QActionGroup>
 #include <QHeaderView>
 #include <QMenu>
 #include <QMouseEvent>
-#include <QScrollBar>
 
 namespace Fooyin::Filters {
 FilterView::FilterView(QWidget* parent)
@@ -47,6 +45,7 @@ FilterView::FilterView(QWidget* parent)
     setSortingEnabled(false);
     setUniformRowHeights(true);
 
+    header()->setSortIndicatorShown(true);
     header()->setSectionsClickable(true);
     header()->setContextMenuPolicy(Qt::CustomContextMenu);
 }

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -242,11 +242,9 @@ void FilterWidget::loadLayout(const QJsonObject& object)
 {
     const QStringList sort = object["Sort"_L1].toString().split("|");
 
-    int column{0};
-    Qt::SortOrder order{Qt::AscendingOrder};
-
     if(!sort.empty()) {
-        column = sort.at(0).toInt();
+        int column = sort.at(0).toInt();
+        Qt::SortOrder order{Qt::AscendingOrder};
         if(sort.size() > 1) {
             order = static_cast<Qt::SortOrder>(sort.at(1).toInt());
         }

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -250,6 +250,7 @@ void FilterWidget::loadLayout(const QJsonObject& object)
             order = static_cast<Qt::SortOrder>(sort.at(1).toInt());
         }
         p->model->sortOnColumn(column, order);
+        p->view->header()->setSortIndicator(column, order);
     }
 
     const QString columnNames = object["Columns"_L1].toString();

--- a/src/plugins/filters/filterwidget.h
+++ b/src/plugins/filters/filterwidget.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include "filterfwd.h"
+
 #include <core/trackfwd.h>
 #include <gui/fywidget.h>
 
@@ -58,7 +60,7 @@ signals:
 
     void selectionChanged(const LibraryFilter& filter, const QString& playlistName);
     void filterDeleted(const LibraryFilter& filter);
-    void requestFieldChange(const LibraryFilter& filter, const QString& field);
+    void requestColumnsChange(const LibraryFilter& filter, const ColumnIds& columns);
     void requestHeaderMenu(const LibraryFilter& filter, QPoint pos);
     void requestContextMenu(const LibraryFilter& filter, QPoint pos);
 

--- a/src/plugins/filters/settings/filterscolumnmodel.h
+++ b/src/plugins/filters/settings/filterscolumnmodel.h
@@ -24,16 +24,16 @@
 #include <utils/treestatusitem.h>
 
 namespace Fooyin::Filters {
-class FieldRegistry;
+class FilterColumnRegistry;
 class FieldItem;
 
-class FieldModel : public ExtendableTableModel
+class FiltersColumnModel : public ExtendableTableModel
 {
     Q_OBJECT
 
 public:
-    explicit FieldModel(FieldRegistry* fieldsRegistry, QObject* parent = nullptr);
-    ~FieldModel() override;
+    explicit FiltersColumnModel(FilterColumnRegistry* columnsRegistry, QObject* parent = nullptr);
+    ~FiltersColumnModel() override;
 
     void populate();
     void processQueue();

--- a/src/plugins/filters/settings/filterscolumnpage.cpp
+++ b/src/plugins/filters/settings/filterscolumnpage.cpp
@@ -17,11 +17,11 @@
  *
  */
 
-#include "filtersfieldspage.h"
+#include "filterscolumnpage.h"
 
 #include "constants.h"
-#include "fieldmodel.h"
-#include "fieldregistry.h"
+#include "filtercolumnregistry.h"
+#include "filterscolumnmodel.h"
 #include "filtersettings.h"
 
 #include <utils/extendabletableview.h>
@@ -33,10 +33,10 @@
 #include <QVBoxLayout>
 
 namespace Fooyin::Filters {
-class FiltersFieldsPageWidget : public SettingsPageWidget
+class FiltersColumnPageWidget : public SettingsPageWidget
 {
 public:
-    explicit FiltersFieldsPageWidget(ActionManager* actionManager, FieldRegistry* fieldsRegistry,
+    explicit FiltersColumnPageWidget(ActionManager* actionManager, FilterColumnRegistry* columnsRegistry,
                                      SettingsManager* settings);
 
     void apply() override;
@@ -44,59 +44,59 @@ public:
 
 private:
     ActionManager* m_actionManager;
-    FieldRegistry* m_fieldsRegistry;
+    FilterColumnRegistry* m_columnsRegistry;
     SettingsManager* m_settings;
 
-    ExtendableTableView* m_fieldList;
-    FieldModel* m_model;
+    ExtendableTableView* m_columnList;
+    FiltersColumnModel* m_model;
 };
 
-FiltersFieldsPageWidget::FiltersFieldsPageWidget(ActionManager* actionManager, FieldRegistry* fieldsRegistry,
+FiltersColumnPageWidget::FiltersColumnPageWidget(ActionManager* actionManager, FilterColumnRegistry* columnsRegistry,
                                                  SettingsManager* settings)
     : m_actionManager{actionManager}
-    , m_fieldsRegistry{fieldsRegistry}
+    , m_columnsRegistry{columnsRegistry}
     , m_settings{settings}
-    , m_fieldList{new ExtendableTableView(m_actionManager, this)}
-    , m_model{new FieldModel(m_fieldsRegistry, this)}
+    , m_columnList{new ExtendableTableView(m_actionManager, this)}
+    , m_model{new FiltersColumnModel(m_columnsRegistry, this)}
 {
-    m_fieldList->setExtendableModel(m_model);
+    m_columnList->setExtendableModel(m_model);
 
     // Hide index column
-    m_fieldList->hideColumn(0);
+    m_columnList->hideColumn(0);
 
-    m_fieldList->setExtendableColumn(1);
-    m_fieldList->verticalHeader()->hide();
-    m_fieldList->horizontalHeader()->setStretchLastSection(true);
-    m_fieldList->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
-    m_fieldList->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_columnList->setExtendableColumn(1);
+    m_columnList->verticalHeader()->hide();
+    m_columnList->horizontalHeader()->setStretchLastSection(true);
+    m_columnList->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    m_columnList->setSelectionBehavior(QAbstractItemView::SelectRows);
 
     auto* mainLayout = new QVBoxLayout(this);
-    mainLayout->addWidget(m_fieldList);
+    mainLayout->addWidget(m_columnList);
 
     m_model->populate();
 }
 
-void FiltersFieldsPageWidget::apply()
+void FiltersColumnPageWidget::apply()
 {
     m_model->processQueue();
 }
 
-void FiltersFieldsPageWidget::reset()
+void FiltersColumnPageWidget::reset()
 {
-    m_settings->reset<Settings::Filters::FilterFields>();
-    m_fieldsRegistry->loadItems();
+    m_settings->reset<Settings::Filters::FilterColumns>();
+    m_columnsRegistry->loadItems();
     m_model->populate();
 }
 
-FiltersFieldsPage::FiltersFieldsPage(ActionManager* actionManager, FieldRegistry* fieldsRegistry,
+FiltersColumnPage::FiltersColumnPage(ActionManager* actionManager, FilterColumnRegistry* columnsRegistry,
                                      SettingsManager* settings)
     : SettingsPage{settings->settingsDialog()}
 {
     setId(Constants::Page::FiltersFields);
-    setName(tr("Fields"));
+    setName(tr("Columns"));
     setCategory({tr("Plugins"), tr("Filters")});
-    setWidgetCreator([actionManager, fieldsRegistry, settings] {
-        return new FiltersFieldsPageWidget(actionManager, fieldsRegistry, settings);
+    setWidgetCreator([actionManager, columnsRegistry, settings] {
+        return new FiltersColumnPageWidget(actionManager, columnsRegistry, settings);
     });
 }
 } // namespace Fooyin::Filters

--- a/src/plugins/filters/settings/filterscolumnpage.h
+++ b/src/plugins/filters/settings/filterscolumnpage.h
@@ -19,26 +19,19 @@
 
 #pragma once
 
-#include "filterfwd.h"
-#include "settings/filtersettings.h"
-
-#include <utils/itemregistry.h>
+#include <utils/settings/settingspage.h>
 
 namespace Fooyin {
+class ActionManager;
 class SettingsManager;
 
 namespace Filters {
-class FieldRegistry : public ItemRegistry<FilterField, Settings::Filters::FilterFields>
+class FilterColumnRegistry;
+
+class FiltersColumnPage : public SettingsPage
 {
-    Q_OBJECT
-
 public:
-    explicit FieldRegistry(SettingsManager* settings, QObject* parent = nullptr);
-
-    void loadItems() override;
-
-signals:
-    void fieldChanged(const FilterField& field);
+    explicit FiltersColumnPage(ActionManager* actionManager, FilterColumnRegistry* columnsRegistry, SettingsManager* settings);
 };
 } // namespace Filters
 } // namespace Fooyin

--- a/src/plugins/filters/settings/filtersettings.cpp
+++ b/src/plugins/filters/settings/filtersettings.cpp
@@ -32,7 +32,7 @@ FiltersSettings::FiltersSettings(SettingsManager* settingsManager)
     m_settings->createSetting<Settings::Filters::FilterAltColours>(false, u"Filters"_s);
     m_settings->createSetting<Settings::Filters::FilterHeader>(true, u"Filters"_s);
     m_settings->createSetting<Settings::Filters::FilterScrollBar>(true, u"Filters"_s);
-    m_settings->createSetting<Settings::Filters::FilterFields>(QByteArray{}, u"Filters"_s);
+    m_settings->createSetting<Settings::Filters::FilterColumns>(QByteArray{}, u"Filters"_s);
     m_settings->createSetting<Settings::Filters::FilterAppearance>(QVariant::fromValue(FilterOptions{}), u"Filters"_s);
     m_settings->createSetting<Settings::Filters::FilterDoubleClick>(1, u"Filters"_s);
     m_settings->createSetting<Settings::Filters::FilterMiddleClick>(0, u"Filters"_s);

--- a/src/plugins/filters/settings/filtersettings.h
+++ b/src/plugins/filters/settings/filtersettings.h
@@ -33,7 +33,7 @@ enum Settings : uint32_t
     FilterAltColours      = 1 | SettingsType::Bool,
     FilterHeader          = 2 | SettingsType::Bool,
     FilterScrollBar       = 3 | SettingsType::Bool,
-    FilterFields          = 4 | SettingsType::ByteArray,
+    FilterColumns         = 4 | SettingsType::ByteArray,
     FilterAppearance      = 5 | SettingsType::Variant,
     FilterDoubleClick     = 6 | SettingsType::Int,
     FilterMiddleClick     = 7 | SettingsType::Int,


### PR DESCRIPTION
Adds support for creating multi-column filters. The sort field associated with each field previously has been removed as the relevant column can be used to sort the filter.