### PR TITLE
Support connecting to search widgets

### DIFF
--- a/data/icons.qrc
+++ b/data/icons.qrc
@@ -59,5 +59,7 @@
         <file>icons/dark/scalable/actions/script-function.svg</file>
         <file>icons/dark/scalable/actions/script-literal.svg</file>
         <file>icons/dark/scalable/actions/script-variable.svg</file>
+        <file>icons/dark/scalable/actions/preferences-other.svg</file>
+        <file>icons/light/scalable/actions/preferences-other.svg</file>
     </qresource>
 </RCC>

--- a/data/icons/dark/scalable/actions/preferences-other.svg
+++ b/data/icons/dark/scalable/actions/preferences-other.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   fill="currentColor"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg17"
+   sodipodi:docname="layout-editing.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="8.4375"
+     inkscape:cx="14.162963"
+     inkscape:cy="22.281481"
+     inkscape:window-width="1886"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     d="m 24,24 m -1.777644,0 a 1.7776452,1.7776452 0 1 0 3.555288,0 1.7776452,1.7776452 0 1 0 -3.555289,0"
+     id="path2"
+     style="stroke-width:3.55529;stroke:#b3b3b3;stroke-opacity:1" />
+  <path
+     d="m 24,36.443517 m -1.777644,0 a 1.7776452,1.7776452 0 1 0 3.555288,0 1.7776452,1.7776452 0 1 0 -3.555289,0"
+     id="path3"
+     style="stroke-width:3.55529;stroke:#b3b3b3;stroke-opacity:1" />
+  <path
+     d="m 24,11.556484 m -1.777644,0 a 1.7776452,1.7776452 0 1 0 3.555288,0 1.7776452,1.7776452 0 1 0 -3.555289,0"
+     id="path4"
+     style="stroke-width:3.55529;stroke:#b3b3b3;stroke-opacity:1" />
+</svg>

--- a/data/icons/light/scalable/actions/preferences-other.svg
+++ b/data/icons/light/scalable/actions/preferences-other.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48"
+   height="48"
+   fill="currentColor"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg17"
+   sodipodi:docname="layout-editing.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview14"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="8.4375"
+     inkscape:cx="14.162963"
+     inkscape:cy="22.281481"
+     inkscape:window-width="1886"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     d="m 24,24 m -1.777644,0 a 1.7776452,1.7776452 0 1 0 3.555288,0 1.7776452,1.7776452 0 1 0 -3.555289,0"
+     id="path2"
+     style="stroke-width:3.55529;stroke:#464546;stroke-opacity:1" />
+  <path
+     d="m 24,36.443517 m -1.777644,0 a 1.7776452,1.7776452 0 1 0 3.555288,0 1.7776452,1.7776452 0 1 0 -3.555289,0"
+     id="path3"
+     style="stroke-width:3.55529;stroke:#464546;stroke-opacity:1" />
+  <path
+     d="m 24,11.556484 m -1.777644,0 a 1.7776452,1.7776452 0 1 0 3.555288,0 1.7776452,1.7776452 0 1 0 -3.555289,0"
+     id="path4"
+     style="stroke-width:3.55529;stroke:#464546;stroke-opacity:1" />
+</svg>

--- a/include/core/library/trackfilter.h
+++ b/include/core/library/trackfilter.h
@@ -23,6 +23,8 @@
 
 #include <core/trackfwd.h>
 
+class QString;
+
 namespace Fooyin::Filter {
 FYCORE_EXPORT Fooyin::TrackList filterTracks(const Fooyin::TrackList& tracks, const QString& search);
 } // namespace Fooyin::Filter

--- a/include/core/library/trackfilter.h
+++ b/include/core/library/trackfilter.h
@@ -1,0 +1,28 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fycore_export.h"
+
+#include <core/trackfwd.h>
+
+namespace Fooyin::Filter {
+FYCORE_EXPORT Fooyin::TrackList filterTracks(const Fooyin::TrackList& tracks, const QString& search);
+} // namespace Fooyin::Filter

--- a/include/gui/editablelayout.h
+++ b/include/gui/editablelayout.h
@@ -19,20 +19,21 @@
 
 #pragma once
 
+#include "fygui_export.h"
+
 #include <gui/fywidget.h>
 
 #include <QWidget>
 
 namespace Fooyin {
 class ActionManager;
-class ActionContainer;
 class LayoutProvider;
 class SettingsManager;
 class WidgetProvider;
 class Id;
 struct Layout;
 
-class EditableLayout : public QWidget
+class FYGUI_EXPORT EditableLayout : public QWidget
 {
     Q_OBJECT
 
@@ -43,8 +44,8 @@ public:
 
     void initialise();
 
-    FyWidget* findWidget(const Id& id) const;
-    WidgetList findWidgetsByFeatures(const FyWidget::Features& features) const;
+    [[nodiscard]] FyWidget* findWidget(const Id& id) const;
+    [[nodiscard]] WidgetList findWidgetsByFeatures(const FyWidget::Features& features) const;
 
     bool eventFilter(QObject* watched, QEvent* event) override;
 

--- a/include/gui/fywidget.h
+++ b/include/gui/fywidget.h
@@ -33,17 +33,29 @@ class FYGUI_EXPORT FyWidget : public QWidget
     Q_OBJECT
 
 public:
+    enum Feature
+    {
+        None   = 0x0,
+        Search = 0x2,
+    };
+    Q_DECLARE_FLAGS(Features, Feature)
+
     explicit FyWidget(QWidget* parent);
 
     [[nodiscard]] Id id() const;
     [[nodiscard]] virtual QString name() const = 0;
     [[nodiscard]] virtual QString layoutName() const;
 
+    [[nodiscard]] Features features() const;
+    void setFeature(Feature feature, bool on = true);
+
     [[nodiscard]] FyWidget* findParent() const;
     [[nodiscard]] QRect widgetGeometry() const;
 
     void saveLayout(QJsonArray& layout);
     void loadLayout(const QJsonObject& layout);
+
+    virtual void searchEvent(const QString& search);
 
     virtual void layoutEditingMenu(ActionContainer* menu);
     virtual void saveLayoutData(QJsonObject& layout);
@@ -52,5 +64,9 @@ public:
 
 private:
     Id m_id;
+    Features m_features;
 };
+using WidgetList = std::vector<FyWidget*>;
 } // namespace Fooyin
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(Fooyin::FyWidget::Features)

--- a/include/gui/guiconstants.h
+++ b/include/gui/guiconstants.h
@@ -51,6 +51,7 @@ constexpr auto Settings      = "preferences-system";
 constexpr auto RescanLibrary = "view-refresh";
 constexpr auto LayoutEditing = "applications-graphics";
 constexpr auto QuickSetup    = "preferences-desktop";
+constexpr auto Options       = "preferences-other";
 } // namespace Icons
 
 constexpr auto MenuBar = "Fooyin.MenuBar";
@@ -122,8 +123,8 @@ constexpr auto Rename          = "Edit.Rename";
 } // namespace Actions
 
 namespace Mime {
-constexpr auto PlaylistItems         = "application/x-fooyin-playlistitems";
-constexpr auto TrackIds              = "application/x-fooyin-trackIds";
+constexpr auto PlaylistItems = "application/x-fooyin-playlistitems";
+constexpr auto TrackIds      = "application/x-fooyin-trackIds";
 } // namespace Mime
 
 namespace Page {

--- a/include/gui/plugins/guiplugincontext.h
+++ b/include/gui/plugins/guiplugincontext.h
@@ -29,18 +29,21 @@ class PropertiesDialog;
 class GuiSettings;
 class SearchController;
 class WidgetFactory;
+class EditableLayout;
 
 struct FYGUI_EXPORT GuiPluginContext
 {
     GuiPluginContext(ActionManager* actionManager, LayoutProvider* layoutProvider,
                      TrackSelectionController* trackSelection, SearchController* searchController,
-                     PropertiesDialog* propertiesDialog, WidgetFactory* widgetFactory, GuiSettings* guiSettings)
+                     PropertiesDialog* propertiesDialog, WidgetFactory* widgetFactory, EditableLayout* editableLayout,
+                     GuiSettings* guiSettings)
         : actionManager{actionManager}
         , layoutProvider{layoutProvider}
         , trackSelection{trackSelection}
         , searchController{searchController}
         , propertiesDialog{propertiesDialog}
         , widgetFactory{widgetFactory}
+        , editableLayout{editableLayout}
         , guiSettings{guiSettings}
     { }
 
@@ -50,6 +53,7 @@ struct FYGUI_EXPORT GuiPluginContext
     SearchController* searchController;
     PropertiesDialog* propertiesDialog;
     WidgetFactory* widgetFactory;
+    EditableLayout* editableLayout;
     GuiSettings* guiSettings;
 };
 } // namespace Fooyin

--- a/include/gui/searchcontroller.h
+++ b/include/gui/searchcontroller.h
@@ -21,21 +21,31 @@
 
 #include "fygui_export.h"
 
+#include <utils/id.h>
+
 #include <QObject>
 
 namespace Fooyin {
+class FyWidget;
+class EditableLayout;
+
 class FYGUI_EXPORT SearchController : public QObject
 {
     Q_OBJECT
 
 public:
-    [[nodiscard]] QString searchText() const;
-    void changeSearch(const QString& search);
+    explicit SearchController(EditableLayout* editableLayout, QObject* parent = nullptr);
+    ~SearchController() override;
 
-signals:
-    void searchChanged(const QString& search);
+    void setupWidgetConnections(const Id& id);
+    IdSet connectedWidgets(const Id& id);
+    void setConnectedWidgets(const Id& id, const IdSet& widgets);
+    void removeConnectedWidgets(const Id& id);
+
+    void changeSearch(const Id& id, const QString& search);
 
 private:
-    QString m_searchText;
+    struct Private;
+    std::unique_ptr<Private> p;
 };
 } // namespace Fooyin

--- a/include/gui/searchcontroller.h
+++ b/include/gui/searchcontroller.h
@@ -26,7 +26,6 @@
 #include <QObject>
 
 namespace Fooyin {
-class FyWidget;
 class EditableLayout;
 
 class FYGUI_EXPORT SearchController : public QObject

--- a/include/gui/splitterwidget.h
+++ b/include/gui/splitterwidget.h
@@ -52,6 +52,8 @@ public:
     void replaceWidget(FyWidget* oldWidget, FyWidget* newWidget) override;
     void removeWidget(FyWidget* widget) override;
 
+    WidgetList widgets() const override;
+
     [[nodiscard]] QString name() const override;
     [[nodiscard]] QString layoutName() const override;
     void layoutEditingMenu(ActionContainer* menu) override;

--- a/include/gui/widgetcontainer.h
+++ b/include/gui/widgetcontainer.h
@@ -35,6 +35,8 @@ public:
     virtual void removeWidget(FyWidget* widget)                          = 0;
     virtual void replaceWidget(FyWidget* oldWidget, FyWidget* newWidget) = 0;
 
+    virtual WidgetList widgets() const = 0;
+
     void loadWidgets(const QJsonArray& widgets);
 
 private:

--- a/include/gui/widgetfilter.h
+++ b/include/gui/widgetfilter.h
@@ -19,10 +19,12 @@
 
 #pragma once
 
+#include "fygui_export.h"
+
 #include <QObject>
 
 namespace Fooyin {
-class WidgetFilter : public QObject
+class FYGUI_EXPORT WidgetFilter : public QObject
 {
     Q_OBJECT
 
@@ -36,5 +38,9 @@ public:
 
 signals:
     void filterFinished();
+
+private:
+    bool m_active;
+    bool m_overOverlay;
 };
 } // namespace Fooyin

--- a/include/utils/widgets/overlaywidget.h
+++ b/include/utils/widgets/overlaywidget.h
@@ -46,6 +46,8 @@ public:
     void setText(const QString& text);
     void setButtonText(const QString& text);
 
+    void setButtonEnabled(bool enabled);
+
     void setColour(const QColor& colour);
     void resetColour();
 

--- a/include/utils/widgets/overlaywidget.h
+++ b/include/utils/widgets/overlaywidget.h
@@ -27,6 +27,7 @@ class QLabel;
 class QPushButton;
 
 namespace Fooyin {
+
 class FYUTILS_EXPORT OverlayWidget : public QWidget
 {
     Q_OBJECT
@@ -34,34 +35,53 @@ class FYUTILS_EXPORT OverlayWidget : public QWidget
 public:
     enum Option
     {
-        None        = 0x0,
-        Label       = 0x2,
-        Button      = 0x4,
+        None       = 0x0,
+        Label      = 0x1,
+        Button     = 0x2,
+        Resize     = 0x4,
+        Static     = 0x8,
+        Selectable = 0x10,
     };
     Q_DECLARE_FLAGS(Options, Option)
 
     explicit OverlayWidget(QWidget* parent = nullptr);
     explicit OverlayWidget(const Options& options, QWidget* parent = nullptr);
 
-    void setText(const QString& text);
-    void setButtonText(const QString& text);
+    void setOption(Option option, bool on = true);
 
-    void setButtonEnabled(bool enabled);
+    QPushButton* button() const;
+    QLabel* label() const;
 
+    void connectOverlay(OverlayWidget* other);
+    void disconnectOverlay(OverlayWidget* other);
+
+    void addWidget(QWidget* widget);
+
+    QColor colour() const;
     void setColour(const QColor& colour);
     void resetColour();
 
+    void select();
+    void deselect();
+
+    bool event(QEvent* event) override;
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
 signals:
-    void buttonClicked();
+    void clicked();
+    void entered();
+    void left();
 
 protected:
+    void showEvent(QShowEvent* event) override;
+    void enterEvent(QEnterEvent* event) override;
+    void leaveEvent(QEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
     void paintEvent(QPaintEvent* event) override;
 
 private:
-    Options m_options;
-    QColor m_colour;
-    QLabel* m_text;
-    QPushButton* m_button;
+    struct Private;
+    std::unique_ptr<Private> p;
 };
 } // namespace Fooyin
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -65,6 +65,7 @@ set(SOURCES
     library/unifiedmusiclibrary.cpp
     library/librarythreadhandler.cpp
     library/sortingregistry.cpp
+    library/trackfilter.cpp
     library/tracksort.cpp
     playlist/playlist.cpp
     playlist/playlisthandler.cpp

--- a/src/core/library/trackfilter.cpp
+++ b/src/core/library/trackfilter.cpp
@@ -1,0 +1,48 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <core/library/trackfilter.h>
+
+#include <core/track.h>
+#include <utils/helpers.h>
+
+namespace {
+bool containsSearch(const QString& text, const QString& search)
+{
+    return text.contains(search, Qt::CaseInsensitive);
+}
+
+// TODO: Support user-defined tags
+bool matchSearch(const Fooyin::Track& track, const QString& search)
+{
+    if(search.isEmpty()) {
+        return true;
+    }
+
+    return containsSearch(track.artist(), search) || containsSearch(track.title(), search)
+        || containsSearch(track.album(), search) || containsSearch(track.albumArtist(), search);
+}
+} // namespace
+
+namespace Fooyin::Filter {
+TrackList filterTracks(const TrackList& tracks, const QString& search)
+{
+    return Fooyin::Utils::filter(tracks, [search](const Fooyin::Track& track) { return matchSearch(track, search); });
+}
+} // namespace Fooyin::Filter

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SOURCES
     guisettings.cpp
     layoutprovider.cpp
     trackselectioncontroller.cpp
+    widgetfilter.cpp
     controls/controlwidget.cpp
     controls/playercontrol.cpp
     controls/playlistcontrol.cpp
@@ -90,7 +91,6 @@ set(SOURCES
     sandbox/scripthighlighter.cpp
     search/searchcontroller.cpp
     search/searchwidget.cpp
-    search/widgetfilter.cpp
     settings/enginepage.cpp
     settings/generalpage.cpp
     settings/guigeneralpage.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -90,6 +90,7 @@ set(SOURCES
     sandbox/scripthighlighter.cpp
     search/searchcontroller.cpp
     search/searchwidget.cpp
+    search/widgetfilter.cpp
     settings/enginepage.cpp
     settings/generalpage.cpp
     settings/guigeneralpage.cpp

--- a/src/gui/editablelayout.cpp
+++ b/src/gui/editablelayout.cpp
@@ -17,7 +17,7 @@
  *
  */
 
-#include "editablelayout.h"
+#include <gui/editablelayout.h>
 
 #include "quicksetup/quicksetupdialog.h"
 #include "widgets/dummy.h"
@@ -382,4 +382,4 @@ void EditableLayout::showQuickSetup()
 }
 } // namespace Fooyin
 
-#include "moc_editablelayout.cpp"
+#include "gui/moc_editablelayout.cpp"

--- a/src/gui/editablelayout.cpp
+++ b/src/gui/editablelayout.cpp
@@ -30,6 +30,7 @@
 #include <gui/widgetprovider.h>
 #include <utils/actions/actioncontainer.h>
 #include <utils/actions/actionmanager.h>
+#include <utils/id.h>
 #include <utils/menuheader.h>
 #include <utils/settings/settingsmanager.h>
 #include <utils/widgets/overlaywidget.h>
@@ -41,6 +42,8 @@
 #include <QJsonObject>
 #include <QMenu>
 #include <QMouseEvent>
+
+#include <stack>
 
 using namespace Qt::Literals::StringLiterals;
 
@@ -202,6 +205,72 @@ void EditableLayout::initialise()
                                                          [this](bool enabled) { p->changeEditingState(enabled); });
 
     QObject::connect(p->menu->menu(), &QMenu::aboutToHide, this, [this]() { p->hideOverlay(); });
+}
+
+FyWidget* EditableLayout::findWidget(const Id& id) const
+{
+    if(!p->splitter) {
+        return nullptr;
+    }
+
+    std::stack<FyWidget*> widgetsToCheck;
+    widgetsToCheck.push(p->splitter);
+
+    while(!widgetsToCheck.empty()) {
+        auto* current = widgetsToCheck.top();
+        widgetsToCheck.pop();
+
+        if(!current) {
+            continue;
+        }
+
+        if(current->id() == id) {
+            return current;
+        }
+
+        if(const auto* container = qobject_cast<WidgetContainer*>(current)) {
+            const auto containerWidgets = container->widgets();
+            for(FyWidget* containerWidget : containerWidgets) {
+                widgetsToCheck.push(containerWidget);
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+WidgetList EditableLayout::findWidgetsByFeatures(const FyWidget::Features& features) const
+{
+    if(!p->splitter) {
+        return {};
+    }
+
+    std::vector<FyWidget*> widgets;
+
+    std::stack<FyWidget*> widgetsToCheck;
+    widgetsToCheck.push(p->splitter);
+
+    while(!widgetsToCheck.empty()) {
+        auto* current = widgetsToCheck.top();
+        widgetsToCheck.pop();
+
+        if(!current) {
+            continue;
+        }
+
+        if(current->features() & features) {
+            widgets.push_back(current);
+        }
+
+        if(const auto* container = qobject_cast<WidgetContainer*>(current)) {
+            const auto containerWidgets = container->widgets();
+            for(FyWidget* containerWidget : containerWidgets) {
+                widgetsToCheck.push(containerWidget);
+            }
+        }
+    }
+
+    return widgets;
 }
 
 bool EditableLayout::eventFilter(QObject* watched, QEvent* event)

--- a/src/gui/fywidget.cpp
+++ b/src/gui/fywidget.cpp
@@ -42,6 +42,21 @@ QString FyWidget::layoutName() const
     return name();
 }
 
+FyWidget::Features FyWidget::features() const
+{
+    return m_features;
+}
+
+void FyWidget::setFeature(Feature feature, bool on)
+{
+    if(on) {
+        m_features |= feature;
+    }
+    else {
+        m_features &= ~feature;
+    }
+}
+
 FyWidget* FyWidget::findParent() const
 {
     QWidget* parent = parentWidget();
@@ -87,6 +102,8 @@ void FyWidget::loadLayout(const QJsonObject& layout)
 
     loadLayoutData(layout);
 }
+
+void FyWidget::searchEvent(const QString& /*search*/) { }
 
 void FyWidget::layoutEditingMenu(ActionContainer* /*menu*/) { }
 

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -96,7 +96,7 @@ struct GuiApplication::Private
     WidgetContext* mainContext;
     std::unique_ptr<PlaylistController> playlistController;
     TrackSelectionController selectionController;
-    SearchController searchController;
+    SearchController* searchController;
 
     FileMenu* fileMenu;
     EditMenu* editMenu;
@@ -144,6 +144,7 @@ struct GuiApplication::Private
               playlistHandler, playerManager, guiSettings.playlistPresetRegistry(), coreSettings->sortingRegistry(),
               &selectionController, settingsManager)}
         , selectionController{actionManager, settingsManager, playlistController.get()}
+        , searchController{new SearchController(editableLayout.get(), self)}
         , fileMenu{new FileMenu(actionManager, settingsManager, self)}
         , editMenu{new EditMenu(actionManager, settingsManager, self)}
         , viewMenu{new ViewMenu(actionManager, &selectionController, settingsManager, self)}
@@ -164,8 +165,8 @@ struct GuiApplication::Private
         , libraryTreeGuiPage{settingsManager}
         , statusWidgetPage{settingsManager}
         , pluginPage{settingsManager, pluginManager}
-        , guiPluginContext{actionManager,     &layoutProvider,  &selectionController,
-                           &searchController, propertiesDialog, widgetProvider.widgetFactory(),
+        , guiPluginContext{actionManager,    &layoutProvider,  &selectionController,
+                           searchController, propertiesDialog, widgetProvider.widgetFactory(),
                            &guiSettings}
     {
         registerLayouts();
@@ -277,8 +278,7 @@ struct GuiApplication::Private
             u"Status Bar"_s);
 
         factory->registerClass<SearchWidget>(
-            u"SearchBar"_s,
-            [this]() { return new SearchWidget(actionManager, &searchController, settingsManager, mainWindow.get()); },
+            u"SearchBar"_s, [this]() { return new SearchWidget(searchController, settingsManager, mainWindow.get()); },
             u"Search Bar"_s);
     }
 

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -20,7 +20,6 @@
 #include "guiapplication.h"
 
 #include "controls/controlwidget.h"
-#include "editablelayout.h"
 #include "info/infowidget.h"
 #include "library/coverwidget.h"
 #include "library/statuswidget.h"
@@ -59,6 +58,7 @@
 #include <core/library/musiclibrary.h>
 #include <core/plugins/coreplugincontext.h>
 #include <core/plugins/pluginmanager.h>
+#include <gui/editablelayout.h>
 #include <gui/layoutprovider.h>
 #include <gui/plugins/guiplugin.h>
 #include <gui/plugins/guiplugincontext.h>
@@ -165,9 +165,9 @@ struct GuiApplication::Private
         , libraryTreeGuiPage{settingsManager}
         , statusWidgetPage{settingsManager}
         , pluginPage{settingsManager, pluginManager}
-        , guiPluginContext{actionManager,    &layoutProvider,  &selectionController,
-                           searchController, propertiesDialog, widgetProvider.widgetFactory(),
-                           &guiSettings}
+        , guiPluginContext{actionManager,        &layoutProvider,  &selectionController,
+                           searchController,     propertiesDialog, widgetProvider.widgetFactory(),
+                           editableLayout.get(), &guiSettings}
     {
         registerLayouts();
         registerWidgets();

--- a/src/gui/librarytree/librarytreewidget.cpp
+++ b/src/gui/librarytree/librarytreewidget.cpp
@@ -118,7 +118,7 @@ LibraryTreeWidgetPrivate::LibraryTreeWidgetPrivate(LibraryTreeWidget* self, Musi
     , settings{settings}
     , layout{new QVBoxLayout(self)}
     , libraryTree{new LibraryTreeView(self)}
-    , model{new LibraryTreeModel(self)} // , proxyModel{new LibraryTreeProxyModel(self)}
+    , model{new LibraryTreeModel(self)}
     , doubleClickAction{static_cast<TrackAction>(settings->value<Settings::Gui::LibraryTreeDoubleClick>())}
     , middleClickAction{static_cast<TrackAction>(settings->value<Settings::Gui::LibraryTreeMiddleClick>())}
 {

--- a/src/gui/librarytree/librarytreewidget.cpp
+++ b/src/gui/librarytree/librarytreewidget.cpp
@@ -25,6 +25,7 @@
 #include "librarytreeview.h"
 
 #include <core/library/musiclibrary.h>
+#include <core/library/trackfilter.h>
 #include <core/library/tracksort.h>
 #include <gui/guisettings.h>
 #include <gui/trackselectioncontroller.h>
@@ -42,7 +43,7 @@
 
 using namespace Qt::Literals::StringLiterals;
 
-namespace Fooyin {
+namespace {
 void getLowestIndexes(const QTreeView* treeView, const QModelIndex& index, QModelIndexList& bottomIndexes)
 {
     if(!index.isValid()) {
@@ -61,7 +62,9 @@ void getLowestIndexes(const QTreeView* treeView, const QModelIndex& index, QMode
         getLowestIndexes(treeView, childIndex, bottomIndexes);
     }
 }
+} // namespace
 
+namespace Fooyin {
 class LibraryTreeWidgetPrivate
 {
 public:
@@ -79,6 +82,7 @@ public:
     void setupHeaderContextMenu(const QPoint& pos);
 
     QCoro::Task<void> selectionChanged() const;
+    QCoro::Task<void> searchChanged(QString search);
     [[nodiscard]] QString playlistNameFromSelection() const;
 
     void handleDoubleClick() const;
@@ -99,6 +103,9 @@ public:
 
     TrackAction doubleClickAction;
     TrackAction middleClickAction;
+
+    QString prevSearch;
+    TrackList prevSearchTracks;
 };
 
 LibraryTreeWidgetPrivate::LibraryTreeWidgetPrivate(LibraryTreeWidget* self, MusicLibrary* library,
@@ -111,12 +118,13 @@ LibraryTreeWidgetPrivate::LibraryTreeWidgetPrivate(LibraryTreeWidget* self, Musi
     , settings{settings}
     , layout{new QVBoxLayout(self)}
     , libraryTree{new LibraryTreeView(self)}
-    , model{new LibraryTreeModel(self)}
+    , model{new LibraryTreeModel(self)} // , proxyModel{new LibraryTreeProxyModel(self)}
     , doubleClickAction{static_cast<TrackAction>(settings->value<Settings::Gui::LibraryTreeDoubleClick>())}
     , middleClickAction{static_cast<TrackAction>(settings->value<Settings::Gui::LibraryTreeMiddleClick>())}
 {
     layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(libraryTree);
+
     libraryTree->setModel(model);
 
     libraryTree->setExpandsOnDoubleClick(doubleClickAction == TrackAction::Expand);
@@ -223,6 +231,26 @@ QCoro::Task<void> LibraryTreeWidgetPrivate::selectionChanged() const
     co_return;
 }
 
+QCoro::Task<void> LibraryTreeWidgetPrivate::searchChanged(QString search)
+{
+    const bool reset = prevSearch.length() > search.length();
+    prevSearch       = search;
+
+    if(search.isEmpty()) {
+        prevSearchTracks.clear();
+        model->reset(library->tracks());
+        co_return;
+    }
+
+    TrackList tracksToFilter = !reset && !prevSearchTracks.empty() ? prevSearchTracks : library->tracks();
+
+    const auto tracks = co_await Utils::asyncExec(
+        [search, tracksToFilter]() { return Filter::filterTracks(tracksToFilter, search); });
+
+    prevSearchTracks = tracks;
+    model->reset(tracks);
+}
+
 QString LibraryTreeWidgetPrivate::playlistNameFromSelection() const
 {
     QString title;
@@ -258,6 +286,8 @@ LibraryTreeWidget::LibraryTreeWidget(MusicLibrary* library, LibraryTreeGroupRegi
 {
     setObjectName(LibraryTreeWidget::name());
 
+    setFeature(FyWidget::Search);
+
     QObject::connect(p->libraryTree, &LibraryTreeView::doubleClicked, this, [this]() { p->handleDoubleClick(); });
     QObject::connect(p->libraryTree, &LibraryTreeView::middleMouseClicked, this, [this]() { p->handleMiddleClick(); });
     QObject::connect(p->libraryTree->selectionModel(), &QItemSelectionModel::selectionChanged, this,
@@ -271,18 +301,14 @@ LibraryTreeWidget::LibraryTreeWidget(MusicLibrary* library, LibraryTreeGroupRegi
                          }
                      });
 
-    auto treeReset = [this]() {
-        p->reset();
-    };
-
-    QObject::connect(library, &MusicLibrary::tracksLoaded, this, treeReset);
+    QObject::connect(library, &MusicLibrary::tracksLoaded, this, [this]() { p->reset(); });
     QObject::connect(library, &MusicLibrary::tracksAdded, p->model, &LibraryTreeModel::addTracks);
     QObject::connect(library, &MusicLibrary::tracksScanned, p->model, &LibraryTreeModel::addTracks);
     QObject::connect(library, &MusicLibrary::tracksUpdated, p->model, &LibraryTreeModel::updateTracks);
     QObject::connect(library, &MusicLibrary::tracksDeleted, p->model, &LibraryTreeModel::removeTracks);
-    QObject::connect(library, &MusicLibrary::tracksSorted, this, treeReset);
-    QObject::connect(library, &MusicLibrary::libraryRemoved, this, treeReset);
-    QObject::connect(library, &MusicLibrary::libraryChanged, this, treeReset);
+    QObject::connect(library, &MusicLibrary::tracksSorted, this, [this]() { p->reset(); });
+    QObject::connect(library, &MusicLibrary::libraryRemoved, this, [this]() { p->reset(); });
+    QObject::connect(library, &MusicLibrary::libraryChanged, this, [this]() { p->reset(); });
 
     settings->subscribe<Settings::Gui::LibraryTreeDoubleClick>(this, [this](int action) {
         p->doubleClickAction = static_cast<TrackAction>(action);
@@ -320,6 +346,11 @@ void LibraryTreeWidget::loadLayoutData(const QJsonObject& layout)
     if(grouping.isValid()) {
         p->changeGrouping(grouping);
     }
+}
+
+void LibraryTreeWidget::searchEvent(const QString& search)
+{
+    p->searchChanged(search);
 }
 
 void LibraryTreeWidget::contextMenuEvent(QContextMenuEvent* event)

--- a/src/gui/librarytree/librarytreewidget.h
+++ b/src/gui/librarytree/librarytreewidget.h
@@ -42,6 +42,8 @@ public:
     void saveLayoutData(QJsonObject& layout) override;
     void loadLayoutData(const QJsonObject& layout) override;
 
+    void searchEvent(const QString& search) override;
+
 protected:
     void contextMenuEvent(QContextMenuEvent* event) override;
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -19,22 +19,19 @@
 
 #include "mainwindow.h"
 
-#include "editablelayout.h"
 #include "mainmenubar.h"
 
 #include <core/constants.h>
 #include <core/coresettings.h>
+#include <gui/editablelayout.h>
 #include <gui/guiconstants.h>
 #include <gui/guisettings.h>
 #include <utils/actions/actionmanager.h>
-#include <utils/settings/settingsdialogcontroller.h>
 #include <utils/settings/settingsmanager.h>
 
-#include <QActionGroup>
 #include <QContextMenuEvent>
 #include <QMenuBar>
 #include <QSettings>
-#include <QTextEdit>
 #include <QTimer>
 
 constexpr auto MainWindowGeometry = "Interface/Geometry";

--- a/src/gui/playlist/playlisttabs.cpp
+++ b/src/gui/playlist/playlisttabs.cpp
@@ -366,6 +366,15 @@ void PlaylistTabs::replaceWidget(FyWidget* oldWidget, FyWidget* newWidget)
         p->layout->addWidget(p->tabsWidget);
     }
 }
+
+WidgetList PlaylistTabs::widgets() const
+{
+    if(!p->tabsWidget) {
+        return {};
+    }
+
+    return {p->tabsWidget};
+}
 } // namespace Fooyin
 
 #include "moc_playlisttabs.cpp"

--- a/src/gui/playlist/playlisttabs.h
+++ b/src/gui/playlist/playlisttabs.h
@@ -52,6 +52,8 @@ public:
     void removeWidget(FyWidget* widget) override;
     void replaceWidget(FyWidget* oldWidget, FyWidget* newWidget) override;
 
+    WidgetList widgets() const override;
+
 protected:
     void contextMenuEvent(QContextMenuEvent* event) override;
     void dragEnterEvent(QDragEnterEvent* event) override;

--- a/src/gui/search/searchcontroller.cpp
+++ b/src/gui/search/searchcontroller.cpp
@@ -19,16 +19,172 @@
 
 #include <gui/searchcontroller.h>
 
+#include "editablelayout.h"
+#include "search/widgetfilter.h"
+
+#include <gui/fywidget.h>
+#include <utils/widgets/overlaywidget.h>
+
+#include <QCoroCore>
+
+#include <set>
+
+using namespace Qt::Literals::StringLiterals;
+
 namespace Fooyin {
-QString SearchController::searchText() const
+struct SearchController::Private
 {
-    return m_searchText;
+    SearchController* self;
+    EditableLayout* editableLayout;
+
+    WidgetFilter* filter;
+
+    std::unordered_map<Id, OverlayWidget*, Id::IdHash> overlays;
+    QColor connectedColour{Qt::green};
+    QColor disconnectedColour{Qt::red};
+
+    std::unordered_map<Id, FyWidget*, Id::IdHash> searchableWidgets;
+    std::unordered_map<Id, std::set<Id>, Id::IdHash> connections;
+
+    explicit Private(SearchController* self, EditableLayout* editableLayout)
+        : self{self}
+        , editableLayout{editableLayout}
+        , filter{new WidgetFilter(self)}
+    {
+        connectedColour.setAlpha(80);
+        disconnectedColour.setAlpha(80);
+    }
+
+    void clearOverlays()
+    {
+        for(auto& [id, widget] : overlays) {
+            widget->deleteLater();
+        }
+        overlays.clear();
+    }
+
+    void handleWidgetOverlay(const Id& sourceId, FyWidget* widget)
+    {
+        const Id widgetId = widget->id();
+
+        const bool connectedToOther = isConnectedToOther(sourceId, widget->id());
+
+        auto* overlay
+            = overlays
+                  .emplace(widgetId, new OverlayWidget(connectedToOther ? OverlayWidget::Label : OverlayWidget::Button,
+                                                       editableLayout))
+                  .first->second;
+
+        if(connectedToOther) {
+            overlay->setText(u"Connected to another widget"_s);
+        }
+        else {
+            const bool connected = connections.contains(sourceId) && connections.at(sourceId).contains(widgetId);
+            overlay->setColour(connected ? connectedColour : disconnectedColour);
+            overlay->setButtonText(connected ? u"Disconnect"_s : u"Connect"_s);
+        }
+        overlay->setGeometry(widget->widgetGeometry());
+
+        QObject::connect(overlay, &OverlayWidget::buttonClicked, self,
+                         [this, sourceId, widget, overlay]() { handleConnectionChanged(sourceId, widget, overlay); });
+
+        overlay->show();
+    }
+
+    void handleConnectionChanged(const Id& sourceId, FyWidget* widget, OverlayWidget* overlay)
+    {
+        const Id id = widget->id();
+
+        if(connections.contains(sourceId) && connections.at(sourceId).contains(id)) {
+            connections[sourceId].erase(id);
+            searchableWidgets.erase(id);
+            overlay->setButtonText(u"Connect"_s);
+            overlay->setColour(disconnectedColour);
+        }
+        else {
+            connections[sourceId].emplace(id);
+            searchableWidgets.emplace(id, widget);
+            overlay->setButtonText(u"Disconnect"_s);
+            overlay->setColour(connectedColour);
+        }
+    }
+
+    bool isConnectedToOther(const Id& sourceId, const Id& widgetId)
+    {
+        return std::ranges::any_of(connections, [sourceId, widgetId](const auto& connection) {
+            return (connection.first != sourceId && connection.second.contains(widgetId));
+        });
+    }
+
+    QCoro::Task<void> setupWidgetConnections(Id id)
+    {
+        clearOverlays();
+
+        const auto widgets = editableLayout->findWidgetsByFeatures(FyWidget::Search);
+
+        if(!widgets.empty()) {
+            filter->start();
+
+            for(const auto& widget : widgets) {
+                handleWidgetOverlay(id, widget);
+            }
+
+            co_await qCoro(filter, &WidgetFilter::filterFinished);
+
+            filter->stop();
+            clearOverlays();
+        }
+    }
+};
+
+SearchController::SearchController(EditableLayout* editableLayout, QObject* parent)
+    : QObject{parent}
+    , p{std::make_unique<Private>(this, editableLayout)}
+{ }
+
+SearchController::~SearchController() = default;
+
+void SearchController::setupWidgetConnections(const Id& id)
+{
+    p->setupWidgetConnections(id);
 }
 
-void SearchController::changeSearch(const QString& search)
+IdSet SearchController::connectedWidgets(const Id& id)
 {
-    m_searchText = search;
-    emit searchChanged(m_searchText);
+    if(!p->connections.contains(id)) {
+        return {};
+    }
+
+    return p->connections.at(id);
+}
+
+void SearchController::setConnectedWidgets(const Id& id, const IdSet& widgets)
+{
+    p->connections[id] = widgets;
+}
+
+void SearchController::removeConnectedWidgets(const Id& id)
+{
+    p->connections.erase(id);
+}
+
+void SearchController::changeSearch(const Id& id, const QString& search)
+{
+    if(!p->connections.contains(id)) {
+        return;
+    }
+
+    for(const auto& widgetId : p->connections[id]) {
+        if(p->searchableWidgets.contains(widgetId)) {
+            if(auto* widget = p->searchableWidgets.at(widgetId)) {
+                widget->searchEvent(search);
+            }
+        }
+        else if(auto* widget = p->editableLayout->findWidget(widgetId)) {
+            p->searchableWidgets.emplace(widgetId, widget);
+            widget->searchEvent(search);
+        }
+    }
 }
 } // namespace Fooyin
 

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -25,6 +25,7 @@
 #include <utils/actions/actioncontainer.h>
 
 #include <QHBoxLayout>
+#include <QJsonObject>
 #include <QLineEdit>
 #include <QMenu>
 #include <QStyleOptionFrame>

--- a/src/gui/search/searchwidget.cpp
+++ b/src/gui/search/searchwidget.cpp
@@ -23,81 +23,148 @@
 #include <gui/guisettings.h>
 #include <gui/searchcontroller.h>
 #include <utils/actions/actioncontainer.h>
-#include <utils/actions/actionmanager.h>
-#include <utils/actions/command.h>
-#include <utils/settings/settingsmanager.h>
 
 #include <QHBoxLayout>
-#include <QKeyEvent>
 #include <QLineEdit>
 #include <QMenu>
+#include <QStyleOptionFrame>
 
 constexpr auto Placeholder = "Search library...";
 
+using namespace Qt::Literals::StringLiterals;
+
 namespace Fooyin {
-SearchWidget::SearchWidget(ActionManager* actionManager, SearchController* controller, SettingsManager* settings,
-                           QWidget* parent)
+struct SearchWidget::Private
+{
+    SearchWidget* self;
+
+    SearchController* searchController;
+    SettingsManager* settings;
+
+    QLineEdit* searchBox;
+
+    Private(SearchWidget* self, SearchController* controller, SettingsManager* settings)
+        : self{self}
+        , searchController{controller}
+        , settings{settings}
+        , searchBox{new QLineEdit(self)}
+    {
+        auto* layout = new QHBoxLayout(self);
+        layout->setContentsMargins(0, 0, 0, 0);
+
+        layout->addWidget(searchBox);
+
+        searchBox->setPlaceholderText(Placeholder);
+        searchBox->setClearButtonEnabled(true);
+    }
+
+    void setupConnections() const
+    {
+        searchController->setupWidgetConnections(self->id());
+    }
+
+    QPoint optionsMenuPoint() const
+    {
+        QStyleOptionFrame opt;
+        opt.initFrom(searchBox);
+
+        const QRect rect = searchBox->style()->subElementRect(QStyle::SE_LineEditContents, &opt, searchBox);
+        const QPoint pos{rect.right() - 5, rect.center().y()};
+
+        return searchBox->mapToGlobal(pos);
+    }
+
+    void showOptionsMenu()
+    {
+        auto* menu = new QMenu(tr("Options"), self);
+        menu->setAttribute(Qt::WA_DeleteOnClose);
+
+        auto* manageConnections = new QAction(tr("Manage Connections"), self);
+        QObject::connect(manageConnections, &QAction::triggered, self, [this]() { setupConnections(); });
+        menu->addAction(manageConnections);
+
+        menu->popup(optionsMenuPoint());
+    }
+};
+
+SearchWidget::SearchWidget(SearchController* controller, SettingsManager* settings, QWidget* parent)
     : FyWidget{parent}
-    , m_actionManager{actionManager}
-    , m_controller{controller}
-    , m_settings{settings}
-    , m_searchBox{new QLineEdit(this)}
-    , m_searchContext{new WidgetContext(this, Context{Constants::Context::Search}, this)}
+    , p{std::make_unique<Private>(this, controller, settings)}
 {
     setObjectName(SearchWidget::name());
 
-    auto* layout = new QHBoxLayout(this);
-    layout->setContentsMargins(0, 0, 0, 0);
+    QObject::connect(p->searchBox, &QLineEdit::textChanged, this,
+                     [this](const QString& search) { p->searchController->changeSearch(id(), search); });
 
-    m_searchBox->setPlaceholderText(Placeholder);
-    m_searchBox->setClearButtonEnabled(true);
+    auto* selectReceiver = new QAction(QIcon::fromTheme(Constants::Icons::Options), tr("Options"), this);
+    QObject::connect(selectReceiver, &QAction::triggered, this, [this]() { p->showOptionsMenu(); });
+    p->searchBox->addAction(selectReceiver, QLineEdit::TrailingPosition);
+}
 
-    layout->addWidget(m_searchBox);
-
-    QObject::connect(m_searchBox, &QLineEdit::textChanged, m_controller, &SearchController::searchChanged);
-
-    m_actionManager->addContextObject(m_searchContext);
-
-    auto* editMenu = m_actionManager->actionContainer(Constants::Menus::Edit);
-
-    auto* clear = new QAction(tr("&Clear"), this);
-    editMenu->addAction(actionManager->registerAction(clear, Constants::Actions::Clear, m_searchContext->context()));
-    QObject::connect(clear, &QAction::triggered, m_searchBox, &QLineEdit::clear);
-
-    auto* selectAll = new QAction(tr("&Select All"), this);
-    auto* selectAllCommand
-        = m_actionManager->registerAction(selectAll, Constants::Actions::SelectAll, m_searchContext->context());
-    selectAllCommand->setDefaultShortcut(QKeySequence::SelectAll);
-    editMenu->addAction(selectAllCommand, Actions::Groups::Two);
-    QObject::connect(selectAll, &QAction::triggered, m_searchBox, &QLineEdit::selectAll);
+SearchWidget::~SearchWidget()
+{
+    p->searchController->removeConnectedWidgets(id());
 }
 
 QString SearchWidget::name() const
 {
-    return QStringLiteral("Search Bar");
+    return u"Search Bar"_s;
 }
 
 QString SearchWidget::layoutName() const
 {
-    return QStringLiteral("SearchBar");
+    return u"SearchBar"_s;
 }
 
-void SearchWidget::keyPressEvent(QKeyEvent* event)
+void SearchWidget::layoutEditingMenu(ActionContainer* menu)
 {
-    //    const auto key = e->key();
-    //    if(key == Qt::Key_Enter || key == Qt::Key_Return) {
-    //            m_library->prepareTracks();
-    //    }
-    // m_searchBox->setFocusPolicy(Qt::StrongFocus);
-    //    m_searchBox->setFocus();
-    //    m_searchBox->setText(e->text());
-    QWidget::keyPressEvent(event);
+    auto* manageConnections = new QAction(tr("Manage Connections"), this);
+    QObject::connect(manageConnections, &QAction::triggered, this, [this]() { p->setupConnections(); });
+    menu->addAction(manageConnections);
 }
 
-void SearchWidget::contextMenuEvent(QContextMenuEvent* event)
+void SearchWidget::saveLayoutData(QJsonObject& layout)
 {
-    if(!m_settings->value<Settings::Gui::LayoutEditing>()) {
-        QWidget::contextMenuEvent(event);
+    const auto connectedWidgets = p->searchController->connectedWidgets(id());
+
+    if(connectedWidgets.empty()) {
+        return;
+    }
+
+    QByteArray widgets;
+    QDataStream stream{&widgets, QDataStream::WriteOnly};
+    stream.setVersion(QDataStream::Qt_6_5);
+
+    stream << connectedWidgets;
+
+    widgets = qCompress(widgets, 9);
+
+    layout["Widgets"_L1] = QString::fromUtf8(widgets.toBase64());
+}
+
+void SearchWidget::loadLayoutData(const QJsonObject& layout)
+{
+    if(!layout.contains("Widgets"_L1)) {
+        return;
+    }
+
+    auto widgets = QByteArray::fromBase64(layout["Widgets"_L1].toString().toUtf8());
+
+    if(widgets.isEmpty()) {
+        return;
+    }
+
+    widgets = qUncompress(widgets);
+
+    QDataStream stream{&widgets, QDataStream::ReadOnly};
+    stream.setVersion(QDataStream::Qt_6_5);
+
+    IdSet connectedWidgets;
+
+    stream >> connectedWidgets;
+
+    if(!connectedWidgets.empty()) {
+        p->searchController->setConnectedWidgets(id(), connectedWidgets);
     }
 }
 } // namespace Fooyin

--- a/src/gui/search/searchwidget.h
+++ b/src/gui/search/searchwidget.h
@@ -19,15 +19,10 @@
 
 #pragma once
 
-#include "gui/fywidget.h"
-
-class QHBoxLayout;
-class QLineEdit;
+#include <gui/fywidget.h>
 
 namespace Fooyin {
-class ActionManager;
 class SettingsManager;
-class WidgetContext;
 class SearchController;
 
 class SearchWidget : public FyWidget
@@ -35,22 +30,18 @@ class SearchWidget : public FyWidget
     Q_OBJECT
 
 public:
-    explicit SearchWidget(ActionManager* actionManager, SearchController* controller, SettingsManager* settings,
-                          QWidget* parent = nullptr);
+    explicit SearchWidget(SearchController* controller, SettingsManager* settings, QWidget* parent = nullptr);
+    ~SearchWidget() override;
 
     [[nodiscard]] QString name() const override;
     [[nodiscard]] QString layoutName() const override;
 
-protected:
-    void keyPressEvent(QKeyEvent* event) override;
-    void contextMenuEvent(QContextMenuEvent* event) override;
+    void layoutEditingMenu(ActionContainer* menu) override;
+    void saveLayoutData(QJsonObject& layout) override;
+    void loadLayoutData(const QJsonObject& layout) override;
 
 private:
-    ActionManager* m_actionManager;
-    SearchController* m_controller;
-    SettingsManager* m_settings;
-
-    QLineEdit* m_searchBox;
-    WidgetContext* m_searchContext;
+    struct Private;
+    std::unique_ptr<Private> p;
 };
 } // namespace Fooyin

--- a/src/gui/search/widgetfilter.cpp
+++ b/src/gui/search/widgetfilter.cpp
@@ -1,0 +1,91 @@
+/*
+ * Fooyin
+ * Copyright 2022-2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "widgetfilter.h"
+
+#include <gui/fywidget.h>
+#include <utils/widgets/overlaywidget.h>
+
+#include <QApplication>
+#include <QEvent>
+#include <QMouseEvent>
+#include <QPushButton>
+
+namespace Fooyin {
+WidgetFilter::WidgetFilter(QObject* parent)
+    : QObject{parent}
+{ }
+
+void WidgetFilter::start()
+{
+    qApp->installEventFilter(this);
+}
+
+void WidgetFilter::stop()
+{
+    qApp->removeEventFilter(this);
+}
+
+bool WidgetFilter::eventFilter(QObject* watched, QEvent* event)
+{
+    auto handleMouseEvent = [this, event]() {
+        const auto* mouseEvent = static_cast<QMouseEvent*>(event);
+
+        if(!mouseEvent) {
+            return false;
+        }
+
+        if(event->type() == QEvent::MouseButtonPress && mouseEvent->button() != Qt::LeftButton) {
+            emit filterFinished();
+            return false;
+        }
+
+        const QPoint pos = mouseEvent->globalPosition().toPoint();
+        auto* widget     = qApp->widgetAt(pos);
+
+        return (widget && (qobject_cast<OverlayWidget*>(widget) || qobject_cast<QPushButton*>(widget)));
+    };
+
+    switch(event->type()) {
+        case(QEvent::MouseMove):
+        case(QEvent::MouseButtonPress): {
+            if(handleMouseEvent()) {
+                event->ignore();
+                return QObject::eventFilter(watched, event);
+            }
+            event->accept();
+            return true;
+        }
+        case(QEvent::KeyPress): {
+            emit filterFinished();
+            event->accept();
+            return true;
+        }
+        case(QEvent::Wheel): {
+            event->accept();
+            return true;
+        }
+        default:
+            event->ignore();
+            return QObject::eventFilter(watched, event);
+    }
+}
+} // namespace Fooyin
+
+#include "moc_widgetfilter.cpp"

--- a/src/gui/search/widgetfilter.h
+++ b/src/gui/search/widgetfilter.h
@@ -19,44 +19,22 @@
 
 #pragma once
 
-#include <gui/fywidget.h>
-
-#include <QWidget>
+#include <QObject>
 
 namespace Fooyin {
-class ActionManager;
-class ActionContainer;
-class LayoutProvider;
-class SettingsManager;
-class WidgetProvider;
-class Id;
-struct Layout;
-
-class EditableLayout : public QWidget
+class WidgetFilter : public QObject
 {
     Q_OBJECT
 
 public:
-    explicit EditableLayout(ActionManager* actionManager, WidgetProvider* widgetProvider,
-                            LayoutProvider* layoutProvider, SettingsManager* settings, QWidget* parent = nullptr);
-    ~EditableLayout() override;
+    explicit WidgetFilter(QObject* parent = nullptr);
 
-    void initialise();
-
-    FyWidget* findWidget(const Id& id) const;
-    WidgetList findWidgetsByFeatures(const FyWidget::Features& features) const;
+    void start();
+    void stop();
 
     bool eventFilter(QObject* watched, QEvent* event) override;
 
-    void changeLayout(const Layout& layout);
-    void saveLayout();
-    bool loadLayout(const Layout& layout);
-    bool loadLayout();
-
-    void showQuickSetup();
-
-private:
-    struct Private;
-    std::unique_ptr<Private> p;
+signals:
+    void filterFinished();
 };
 } // namespace Fooyin

--- a/src/gui/settings/guigeneralpage.cpp
+++ b/src/gui/settings/guigeneralpage.cpp
@@ -19,9 +19,9 @@
 
 #include "guigeneralpage.h"
 
-#include "editablelayout.h"
 #include "quicksetup/quicksetupdialog.h"
 
+#include <gui/editablelayout.h>
 #include <gui/guiconstants.h>
 #include <gui/guipaths.h>
 #include <gui/guisettings.h>

--- a/src/gui/widgets/splitterwidget.cpp
+++ b/src/gui/widgets/splitterwidget.cpp
@@ -110,7 +110,7 @@ struct SplitterWidget::Private
     WidgetProvider* widgetProvider;
 
     Splitter* splitter;
-    QList<FyWidget*> children;
+    WidgetList children;
     Dummy* dummy{nullptr};
 
     int limit{0};
@@ -158,10 +158,11 @@ struct SplitterWidget::Private
             return;
         }
 
-        FyWidget* oldWidget = children.takeAt(index);
+        FyWidget* oldWidget = children.at(index);
+        children.erase(children.begin() + index);
         oldWidget->deleteLater();
 
-        children.insert(index, widget);
+        children.insert(children.begin() + index, widget);
         splitter->insertWidget(index, widget);
     }
 };
@@ -262,9 +263,14 @@ void SplitterWidget::removeWidget(FyWidget* widget)
     p->widgetCount -= 1;
 
     widget->deleteLater();
-    p->children.remove(index);
+    p->children.erase(p->children.begin() + index);
 
     p->checkShowDummy();
+}
+
+WidgetList SplitterWidget::widgets() const
+{
+    return p->children;
 }
 
 QString SplitterWidget::name() const
@@ -296,7 +302,7 @@ void SplitterWidget::layoutEditingMenu(ActionContainer* menu)
         addWidget(newWidget);
         newWidget->finalise();
     });
-    
+
     menu->addMenu(addMenu);
 }
 

--- a/src/gui/widgets/tabstackwidget.cpp
+++ b/src/gui/widgets/tabstackwidget.cpp
@@ -44,7 +44,7 @@ struct TabStackWidget::Private
     ActionManager* actionManager;
     WidgetProvider* widgetProvider;
 
-    std::vector<FyWidget*> widgets;
+    WidgetList widgets;
     EditableTabWidget* tabs;
 
     Private(TabStackWidget* self, ActionManager* actionManager, WidgetProvider* widgetProvider)
@@ -181,6 +181,11 @@ void TabStackWidget::replaceWidget(FyWidget* oldWidget, FyWidget* newWidget)
 
         p->tabs->setCurrentIndex(index);
     }
+}
+
+WidgetList TabStackWidget::widgets() const
+{
+    return p->widgets;
 }
 
 void TabStackWidget::contextMenuEvent(QContextMenuEvent* event)

--- a/src/gui/widgets/tabstackwidget.h
+++ b/src/gui/widgets/tabstackwidget.h
@@ -43,6 +43,8 @@ public:
     void removeWidget(FyWidget* widget) override;
     void replaceWidget(FyWidget* oldWidget, FyWidget* newWidget) override;
 
+    WidgetList widgets() const override;
+
 protected:
     void contextMenuEvent(QContextMenuEvent* event) override;
 

--- a/src/plugins/filters/filtermanager.h
+++ b/src/plugins/filters/filtermanager.h
@@ -23,8 +23,6 @@
 
 #include <QObject>
 
-#include <QCoroTask>
-
 namespace Fooyin {
 class SettingsManager;
 class MusicLibrary;
@@ -52,9 +50,6 @@ public:
 signals:
     void tracksRemoved(const TrackList& tracks);
     void tracksUpdated(const TrackList& tracks);
-
-public slots:
-    QCoro::Task<void> searchChanged(QString search);
 
 private:
     struct Private;

--- a/src/plugins/filters/filtersplugin.cpp
+++ b/src/plugins/filters/filtersplugin.cpp
@@ -39,7 +39,6 @@ struct FiltersPlugin::Private
     MusicLibrary* library;
     PlayerManager* playerManager;
     LayoutProvider* layoutProvider;
-    SearchController* searchController;
     WidgetFactory* factory;
     TrackSelectionController* trackSelection;
 
@@ -101,16 +100,12 @@ void FiltersPlugin::initialise(const CorePluginContext& context)
 
 void FiltersPlugin::initialise(const GuiPluginContext& context)
 {
-    p->actionManager    = context.actionManager;
-    p->layoutProvider   = context.layoutProvider;
-    p->searchController = context.searchController;
-    p->factory          = context.widgetFactory;
-    p->trackSelection   = context.trackSelection;
+    p->actionManager  = context.actionManager;
+    p->layoutProvider = context.layoutProvider;
+    p->factory        = context.widgetFactory;
+    p->trackSelection = context.trackSelection;
 
     p->filterManager = new FilterManager(p->library, p->trackSelection, p->settings, this);
-
-    QObject::connect(p->searchController, &SearchController::searchChanged, p->filterManager,
-                     &FilterManager::searchChanged);
 
     p->factory->registerClass<FilterWidget>(
         QStringLiteral("LibraryFilter"), [this]() { return p->filterManager->createFilter(); }, "Library Filter");

--- a/src/plugins/filters/filtersplugin.cpp
+++ b/src/plugins/filters/filtersplugin.cpp
@@ -54,7 +54,8 @@ struct FiltersPlugin::Private
             R"({"Obsidian":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAADAAAAGQAAA8EAAAAUAP////8BAAAAAgA=",
             "Widgets":[{"StatusBar":{}},{"SplitterHorizontal":{
             "State":"AAAA/wAAAAEAAAADAAAB+AAAA5wAAAGyAP////8BAAAAAQA=","Widgets":[{"SplitterVertical":{
-            "State":"AAAA/wAAAAEAAAACAAAAHQAAA6AA/////wEAAAACAA==","Widgets":[{"SearchBar":{}},
+            "State":"AAAA/wAAAAEAAAACAAAAHQAAA6AA/////wEAAAACAA==","Widgets":[{"SearchBar":{
+            "Widgets": "1c827a58f07a4a939b185d9c0285f936|09356ff889694ff7941174448bd67b7a"}},
             {"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAACAAAA5wAAAQ0A/////wEAAAABAA==","Widgets":[
             {"LibraryFilter":{"Columns":"1","ID":"1c827a58f07a4a939b185d9c0285f936",
             "State":"AAAAJXjaY2BgYGRgYHjKAKFBgNH+A5QBFWAAAC6BAhk="}},{"LibraryFilter":{"Columns":"3",
@@ -74,7 +75,8 @@ struct FiltersPlugin::Private
             "State":"AAAAJXjaY2BgYASi8wxgGgwY7T9AGVABBgAsDAIE="}},{"LibraryFilter":{"Columns":"3",
             "ID":"34777508a4ae4ec5939620f235e8ec1a","State":"AAAAJXjaY2BgYASicwxgGgwY7T9AGVABBgAr7gID="}}]}},
             {"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAACAAAFewAAAc8A/////wEAAAABAA==",
-            "Widgets":[{"ControlBar":{}},{"SearchBar":{"ID":"55a31e58410a45e2a506bf14a30041e4"}}]}},
+            "Widgets":[{"ControlBar":{}},{"SearchBar":{"Widgets": "955f29805de446d7a9b6195a94bfd817|
+            34777508a4ae4ec5939620f235e8ec1a|4fee1a754b3e47ff86f4c711fbf0f0eb|3b20c1db282d4bfe9a95c776e6723608"}}]}},
             {"SplitterHorizontal":{"State":"AAAA/wAAAAEAAAADAAABdAAABGgAAAFgAP////8BAAAAAQA=",
             "Widgets":[{"SplitterVertical":{"State":"AAAA/wAAAAEAAAACAAABdAAAAU0A/////wEAAAACAA==",
             "Widgets":[{"ArtworkPanel":{}},{"SelectionInfo":{}}]}},{"Playlist":{

--- a/src/plugins/filters/filterwidget.cpp
+++ b/src/plugins/filters/filterwidget.cpp
@@ -169,6 +169,8 @@ FilterWidget::FilterWidget(SettingsManager* settings, QWidget* parent)
 {
     setObjectName(FilterWidget::name());
 
+    setFeature(FyWidget::Search);
+
     auto* layout = new QHBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);
 
@@ -276,6 +278,11 @@ void FilterWidget::loadLayoutData(const QJsonObject& layout)
 void FilterWidget::finalise()
 {
     p->model->sortOnColumn(p->header->sortIndicatorSection(), p->header->sortIndicatorOrder());
+}
+
+void FilterWidget::searchEvent(const QString& search)
+{
+    emit requestSearch(p->filter, search);
 }
 
 void FilterWidget::tracksAdded(const TrackList& tracks)

--- a/src/plugins/filters/filterwidget.h
+++ b/src/plugins/filters/filterwidget.h
@@ -50,6 +50,8 @@ public:
     void loadLayoutData(const QJsonObject& layout) override;
     void finalise() override;
 
+    void searchEvent(const QString& search) override;
+
     void tracksAdded(const TrackList& tracks);
     void tracksUpdated(const TrackList& tracks);
     void tracksRemoved(const TrackList& tracks);
@@ -63,6 +65,7 @@ signals:
     void requestColumnsChange(const LibraryFilter& filter, const ColumnIds& columns);
     void requestHeaderMenu(const LibraryFilter& filter, AutoHeaderView* header, const QPoint& pos);
     void requestContextMenu(const LibraryFilter& filter, const QPoint& pos);
+    void requestSearch(const LibraryFilter& filter, const QString& search);
 
 protected:
     void contextMenuEvent(QContextMenuEvent* event) override;

--- a/src/utils/widgets/overlaywidget.cpp
+++ b/src/utils/widgets/overlaywidget.cpp
@@ -33,8 +33,8 @@ struct OverlayWidget::Private
 
     QVBoxLayout* layout;
 
-    int xOffset;
-    int yOffset;
+    int xOffset{0};
+    int yOffset{0};
 
     QPushButton* button{nullptr};
     QLabel* label{nullptr};

--- a/src/utils/widgets/overlaywidget.cpp
+++ b/src/utils/widgets/overlaywidget.cpp
@@ -52,7 +52,7 @@ OverlayWidget::OverlayWidget(const Options& options, QWidget* parent)
     if(m_options & Option::Button) {
         m_button = new QPushButton(this);
         m_button->setAutoFillBackground(true);
-        QObject::connect(m_button, &QPushButton::pressed, this, &OverlayWidget::buttonClicked);
+        QObject::connect(m_button, &QPushButton::clicked, this, &OverlayWidget::buttonClicked);
         layout->addWidget(m_button);
     }
 

--- a/src/utils/widgets/overlaywidget.cpp
+++ b/src/utils/widgets/overlaywidget.cpp
@@ -43,11 +43,15 @@ OverlayWidget::OverlayWidget(const Options& options, QWidget* parent)
 
     if(m_options & Option::Label) {
         m_text = new QLabel(this);
+        m_text->setContentsMargins(5, 5, 5, 5);
+        m_text->setWordWrap(true);
+        m_text->setAutoFillBackground(true);
         layout->addWidget(m_text);
     }
 
     if(m_options & Option::Button) {
         m_button = new QPushButton(this);
+        m_button->setAutoFillBackground(true);
         QObject::connect(m_button, &QPushButton::pressed, this, &OverlayWidget::buttonClicked);
         layout->addWidget(m_button);
     }
@@ -68,6 +72,11 @@ void OverlayWidget::setButtonText(const QString& text)
     if(m_button) {
         m_button->setText(text);
     }
+}
+
+void OverlayWidget::setButtonEnabled(bool enabled)
+{
+    m_button->setEnabled(enabled);
 }
 
 void OverlayWidget::setColour(const QColor& colour)


### PR DESCRIPTION
Changes the functionality and behavior of SearchWidget by allowing other widgets to 'connect' to a specific SearchWidget instance. When the search string of that instance changes, only the connected widgets are notified.

In order to receive search events, a FyWidget subclass must enable the 'Search' feature using setFeature. It can then re-implement searchEvent to receive updates from the SearchWidget it's connected to. Such connections are managed in the options menu in the right corner of each SearchWidget.

![Connecting widgets](https://github.com/ludouzi/fooyin/assets/45490980/e158edb5-3c87-4b54-b3c4-1460f6a319a5)
