### PR TITLE
Persist FyWidget ids

### DIFF
--- a/include/gui/fywidget.h
+++ b/include/gui/fywidget.h
@@ -41,9 +41,12 @@ public:
 
     [[nodiscard]] FyWidget* findParent() const;
 
+    void saveLayout(QJsonArray& layout);
+    void loadLayout(const QJsonObject& layout);
+
     virtual void layoutEditingMenu(ActionContainer* menu);
-    virtual void saveLayout(QJsonArray& array);
-    virtual void loadLayout(const QJsonObject& object);
+    virtual void saveLayoutData(QJsonObject& layout);
+    virtual void loadLayoutData(const QJsonObject& layout);
 
 private:
     Id m_id;

--- a/include/gui/splitterwidget.h
+++ b/include/gui/splitterwidget.h
@@ -55,8 +55,8 @@ public:
     [[nodiscard]] QString name() const override;
     [[nodiscard]] QString layoutName() const override;
     void layoutEditingMenu(ActionContainer* menu) override;
-    void saveLayout(QJsonArray& array) override;
-    void loadLayout(const QJsonObject& object) override;
+    void saveLayoutData(QJsonObject& layout) override;
+    void loadLayoutData(const QJsonObject& layout) override;
 
 private:
     struct Private;

--- a/include/utils/crypto.h
+++ b/include/utils/crypto.h
@@ -36,4 +36,5 @@ QString generateHash(const Args&... args)
 }
 
 FYUTILS_EXPORT QString generateRandomHash();
+FYUTILS_EXPORT QString generateUniqueHash();
 } // namespace Fooyin::Utils

--- a/src/gui/fywidget.cpp
+++ b/src/gui/fywidget.cpp
@@ -22,6 +22,7 @@
 #include <utils/crypto.h>
 
 #include <QJsonArray>
+#include <QJsonObject>
 
 using namespace Qt::Literals::StringLiterals;
 

--- a/src/gui/fywidget.cpp
+++ b/src/gui/fywidget.cpp
@@ -19,16 +19,17 @@
 
 #include <gui/fywidget.h>
 
+#include <utils/crypto.h>
+
 #include <QJsonArray>
+
+using namespace Qt::Literals::StringLiterals;
 
 namespace Fooyin {
 FyWidget::FyWidget(QWidget* parent)
     : QWidget{parent}
-    , m_id{"FyWidget."}
-{
-    static int id{0};
-    m_id.append(id++);
-}
+    , m_id{Utils::generateUniqueHash()}
+{ }
 
 Id FyWidget::id() const
 {
@@ -49,14 +50,33 @@ FyWidget* FyWidget::findParent() const
     return qobject_cast<FyWidget*>(parent);
 }
 
-void FyWidget::layoutEditingMenu(ActionContainer* /*menu*/) { }
-
-void FyWidget::saveLayout(QJsonArray& array)
+void FyWidget::saveLayout(QJsonArray& layout)
 {
-    array.append(layoutName());
+    QJsonObject widgetData;
+    widgetData["ID"_L1] = m_id.name();
+
+    saveLayoutData(widgetData);
+
+    QJsonObject widgetObject;
+    widgetObject[layoutName()] = widgetData;
+
+    layout.append(widgetObject);
 }
 
-void FyWidget::loadLayout(const QJsonObject& /*object*/) { }
+void FyWidget::loadLayout(const QJsonObject& layout)
+{
+    if(layout.contains("ID"_L1)) {
+        m_id = Id{layout["ID"_L1].toString()};
+    }
+
+    loadLayoutData(layout);
+}
+
+void FyWidget::layoutEditingMenu(ActionContainer* /*menu*/) { }
+
+void FyWidget::saveLayoutData(QJsonObject& /*object*/) { }
+
+void FyWidget::loadLayoutData(const QJsonObject& /*object*/) { }
 } // namespace Fooyin
 
 #include "gui/moc_fywidget.cpp"

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -179,23 +179,22 @@ struct GuiApplication::Private
 
     void registerLayouts()
     {
-        layoutProvider.registerLayout(
-            R"({"Empty":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAABAAACLwD/////AQAAAAIA"}}]})");
+        layoutProvider.registerLayout(R"({"Empty": [{}]})");
 
         layoutProvider.registerLayout(
-            R"({"Simple":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAAEAAAAGQAAA94AAAAUAAAAAAD/////AQAAAAIA",
-            "Widgets":["StatusBar","Playlist","ControlBar"]}}]})");
+            R"({"Simple":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAADAAAAGQAAA6kAAAAUAP////8BAAAAAgA=",
+            "Widgets":[{"StatusBar":{}},{"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAACAAABYAAABeoA/////wEAAAABAA==",
+            "Widgets":[{"LibraryTree":{"Grouping":"Artist/Album","ID":"8c3bf224ae774bd780cc2ff3ad638081"}},
+            {"SplitterVertical":{"State":"AAAA/wAAAAEAAAABAAAAGwD/////AQAAAAIA",
+            "Widgets":[{"PlaylistTabs":{"Widgets":[{"Playlist":{"ID":"39b31f941a964e2894f6774f204140e3"}}]}}]}}]}},
+            {"ControlBar":{}}]}}]})");
 
         layoutProvider.registerLayout(
-            R"({"Stone":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAAEAAAAGQAAAB4AAAO8AAAAFAD/////AQAAAAIA",
-            "Widgets":["StatusBar","SearchBar",{"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAACAAABQgAABggA/////wEAAAABAA==",
-            "Widgets":[{"LibraryTree":{"Grouping":"Artist/Album"}},{"PlaylistTabs":{"Widgets":["Playlist"]}}]}},"ControlBar"]}}]})");
-
-        layoutProvider.registerLayout(
-            R"({"Vision":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAAEAAAAGQAAAB4AAAPUAAAAFAD/////AQAAAAIA",
-            "Widgets":["StatusBar",{"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAADAAAD1wAAA3kAAAAAAP////8BAAAAAQA=",
-            "Widgets":["ControlBar","SearchBar"]}},{"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAADAAAD2AAAA3gAAAAAAP////8BAAAAAQA=",
-            "Widgets":["ArtworkPanel","Playlist"]}}]}}]})");
+            R"({"Vision":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAADAAAAFAAAA6kAAAAZAP////8BAAAAAgA=",
+            "Widgets":[{"ControlBar":{}},{"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAACAAADwgAAA4gA/////wEAAAABAA==",
+            "Widgets":[{"TabStack":{"Position":"West","State":"Artwork\u001fInfo\u001fLibrary Tree\u001fPlaylist Organiser",
+            "Widgets":[{"ArtworkPanel":{}},{"SelectionInfo":{}},{"LibraryTree":{"Grouping":"Artist/Album"}},{"PlaylistOrganiser":{}}]}},
+            {"SplitterVertical":{"State":"AAAA/wAAAAEAAAABAAAAwAD/////AQAAAAIA","Widgets":[{"Playlist":{}}]}}]}},{"StatusBar":{}}]}}]})");
     }
 
     void registerWidgets()

--- a/src/gui/librarytree/librarytreewidget.cpp
+++ b/src/gui/librarytree/librarytreewidget.cpp
@@ -309,19 +309,14 @@ QString LibraryTreeWidget::layoutName() const
     return u"LibraryTree"_s;
 }
 
-void LibraryTreeWidget::saveLayout(QJsonArray& array)
+void LibraryTreeWidget::saveLayoutData(QJsonObject& layout)
 {
-    QJsonObject options;
-    options["Grouping"_L1] = p->grouping.name;
-
-    QJsonObject tree;
-    tree[layoutName()] = options;
-    array.append(tree);
+    layout["Grouping"_L1] = p->grouping.name;
 }
 
-void LibraryTreeWidget::loadLayout(const QJsonObject& object)
+void LibraryTreeWidget::loadLayoutData(const QJsonObject& layout)
 {
-    const LibraryTreeGrouping grouping = p->groupsRegistry->itemByName(object["Grouping"_L1].toString());
+    const LibraryTreeGrouping grouping = p->groupsRegistry->itemByName(layout["Grouping"_L1].toString());
     if(grouping.isValid()) {
         p->changeGrouping(grouping);
     }

--- a/src/gui/librarytree/librarytreewidget.h
+++ b/src/gui/librarytree/librarytreewidget.h
@@ -39,8 +39,8 @@ public:
     QString name() const override;
     QString layoutName() const override;
 
-    void saveLayout(QJsonArray& array) override;
-    void loadLayout(const QJsonObject& object) override;
+    void saveLayoutData(QJsonObject& layout) override;
+    void loadLayoutData(const QJsonObject& layout) override;
 
 protected:
     void contextMenuEvent(QContextMenuEvent* event) override;

--- a/src/gui/playlist/playlisttabs.cpp
+++ b/src/gui/playlist/playlisttabs.cpp
@@ -325,27 +325,21 @@ void PlaylistTabs::layoutEditingMenu(ActionContainer* menu)
     menu->addMenu(addMenu);
 }
 
-void PlaylistTabs::saveLayout(QJsonArray& array)
+void PlaylistTabs::saveLayoutData(QJsonObject& layout)
 {
     if(!p->tabsWidget) {
-        FyWidget::saveLayout(array);
         return;
     }
 
     QJsonArray children;
     p->tabsWidget->saveLayout(children);
 
-    QJsonObject options;
-    options["Widgets"_L1] = children;
-
-    QJsonObject tabsObject;
-    tabsObject[layoutName()] = options;
-    array.append(tabsObject);
+    layout["Widgets"_L1] = children;
 }
 
-void PlaylistTabs::loadLayout(const QJsonObject& object)
+void PlaylistTabs::loadLayoutData(const QJsonObject& layout)
 {
-    const auto children = object["Widgets"_L1].toArray();
+    const auto children = layout["Widgets"_L1].toArray();
 
     WidgetContainer::loadWidgets(children);
 }

--- a/src/gui/playlist/playlisttabs.h
+++ b/src/gui/playlist/playlisttabs.h
@@ -45,8 +45,8 @@ public:
     [[nodiscard]] QString name() const override;
     [[nodiscard]] QString layoutName() const override;
     void layoutEditingMenu(ActionContainer* menu) override;
-    void saveLayout(QJsonArray& array) override;
-    void loadLayout(const QJsonObject& object) override;
+    void saveLayoutData(QJsonObject& layout) override;
+    void loadLayoutData(const QJsonObject& layout) override;
 
     void addWidget(FyWidget* widget) override;
     void removeWidget(FyWidget* widget) override;

--- a/src/gui/widgets/splitterwidget.cpp
+++ b/src/gui/widgets/splitterwidget.cpp
@@ -296,27 +296,23 @@ void SplitterWidget::layoutEditingMenu(ActionContainer* menu)
     menu->addMenu(addMenu);
 }
 
-void SplitterWidget::saveLayout(QJsonArray& array)
+void SplitterWidget::saveLayoutData(QJsonObject& layout)
 {
-    QJsonArray children;
-    for(const auto& widget : p->children) {
-        widget->saveLayout(children);
+    layout["State"_L1] = QString::fromUtf8(saveState().toBase64());
+
+    if(!p->children.empty()) {
+        QJsonArray children;
+        for(const auto& widget : p->children) {
+            widget->saveLayout(children);
+        }
+        layout["Widgets"_L1] = children;
     }
-    const QString state = QString::fromUtf8(saveState().toBase64());
-
-    QJsonObject options;
-    options["State"_L1]   = state;
-    options["Widgets"_L1] = children;
-
-    QJsonObject splitter;
-    splitter[layoutName()] = options;
-    array.append(splitter);
 }
 
-void SplitterWidget::loadLayout(const QJsonObject& object)
+void SplitterWidget::loadLayoutData(const QJsonObject& layout)
 {
-    const auto state    = QByteArray::fromBase64(object["State"_L1].toString().toUtf8());
-    const auto children = object["Widgets"_L1].toArray();
+    const auto state    = QByteArray::fromBase64(layout["State"_L1].toString().toUtf8());
+    const auto children = layout["Widgets"_L1].toArray();
 
     WidgetContainer::loadWidgets(children);
 

--- a/src/gui/widgets/tabstackwidget.cpp
+++ b/src/gui/widgets/tabstackwidget.cpp
@@ -114,7 +114,7 @@ void TabStackWidget::layoutEditingMenu(ActionContainer* menu)
     menu->addMenu(addMenu);
 }
 
-void TabStackWidget::saveLayout(QJsonArray& array)
+void TabStackWidget::saveLayoutData(QJsonObject& layout)
 {
     QJsonArray widgets;
     for(FyWidget* widget : p->widgets) {
@@ -129,28 +129,22 @@ void TabStackWidget::saveLayout(QJsonArray& array)
         state.append(p->tabs->tabText(i));
     }
 
-    QJsonObject options;
-    options["Position"_L1] = Utils::Enum::toString(p->tabs->tabPosition());
-    options["State"_L1]    = state;
-    options["Widgets"_L1]  = widgets;
-
-    QJsonObject tabStack;
-    tabStack[layoutName()] = options;
-    array.append(tabStack);
+    layout["Position"_L1] = Utils::Enum::toString(p->tabs->tabPosition());
+    layout["State"_L1]    = state;
+    layout["Widgets"_L1]  = widgets;
 }
 
-void TabStackWidget::loadLayout(const QJsonObject& object)
+void TabStackWidget::loadLayoutData(const QJsonObject& layout)
 {
-    const auto position = Utils::Enum::fromString<QTabWidget::TabPosition>(object.value("Position"_L1).toString());
-    if(position) {
-        p->tabs->setTabPosition(*position);
+    if(const auto position = Utils::Enum::fromString<QTabWidget::TabPosition>(layout.value("Position"_L1).toString())) {
+        p->tabs->setTabPosition(position.value());
     }
 
-    const auto widgets = object.value("Widgets"_L1).toArray();
+    const auto widgets = layout.value("Widgets"_L1).toArray();
 
     WidgetContainer::loadWidgets(widgets);
 
-    const auto state         = object.value("State"_L1).toString();
+    const auto state         = layout.value("State"_L1).toString();
     const QStringList titles = state.split(Constants::Separator);
 
     for(int i{0}; const QString& title : titles) {

--- a/src/gui/widgets/tabstackwidget.h
+++ b/src/gui/widgets/tabstackwidget.h
@@ -36,8 +36,8 @@ public:
     [[nodiscard]] QString name() const override;
     [[nodiscard]] QString layoutName() const override;
     void layoutEditingMenu(ActionContainer* menu) override;
-    void saveLayout(QJsonArray& array) override;
-    void loadLayout(const QJsonObject& object) override;
+    void saveLayoutData(QJsonObject& layout) override;
+    void loadLayoutData(const QJsonObject& layout) override;
 
     void addWidget(FyWidget* widget) override;
     void removeWidget(FyWidget* widget) override;

--- a/src/gui/widgets/widgetcontainer.cpp
+++ b/src/gui/widgets/widgetcontainer.cpp
@@ -33,27 +33,20 @@ WidgetContainer::WidgetContainer(WidgetProvider* widgetProvider, QWidget* parent
 void WidgetContainer::loadWidgets(const QJsonArray& widgets)
 {
     for(const auto& widget : widgets) {
-        const QJsonObject jsonObject = widget.toObject();
-
-        if(!jsonObject.isEmpty()) {
-            const auto widgetName = jsonObject.constBegin().key();
-
-            if(auto* childWidget = m_widgetProvider->createWidget(widgetName)) {
-                addWidget(childWidget);
-                const auto childValue = jsonObject.value(widgetName);
-
-                if(childValue.isObject()) {
-                    childWidget->loadLayout(childValue.toObject());
-                }
-
-                else if(childValue.isArray()) {
-                    childWidget->loadLayout(jsonObject);
-                }
-            }
+        if(!widget.isObject()) {
+            continue;
         }
-        else {
-            auto* childWidget = m_widgetProvider->createWidget(widget.toString());
+        const QJsonObject widgetObject = widget.toObject();
+
+        const auto widgetName = widgetObject.constBegin().key();
+
+        if(auto* childWidget = m_widgetProvider->createWidget(widgetName)) {
             addWidget(childWidget);
+            const auto childValue = widgetObject.value(widgetName);
+
+            if(childValue.isObject()) {
+                childWidget->loadLayout(childValue.toObject());
+            }
         }
     }
 }

--- a/src/plugins/filters/filtersplugin.cpp
+++ b/src/plugins/filters/filtersplugin.cpp
@@ -52,24 +52,35 @@ struct FiltersPlugin::Private
     void registerLayouts() const
     {
         layoutProvider->registerLayout(
-            R"({"Obsidian":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAAEAAAAGQAAABkAAAOJAAAAFAD/////AQAAAAIA",
-            "Widgets":["StatusBar","SearchBar",{"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAAEAAAA+wAAAVoAAAN6AAABcwD/////AQAAAAEA",
-            "Widgets":[{"LibraryFilter":{"Columns":"1","State":"AAAAJXjaY2BgYGRgYPjJAKFBgNH+A5QBFWAAADDZAi0="}},
-            {"LibraryFilter":{"Columns":"3","State":"AAAAJXjaY2BgYASiCAYwDQaM9h+gDKgAAwAeGgGN"}},"Playlist",
-            {"SplitterVertical":{"State":"AAAA/wAAAAEAAAACAAABcgAAAg4A/////wEAAAACAA==",
-            "Widgets":["ArtworkPanel","SelectionInfo"]}}]}},"ControlBar"]}}]})");
+            R"({"Obsidian":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAADAAAAGQAAA8EAAAAUAP////8BAAAAAgA=",
+            "Widgets":[{"StatusBar":{}},{"SplitterHorizontal":{
+            "State":"AAAA/wAAAAEAAAADAAAB+AAAA5wAAAGyAP////8BAAAAAQA=","Widgets":[{"SplitterVertical":{
+            "State":"AAAA/wAAAAEAAAACAAAAHQAAA6AA/////wEAAAACAA==","Widgets":[{"SearchBar":{}},
+            {"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAACAAAA5wAAAQ0A/////wEAAAABAA==","Widgets":[
+            {"LibraryFilter":{"Columns":"1","ID":"1c827a58f07a4a939b185d9c0285f936",
+            "State":"AAAAJXjaY2BgYGRgYHjKAKFBgNH+A5QBEwQALoYCGg=="}},{"LibraryFilter":{"Columns":"3",
+            "ID":"09356ff889694ff7941174448bd67b7a","State":"AAAAJXjaY2BgYAQibgYwDQaM9h+gDJggABUZAUE="}}]}}]}},
+            {"PlaylistTabs":{"ID":"63546e1b2731459eb8dc448086c3ac6a","Widgets":[
+            {"Playlist":{"ID":"943e9ac526414587baa7de36937a8b89"}}]}},
+            {"SplitterVertical":{"State":"AAAA/wAAAAEAAAADAAAAHQAAAbEAAAHTAP////8BAAAAAgA=",
+            "Widgets":[{"Spacer":{}},{"ArtworkPanel":{}},{"SelectionInfo":{}}]}}]}},{"ControlBar":{}}]}}]})");
 
         layoutProvider->registerLayout(
-            R"({"Ember":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAAEAAAA+gAAABkAAAKjAAAAGQD/////AQAAAAIA",
+            R"({"Ember":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAAEAAAA3AAAABoAAALMAAAAGQD/////AQAAAAIA",
             "Widgets":[{"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAAEAAABAAAAAQAAAAEAAAABAAD/////AQAAAAEA",
-            "Widgets":[{"LibraryFilter":{"Columns":"0","State":"AAAAJXjaY2BgYGRgYHjIAKFBgNH+A5QBFWAAAC4JAhU="}},
-            {"LibraryFilter":{"Columns":"1","State":"AAAAJXjaY2BgYGRgYHjIAKFBgNH+A5QBFWAAAC4JAhU="}},
-            {"LibraryFilter":{"Columns":"2","State":"AAAAJXjaY2BgYGRgYHjIAKFBgNH+A5QBFWAAAC4JAhU="}},
-            {"LibraryFilter":{"Columns":"3","State":"AAAAJXjaY2BgYGRgYHjIAKFBgNH+A5QBFWAAAC4JAhU="}}]}},
-            {"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAACAAAFfgAAAdIA/////wEAAAABAA==",
-            "Widgets":["ControlBar","SearchBar"]}},{"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAACAAABWgAABfAA/////wEAAAABAA==",
-            "Widgets":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAACAAABzAAAAbcA/////wEAAAACAA==",
-            "Widgets":["ArtworkPanel","SelectionInfo"]}},"Playlist"]}},"StatusBar"]}}]})");
+            "Widgets":[{"LibraryFilter":{"Columns":"0","ID":"955f29805de446d7a9b6195a94bfd817",
+            "State":"AAAAJXjaY2BgYASi8wxgGgwY7T9AGTBBACwRAgU="}},{"LibraryFilter":{"Columns":"1",
+            "ID":"4fee1a754b3e47ff86f4c711fbf0f0eb","State":"AAAAJXjaY2BgYASicwxgGgwY7T9AGTBBACvzAgQ="}},
+            {"LibraryFilter":{"Columns":"2","ID":"3b20c1db282d4bfe9a95c776e6723608",
+            "State":"AAAAJXjaY2BgYASi8wxgGgwY7T9AGTBBACwRAgU="}},{"LibraryFilter":{"Columns":"3",
+            "ID":"34777508a4ae4ec5939620f235e8ec1a","State":"AAAAJXjaY2BgYASicwxgGgwY7T9AGTBBACvzAgQ="}}]}},
+            {"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAACAAAFewAAAc8A/////wEAAAABAA==",
+            "Widgets":[{"ControlBar":{}},{"SearchBar":{"ID":"55a31e58410a45e2a506bf14a30041e4"}}]}},
+            {"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAADAAABdAAABGgAAAFgAP////8BAAAAAQA=",
+            "Widgets":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAACAAABdAAAAU0A/////wEAAAACAA==",
+            "Widgets":[{"ArtworkPanel":{}},{"SelectionInfo":{}}]}},{"Playlist":{
+            "ID":"3eb9c89184844b5a97c2dabb05aac1c0"}},{"PlaylistOrganiser":{
+            "ID":"1a202fbca60f4a838b456663cebd1c67"}}]}},{"StatusBar":{}}]}}]})");
     }
 };
 

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -230,10 +230,8 @@ QString FilterWidget::layoutName() const
     return u"LibraryFilter"_s;
 }
 
-void FilterWidget::saveLayout(QJsonArray& array)
+void FilterWidget::saveLayoutData(QJsonObject& layout)
 {
-    QJsonObject options;
-
     QStringList columns;
     std::ranges::transform(p->filter.columns, std::back_inserter(columns),
                            [](const auto& column) { return QString::number(column.id); });
@@ -241,24 +239,20 @@ void FilterWidget::saveLayout(QJsonArray& array)
     QByteArray state = p->header->saveHeaderState();
     state            = qCompress(state, 9);
 
-    options["Columns"_L1] = columns.join("|"_L1);
-    options["State"_L1]   = QString::fromUtf8(state.toBase64());
-
-    QJsonObject filter;
-    filter[layoutName()] = options;
-    array.append(filter);
+    layout["Columns"_L1] = columns.join("|"_L1);
+    layout["State"_L1]   = QString::fromUtf8(state.toBase64());
 }
 
-void FilterWidget::loadLayout(const QJsonObject& object)
+void FilterWidget::loadLayoutData(const QJsonObject& layout)
 {
-    const QString columnNames = object["Columns"_L1].toString();
+    const QString columnNames = layout["Columns"_L1].toString();
     const QStringList columns = columnNames.split("|"_L1);
     ColumnIds ids;
     std::ranges::transform(columns, std::back_inserter(ids), [](const QString& column) { return column.toInt(); });
 
     emit requestColumnsChange(p->filter, ids);
 
-    auto state = QByteArray::fromBase64(object["State"_L1].toString().toUtf8());
+    auto state = QByteArray::fromBase64(layout["State"_L1].toString().toUtf8());
 
     if(state.isEmpty()) {
         p->header->restoreHeaderState(state);

--- a/src/plugins/filters/filterwidget.h
+++ b/src/plugins/filters/filterwidget.h
@@ -46,8 +46,8 @@ public:
 
     [[nodiscard]] QString name() const override;
     [[nodiscard]] QString layoutName() const override;
-    void saveLayout(QJsonArray& array) override;
-    void loadLayout(const QJsonObject& object) override;
+    void saveLayoutData(QJsonObject& layout) override;
+    void loadLayoutData(const QJsonObject& layout) override;
 
     void tracksAdded(const TrackList& tracks);
     void tracksUpdated(const TrackList& tracks);

--- a/src/utils/crypto.cpp
+++ b/src/utils/crypto.cpp
@@ -36,4 +36,9 @@ QString generateRandomHash()
     QString headerKey = hash.result().toHex();
     return headerKey;
 }
+
+QString generateUniqueHash()
+{
+    return QUuid::createUuid().toString(QUuid::Id128);
+}
 } // namespace Fooyin::Utils


### PR DESCRIPTION
Stores the unique id given to a FyWidget in the layout, and restores it on load. The persistence of ids means widgets in a layout can be uniquely identified by other widgets in the layout.

In order to ensure the id of a widget is always saved, the _saveLayout_ and _loadLayout_ methods of FyWidget are no longer virtual. Instead, widgets should override _saveLayoutData_ and _loadLayoutData_ if they have any extra data they need to persist.

The default layouts provided have also been modified to accommodate these changes.