### PR TITLE
Store track statistics in a separate sql table

### DIFF
--- a/include/core/library/musiclibrary.h
+++ b/include/core/library/musiclibrary.h
@@ -92,6 +92,9 @@ public:
     /** Updates the metdata in the database for @p tracks and writes metdata to files  */
     virtual void updateTrackMetadata(const TrackList& tracks) = 0;
 
+    /** Updates the statistics (playcount, rating etc) in the database for @p track  */
+    virtual void updateTrackStats(const Track& track) = 0;
+
 signals:
     void scanProgress(int id, int percent);
 

--- a/include/core/player/playermanager.h
+++ b/include/core/player/playermanager.h
@@ -88,5 +88,6 @@ signals:
     void positionChanged(uint64_t ms);
     void positionMoved(uint64_t ms);
     void currentTrackChanged(const Track& track);
+    void trackPlayed(const Track& track);
 };
 } // namespace Fooyin

--- a/include/core/playlist/playlist.h
+++ b/include/core/playlist/playlist.h
@@ -53,6 +53,7 @@ public:
     [[nodiscard]] QString name() const;
 
     [[nodiscard]] TrackList tracks() const;
+    [[nodiscard]] std::optional<Track> track(int index) const;
     [[nodiscard]] int trackCount() const;
 
     [[nodiscard]] int currentTrackIndex() const;

--- a/include/core/playlist/playlistmanager.h
+++ b/include/core/playlist/playlistmanager.h
@@ -79,7 +79,7 @@ signals:
     void playlistsPopulated();
     void playlistAdded(Playlist* playlist);
     void playlistTracksAdded(Playlist* playlist, const TrackList& tracks, int index);
-    void playlistTracksChanged(Playlist* playlist);
+    void playlistTracksChanged(Playlist* playlist, const std::vector<int>& indexes);
     void playlistRemoved(Playlist* playlist);
     void playlistRenamed(Playlist* playlist);
     void activePlaylistChanged(Playlist* playlist);

--- a/include/core/track.h
+++ b/include/core/track.h
@@ -117,6 +117,8 @@ public:
 
     [[nodiscard]] uint64_t addedTime() const;
     [[nodiscard]] uint64_t modifiedTime() const;
+    [[nodiscard]] uint64_t firstPlayed() const;
+    [[nodiscard]] uint64_t lastPlayed() const;
 
     [[nodiscard]] QString sort() const;
 
@@ -125,6 +127,7 @@ public:
     void setId(int id);
     void setHash(const QString& hash);
     void setType(Type type);
+    void setFilePath(const QString& path);
     void setRelativePath(const QString& path);
     void setTitle(const QString& title);
     void setArtists(const QStringList& artists);
@@ -158,6 +161,8 @@ public:
 
     void setAddedTime(uint64_t time);
     void setModifiedTime(uint64_t time);
+    void setFirstPlayed(uint64_t time);
+    void setLastPlayed(uint64_t time);
 
     void setSort(const QString& sort);
 

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -92,6 +92,7 @@ Application::Application(QObject* parent)
     : QObject{parent}
     , p{std::make_unique<Private>(this)}
 {
+    QObject::connect(p->playerManager, &PlayerManager::trackPlayed, p->library, &UnifiedMusicLibrary::trackWasPlayed);
     QObject::connect(p->library, &MusicLibrary::tracksLoaded, p->playlistHandler, &PlaylistHandler::populatePlaylists);
     QObject::connect(p->library, &MusicLibrary::libraryRemoved, p->playlistHandler, &PlaylistHandler::libraryRemoved);
     QObject::connect(p->library, &MusicLibrary::tracksUpdated, p->playlistHandler, &PlaylistHandler::tracksUpdated);

--- a/src/core/database/database.cpp
+++ b/src/core/database/database.cpp
@@ -69,6 +69,16 @@ bool Database::createDatabase()
         return false;
     }
 
+    checkInsertTable(u"Libraries"_s, u"CREATE TABLE Libraries ("
+                                     "    LibraryID INTEGER PRIMARY KEY AUTOINCREMENT,"
+                                     "    Name TEXT NOT NULL UNIQUE,"
+                                     "    Path TEXT NOT NULL UNIQUE);"_s);
+
+    checkInsertTable(u"Playlists"_s, u"CREATE TABLE Playlists ("
+                                     "    PlaylistID INTEGER PRIMARY KEY AUTOINCREMENT,"
+                                     "    Name TEXT NOT NULL UNIQUE,"
+                                     "    PlaylistIndex INTEGER);"_s);
+
     checkInsertTable(u"Tracks"_s, u"CREATE TABLE Tracks ("
                                   "    TrackID INTEGER PRIMARY KEY AUTOINCREMENT,"
                                   "    FilePath TEXT UNIQUE NOT NULL,"
@@ -82,80 +92,80 @@ bool Database::createDatabase()
                                   "    DiscNumber INTEGER,"
                                   "    DiscTotal INTEGER,"
                                   "    Date TEXT,"
-                                  "    Year INTEGER,"
                                   "    Composer TEXT,"
                                   "    Performer TEXT,"
                                   "    Genres TEXT,"
                                   "    Lyrics TEXT,"
                                   "    Comment TEXT,"
                                   "    Duration INTEGER DEFAULT 0,"
-                                  "    PlayCount INTEGER DEFAULT 0,"
-                                  "    Rating INTEGER DEFAULT 0,"
                                   "    FileSize INTEGER DEFAULT 0,"
                                   "    BitRate INTEGER DEFAULT 0,"
                                   "    SampleRate INTEGER DEFAULT 0,"
                                   "    ExtraTags BLOB,"
                                   "    Type INTEGER DEFAULT 0,"
-                                  "    AddedDate INTEGER,"
                                   "    ModifiedDate INTEGER,"
-                                  "    LibraryID INTEGER REFERENCES Libraries ON DELETE CASCADE);"_s);
+                                  "    LibraryID INTEGER REFERENCES Libraries ON DELETE CASCADE,"
+                                  "    TrackHash TEXT);"_s);
 
-    checkInsertTable(u"Libraries"_s, u"CREATE TABLE Libraries ("
-                                     "    LibraryID INTEGER PRIMARY KEY AUTOINCREMENT,"
-                                     "    Name TEXT NOT NULL UNIQUE,"
-                                     "    Path TEXT NOT NULL UNIQUE);"_s);
-
-    checkInsertTable(u"Playlists"_s, u"CREATE TABLE Playlists ("
-                                     "    PlaylistID INTEGER PRIMARY KEY AUTOINCREMENT,"
-                                     "    Name TEXT NOT NULL UNIQUE,"
-                                     "    PlaylistIndex INTEGER);"_s);
+    checkInsertTable(u"TrackStats"_s, u"CREATE TABLE TrackStats ("
+                                      "    TrackHash TEXT PRIMARY KEY,"
+                                      "    LastSeen INTEGER,"
+                                      "    AddedDate INTEGER,"
+                                      "    FirstPlayed INTEGER,"
+                                      "    LastPlayed INTEGER,"
+                                      "    PlayCount INTEGER DEFAULT 0,"
+                                      "    Rating INTEGER DEFAULT 0);"_s);
 
     checkInsertTable(u"PlaylistTracks"_s, u"CREATE TABLE PlaylistTracks ("
                                           "    PlaylistID INTEGER NOT NULL REFERENCES Playlists ON DELETE CASCADE,"
                                           "    TrackID INTEGER NOT NULL REFERENCES Tracks ON DELETE CASCADE,"
                                           "    TrackIndex INTEGER NOT NULL);"_s);
 
-    checkInsertTable(u"TrackView"_s, u"CREATE VIEW TracksView AS "
-                                     "SELECT "
-                                     "    Tracks.TrackID, "
-                                     "    Tracks.FilePath, "
-                                     "    Tracks.Title, "
-                                     "    Tracks.TrackNumber, "
-                                     "    Tracks.TrackTotal, "
-                                     "    Tracks.Artists, "
-                                     "    Tracks.AlbumArtist, "
-                                     "    Tracks.Album, "
-                                     "    Tracks.CoverPath, "
-                                     "    Tracks.DiscNumber, "
-                                     "    Tracks.DiscTotal, "
-                                     "    Tracks.Date, "
-                                     "    Tracks.Year, "
-                                     "    Tracks.Composer, "
-                                     "    Tracks.Performer, "
-                                     "    Tracks.Genres, "
-                                     "    Tracks.Lyrics, "
-                                     "    Tracks.Comment, "
-                                     "    Tracks.Duration, "
-                                     "    Tracks.PlayCount, "
-                                     "    Tracks.Rating, "
-                                     "    Tracks.FileSize, "
-                                     "    Tracks.BitRate, "
-                                     "    Tracks.SampleRate, "
-                                     "    Tracks.ExtraTags, "
-                                     "    Tracks.Type, "
-                                     "    Tracks.AddedDate, "
-                                     "    Tracks.ModifiedDate, "
-                                     "    Tracks.LibraryID, "
-                                     "    SUBSTR(Tracks.FilePath, LENGTH(Libraries.Path) + 2) AS RelativePath "
-                                     "FROM Tracks "
-                                     "JOIN Libraries ON Tracks.LibraryID = Libraries.LibraryID;"_s);
+    checkInsertTable(u"TrackView"_s, u"CREATE VIEW TracksView AS"
+                                     "  SELECT"
+                                     "    Tracks.TrackID,"
+                                     "    Tracks.FilePath,"
+                                     "    SUBSTR(Tracks.FilePath, LENGTH(Libraries.Path) + 2) AS RelativePath,"
+                                     "    Tracks.Title,"
+                                     "    Tracks.TrackNumber,"
+                                     "    Tracks.TrackTotal,"
+                                     "    Tracks.Artists,"
+                                     "    Tracks.AlbumArtist,"
+                                     "    Tracks.Album,"
+                                     "    Tracks.CoverPath,"
+                                     "    Tracks.DiscNumber,"
+                                     "    Tracks.DiscTotal,"
+                                     "    Tracks.Date,"
+                                     "    Tracks.Composer,"
+                                     "    Tracks.Performer,"
+                                     "    Tracks.Genres,"
+                                     "    Tracks.Lyrics,"
+                                     "    Tracks.Comment,"
+                                     "    Tracks.Duration,"
+                                     "    Tracks.FileSize,"
+                                     "    Tracks.BitRate,"
+                                     "    Tracks.SampleRate,"
+                                     "    Tracks.ExtraTags,"
+                                     "    Tracks.Type,"
+                                     "    Tracks.ModifiedDate,"
+                                     "    Tracks.LibraryID,"
+                                     "    Tracks.TrackHash,"
+                                     "    TrackStats.AddedDate,"
+                                     "    TrackStats.FirstPlayed,"
+                                     "    TrackStats.LastPlayed,"
+                                     "    TrackStats.PlayCount,"
+                                     "    TrackStats.Rating"
+                                     "  FROM Tracks"
+                                     "  JOIN Libraries ON Tracks.LibraryID = Libraries.LibraryID"
+                                     "  LEFT JOIN TrackStats ON Tracks.TrackHash = TrackStats.TrackHash;"_s);
 
+    checkInsertIndex(u"TrackIndex"_s, u"CREATE INDEX TrackIndex ON Tracks(TrackHash);"_s);
     checkInsertIndex(u"PlaylistIndex"_s, u"CREATE INDEX PlaylistIndex ON Playlists(PlaylistID,Name);"_s);
     checkInsertIndex(u"PlaylistTracksIndex"_s,
                      u"CREATE INDEX PlaylistTracksIndex ON PlaylistTracks(PlaylistID,TrackIndex);"_s);
 
-    module()->insert(u"Libraries"_s, {{u"LibraryID"_s, u"0"_s}, {u"Name"_s, u"No Library"_s}, {u"Path"_s, u""_s}},
-                     "Could not insert default library");
+    insert(u"Libraries"_s, {{u"LibraryID"_s, u"0"_s}, {u"Name"_s, u"No Library"_s}, {u"Path"_s, u""_s}},
+           "Could not insert default library");
 
     return true;
 }

--- a/src/core/database/databasemodule.cpp
+++ b/src/core/database/databasemodule.cpp
@@ -209,14 +209,4 @@ DatabaseQuery DatabaseModule::remove(const QString& tableName,
 
     return q;
 }
-
-DatabaseModule* DatabaseModule::module()
-{
-    return this;
-}
-
-const DatabaseModule* DatabaseModule::module() const
-{
-    return this;
-}
 } // namespace Fooyin

--- a/src/core/database/databasemodule.h
+++ b/src/core/database/databasemodule.h
@@ -51,8 +51,6 @@ public:
 
 protected:
     void runPragma(const QString& pragma, const QString& value) const;
-    DatabaseModule* module();
-    [[nodiscard]] const DatabaseModule* module() const;
 
 private:
     QString m_connectionName;

--- a/src/core/database/librarydatabase.cpp
+++ b/src/core/database/librarydatabase.cpp
@@ -56,16 +56,16 @@ int LibraryDatabase::insertLibrary(const QString& path, const QString& name)
         return -1;
     }
 
-    auto q = module()->insert(u"Libraries"_s, {{"Name", name}, {"Path", path}},
-                              QString{u"Cannot insert library (name: %1, path: %2)"_s}.arg(name, path));
+    auto q = insert(u"Libraries"_s, {{"Name", name}, {"Path", path}},
+                    QString{u"Cannot insert library (name: %1, path: %2)"_s}.arg(name, path));
 
     return (q.hasError()) ? -1 : q.lastInsertId().toInt();
 }
 
 bool LibraryDatabase::removeLibrary(int id)
 {
-    auto q = module()->remove(u"Libraries"_s, {{"LibraryID", QString::number(id)}},
-                              "Cannot remove library " + QString::number(id));
+    auto q
+        = remove(u"Libraries"_s, {{"LibraryID", QString::number(id)}}, "Cannot remove library " + QString::number(id));
     return !q.hasError();
 }
 
@@ -75,8 +75,8 @@ bool LibraryDatabase::renameLibrary(int id, const QString& name)
         return false;
     }
 
-    auto q = module()->update(u"Libraries"_s, {{"Name", name}}, {"LibraryID", QString::number(id)},
-                              "Cannot update library " + QString::number(id));
+    auto q = update(u"Libraries"_s, {{"Name", name}}, {"LibraryID", QString::number(id)},
+                    "Cannot update library " + QString::number(id));
     return !q.hasError();
 }
 } // namespace Fooyin

--- a/src/core/database/playlistdatabase.cpp
+++ b/src/core/database/playlistdatabase.cpp
@@ -175,8 +175,8 @@ int PlaylistDatabase::insertPlaylist(const QString& name, int index)
         return -1;
     }
 
-    auto q = module()->insert(u"Playlists"_s, {{"Name", name}, {u"PlaylistIndex"_s, QString::number(index)}},
-                              QString{u"Cannot insert playlist (name: %1, index: %2)"_s}.arg(name).arg(index));
+    auto q = insert(u"Playlists"_s, {{"Name", name}, {u"PlaylistIndex"_s, QString::number(index)}},
+                    QString{u"Cannot insert playlist (name: %1, index: %2)"_s}.arg(name).arg(index));
 
     return (q.hasError()) ? -1 : q.lastInsertId().toInt();
 }
@@ -202,8 +202,8 @@ bool PlaylistDatabase::saveModifiedPlaylists(const PlaylistList& playlists)
 
 bool PlaylistDatabase::removePlaylist(int id)
 {
-    auto q = module()->remove(u"Playlists"_s, {{u"PlaylistID"_s, QString::number(id)}},
-                              "Cannot remove playlist " + QString::number(id));
+    auto q = remove(u"Playlists"_s, {{u"PlaylistID"_s, QString::number(id)}},
+                    "Cannot remove playlist " + QString::number(id));
     return !q.hasError();
 }
 
@@ -213,8 +213,8 @@ bool PlaylistDatabase::renamePlaylist(int id, const QString& name)
         return false;
     }
 
-    auto q = module()->update(u"Playlists"_s, {{u"Name"_s, name}}, {u"PlaylistID"_s, QString::number(id)},
-                              "Cannot update playlist " + QString::number(id));
+    auto q = update(u"Playlists"_s, {{u"Name"_s, name}}, {u"PlaylistID"_s, QString::number(id)},
+                    "Cannot update playlist " + QString::number(id));
     return !q.hasError();
 }
 } // namespace Fooyin

--- a/src/core/database/trackdatabase.cpp
+++ b/src/core/database/trackdatabase.cpp
@@ -25,66 +25,69 @@
 #include <core/track.h>
 #include <utils/fileutils.h>
 
+#include <QDateTime>
+
 using namespace Qt::Literals::StringLiterals;
 
-namespace Fooyin {
+namespace {
 QString fetchQueryTracks()
 {
     static const QStringList fields = {
         u"TrackID"_s,      // 0
         u"FilePath"_s,     // 1
-        u"Title"_s,        // 2
-        u"TrackNumber"_s,  // 3
-        u"TrackTotal"_s,   // 4
-        u"Artists"_s,      // 5
-        u"AlbumArtist"_s,  // 6
-        u"Album"_s,        // 7
-        u"CoverPath"_s,    // 8
-        u"DiscNumber"_s,   // 9
-        u"DiscTotal"_s,    // 10
-        u"Date"_s,         // 11
-        u"Year"_s,         // 12
+        u"RelativePath"_s, // 2
+        u"Title"_s,        // 3
+        u"TrackNumber"_s,  // 4
+        u"TrackTotal"_s,   // 5
+        u"Artists"_s,      // 6
+        u"AlbumArtist"_s,  // 7
+        u"Album"_s,        // 8
+        u"CoverPath"_s,    // 9
+        u"DiscNumber"_s,   // 10
+        u"DiscTotal"_s,    // 11
+        u"Date"_s,         // 12
         u"Composer"_s,     // 13
         u"Performer"_s,    // 14
         u"Genres"_s,       // 15
         u"Lyrics"_s,       // 16
         u"Comment"_s,      // 17
         u"Duration"_s,     // 18
-        u"PlayCount"_s,    // 19
-        u"Rating"_s,       // 20
-        u"FileSize"_s,     // 21
-        u"BitRate"_s,      // 22
-        u"SampleRate"_s,   // 23
-        u"ExtraTags"_s,    // 24
-        u"Type"_s,         // 25
-        u"AddedDate"_s,    // 26
-        u"ModifiedDate"_s, // 27
-        u"LibraryID"_s,    // 28
-        u"RelativePath"_s  // 29
+        u"FileSize"_s,     // 19
+        u"BitRate"_s,      // 20
+        u"SampleRate"_s,   // 21
+        u"ExtraTags"_s,    // 22
+        u"Type"_s,         // 23
+        u"ModifiedDate"_s, // 24
+        u"LibraryID"_s,    // 25
+        u"TrackHash"_s,    // 26
+        u"AddedDate"_s,    // 27
+        u"FirstPlayed"_s,  // 28
+        u"LastPlayed"_s,   // 29
+        u"PlayCount"_s,    // 30
+        u"Rating"_s,       // 31
     };
 
-    const auto joinedFields = fields.join(", "_L1);
+    const QString joinedFields = fields.join(", "_L1);
 
-    return QString(u"SELECT %1 FROM TracksView;"_s).arg(joinedFields);
+    return QString(u"SELECT %1 FROM TracksView"_s).arg(joinedFields);
 }
 
-BindingsMap getTrackBindings(const Track& track)
+Fooyin::BindingsMap trackBindings(const Fooyin::Track& track)
 {
-    return {{u"FilePath"_s, Utils::File::cleanPath(track.filepath())},
+    return {{u"FilePath"_s, Fooyin::Utils::File::cleanPath(track.filepath())},
             {u"Title"_s, track.title()},
             {u"TrackNumber"_s, QString::number(track.trackNumber())},
             {u"TrackTotal"_s, QString::number(track.trackTotal())},
-            {u"Artists"_s, track.artists().join(Constants::Separator)},
+            {u"Artists"_s, track.artists().join(Fooyin::Constants::Separator)},
             {u"AlbumArtist"_s, track.albumArtist()},
             {u"Album"_s, track.album()},
             {u"CoverPath"_s, track.coverPath()},
             {u"DiscNumber"_s, QString::number(track.discNumber())},
             {u"DiscTotal"_s, QString::number(track.discTotal())},
             {u"Date"_s, track.date()},
-            {u"Year"_s, QString::number(track.year())},
             {u"Composer"_s, track.composer()},
             {u"Performer"_s, track.performer()},
-            {u"Genres"_s, track.genres().join(Constants::Separator)},
+            {u"Genres"_s, track.genres().join(Fooyin::Constants::Separator)},
             {u"Lyrics"_s, track.lyrics()},
             {u"Comment"_s, track.comment()},
             {u"Duration"_s, QString::number(track.duration())},
@@ -93,15 +96,208 @@ BindingsMap getTrackBindings(const Track& track)
             {u"SampleRate"_s, QString::number(track.sampleRate())},
             {u"ExtraTags"_s, track.serialiseExtrasTags()},
             {u"Type"_s, QString::number(static_cast<int>(track.type()))},
-            {u"AddedDate"_s, QString::number(track.addedTime())},
             {u"ModifiedDate"_s, QString::number(track.modifiedTime())},
+            {u"TrackHash"_s, track.hash()},
             {u"LibraryID"_s, QString::number(track.libraryId())}};
 }
 
+void readToTrack(const Fooyin::DatabaseQuery& q, Fooyin::Track& track)
+{
+    track.setId(q.value(0).toInt());
+    track.setFilePath(q.value(1).toString());
+    track.setRelativePath(q.value(2).toString());
+    track.setTitle(q.value(3).toString());
+    track.setTrackNumber(q.value(4).toInt());
+    track.setTrackTotal(q.value(5).toInt());
+    track.setArtists(q.value(6).toString().split(Fooyin::Constants::Separator, Qt::SkipEmptyParts));
+    track.setAlbumArtist(q.value(7).toString());
+    track.setAlbum(q.value(8).toString());
+    track.setCoverPath(q.value(9).toString());
+    track.setDiscNumber(q.value(10).toInt());
+    track.setDiscTotal(q.value(11).toInt());
+    track.setDate(q.value(12).toString());
+    track.setComposer(q.value(13).toString());
+    track.setPerformer(q.value(14).toString());
+    track.setGenres(q.value(15).toString().split(Fooyin::Constants::Separator, Qt::SkipEmptyParts));
+    track.setLyrics(q.value(16).toString());
+    track.setComment(q.value(17).toString());
+    track.setDuration(q.value(18).toULongLong());
+    track.setFileSize(q.value(19).toInt());
+    track.setBitrate(q.value(20).toInt());
+    track.setSampleRate(q.value(21).toInt());
+    track.storeExtraTags(q.value(22).toByteArray());
+    track.setType(static_cast<Fooyin::Track::Type>(q.value(23).toInt()));
+    track.setModifiedTime(q.value(24).toULongLong());
+    track.setLibraryId(q.value(25).toInt());
+    track.setHash(q.value(26).toString());
+    track.setAddedTime(q.value(27).toULongLong());
+    track.setFirstPlayed(q.value(28).toULongLong());
+    track.setLastPlayed(q.value(29).toULongLong());
+    track.setPlayCount(q.value(30).toInt());
+
+    track.generateHash();
+}
+} // namespace
+
+namespace Fooyin {
+struct TrackDatabase::Private
+{
+    TrackDatabase* self;
+
+    explicit Private(TrackDatabase* self)
+        : self{self}
+    { }
+
+    void removeUnmanagedTracks() const
+    {
+        QString queryText
+            = u"DELETE FROM Tracks WHERE LibraryID = 0 AND TrackID NOT IN (SELECT TrackID FROM PlaylistTracks);"_s;
+        const auto q = self->runQuery(queryText, u"Cannot cleanup tracks"_s);
+    }
+
+    void markUnusedStatsForDelete() const
+    {
+        const QString queryText
+            = "UPDATE TrackStats SET LastSeen = :lastSeen WHERE LastSeen IS NULL AND TrackHash NOT IN "
+              "(SELECT TrackHash FROM Tracks);";
+        const auto q
+            = self->runQuery(queryText, {{u":lastSeen"_s, QString::number(QDateTime::currentMSecsSinceEpoch())}},
+                             u"Error updating LastSeen"_s);
+    }
+
+    void deleteExpiredStats() const
+    {
+        const QString queryText
+            = "DELETE FROM TrackStats WHERE LastSeen IS NOT NULL AND LastSeen <= :clearInterval AND "
+              "TrackHash NOT IN (SELECT TrackHash FROM Tracks);";
+        const auto q = self->runQuery(
+            queryText,
+            {{u":clearInterval"_s, QString::number(QDateTime::currentDateTime().addDays(-28).toMSecsSinceEpoch())}},
+            u"Error deleting expired track stats"_s);
+    }
+
+    int trackCount() const
+    {
+        auto q = self->runQuery(u"SELECT COUNT(*) FROM Tracks"_s, u"Cannot fetch track count"_s);
+
+        if(!q.hasError() && q.next()) {
+            return q.value(0).toInt();
+        }
+        return -1;
+    }
+
+    bool insertTrack(Track& track) const
+    {
+        auto bindings = trackBindings(track);
+        const auto q  = self->insert(u"Tracks"_s, bindings, "Cannot insert track " + track.filepath());
+
+        if(q.hasError()) {
+            return false;
+        }
+
+        track.setId(q.lastInsertId().toInt());
+
+        return insertOrUpdateStats(track);
+    }
+
+    bool insertOrUpdateStats(Track& track) const
+    {
+        if(track.hash().isEmpty()) {
+            qDebug() << "Cannot insert/update track stats (Hash empty)";
+            return false;
+        }
+
+        static const QStringList fields = {
+            u"AddedDate"_s,   // 0
+            u"FirstPlayed"_s, // 1
+            u"LastPlayed"_s,  // 2
+            u"PlayCount"_s,   // 3
+            u"Rating"_s,      // 4
+        };
+
+        const QString joinedFields = fields.join(", "_L1);
+
+        const auto existsQuery
+            = QString{u"SELECT %1 FROM TrackStats WHERE TrackHash = :trackHash;"_s}.arg(joinedFields);
+        auto exists = self->runQuery(existsQuery, std::make_pair(u":trackHash"_s, track.hash()),
+                                     u"Couldn't check stats for track "_s + track.filepath());
+
+        if(exists.hasError()) {
+            return false;
+        }
+
+        if(exists.next()) {
+            const auto added       = static_cast<uint64_t>(exists.value(0).toULongLong());
+            const auto firstPlayed = static_cast<uint64_t>(exists.value(1).toULongLong());
+            const auto lastPlayed  = static_cast<uint64_t>(exists.value(2).toULongLong());
+            const int playCount    = exists.value(3).toInt();
+
+            bool changed{false};
+            BindingsMap bindings;
+
+            if(track.addedTime() != added) {
+                if(added == 0 || track.addedTime() < added) {
+                    changed = true;
+                    bindings.emplace(u"AddedDate"_s, QString::number(track.addedTime()));
+                }
+                else {
+                    track.setAddedTime(added);
+                }
+            }
+            if(track.firstPlayed() != firstPlayed) {
+                if(firstPlayed == 0 || track.firstPlayed() < firstPlayed) {
+                    changed = true;
+                    bindings.emplace(u"FirstPlayed"_s, QString::number(track.firstPlayed()));
+                }
+                else {
+                    track.setFirstPlayed(firstPlayed);
+                }
+            }
+            if(track.lastPlayed() != lastPlayed) {
+                if(track.lastPlayed() > lastPlayed) {
+                    changed = true;
+                    bindings.emplace(u"LastPlayed"_s, QString::number(track.lastPlayed()));
+                }
+                else {
+                    track.setLastPlayed(lastPlayed);
+                }
+            }
+            if(track.playCount() != playCount) {
+                if(track.playCount() > playCount) {
+                    changed = true;
+                    bindings.emplace(u"PlayCount"_s, QString::number(track.playCount()));
+                }
+                else {
+                    track.setPlayCount(playCount);
+                }
+            }
+
+            if(changed) {
+                const auto q = self->update(u"TrackStats"_s, bindings, {u"TrackHash"_s, track.hash()},
+                                            u"Cannot update stats for track "_s + track.filepath());
+                return !q.hasError();
+            }
+
+            return changed;
+        }
+
+        const BindingsMap bindings = {{u"TrackHash"_s, track.hash()},
+                                      {u"AddedDate"_s, QString::number(track.addedTime())},
+                                      {u"FirstPlayed"_s, QString::number(track.firstPlayed())},
+                                      {u"LastPlayed"_s, QString::number(track.lastPlayed())},
+                                      {u"PlayCount"_s, QString::number(track.playCount())}};
+
+        const auto q = self->insert(u"TrackStats"_s, bindings, u"Cannot insert stats for track "_s + track.filepath());
+        return !q.hasError();
+    }
+};
+
 TrackDatabase::TrackDatabase(const QString& connectionName)
-    : DatabaseModule(connectionName)
-    , m_connectionName(connectionName)
+    : DatabaseModule{connectionName}
+    , p{std::make_unique<Private>(this)}
 { }
+
+TrackDatabase::~TrackDatabase() = default;
 
 bool TrackDatabase::storeTracks(TrackList& tracks)
 {
@@ -119,8 +315,7 @@ bool TrackDatabase::storeTracks(TrackList& tracks)
             updateTrack(track);
         }
         else {
-            const int id = insertTrack(track);
-            track.setId(id);
+            p->insertTrack(track);
         }
     }
 
@@ -132,104 +327,116 @@ bool TrackDatabase::storeTracks(TrackList& tracks)
     return true;
 }
 
-bool TrackDatabase::getAllTracks(TrackList& result)
+bool TrackDatabase::reloadTrack(Track& track) const
 {
-    DatabaseQuery q{module()};
-    const QString query = fetchQueryTracks();
+    DatabaseQuery q{this};
+    const QString query = fetchQueryTracks() + u" WHERE TrackID = :trackId;"_s;
     q.prepareQuery(query);
-
-    return dbFetchTracks(q, result);
-}
-
-bool TrackDatabase::dbFetchTracks(DatabaseQuery& q, TrackList& result) const
-{
-    result.clear();
+    q.bindQueryValue(u"trackId"_s, track.id());
 
     if(!q.execQuery()) {
         q.error(u"Cannot fetch tracks from database"_s);
         return false;
     }
 
-    const int numRows = dbTrackCount();
-    if(numRows > 0) {
-        result.reserve(numRows);
-    }
-
-    while(q.next()) {
-        Track track{q.value(1).toString()};
-
-        track.setId(q.value(0).toInt());
-        track.setTitle(q.value(2).toString());
-        track.setTrackNumber(q.value(3).toInt());
-        track.setTrackTotal(q.value(4).toInt());
-        track.setArtists(q.value(5).toString().split(Constants::Separator, Qt::SkipEmptyParts));
-        track.setAlbumArtist(q.value(6).toString());
-        track.setAlbum(q.value(7).toString());
-        track.setCoverPath(q.value(8).toString());
-        track.setDiscNumber(q.value(9).toInt());
-        track.setDiscTotal(q.value(10).toInt());
-        track.setDate(q.value(11).toString());
-        track.setYear(q.value(12).toInt());
-        track.setComposer(q.value(13).toString());
-        track.setPerformer(q.value(14).toString());
-        track.setGenres(q.value(15).toString().split(Constants::Separator, Qt::SkipEmptyParts));
-        track.setLyrics(q.value(16).toString());
-        track.setComment(q.value(17).toString());
-        track.setDuration(q.value(18).toULongLong());
-        track.setPlayCount(q.value(19).toInt());
-        // 20 - Rating
-        track.setFileSize(q.value(21).toInt());
-        track.setBitrate(q.value(22).toInt());
-        track.setSampleRate(q.value(23).toInt());
-        track.storeExtraTags(q.value(24).toByteArray());
-        track.setType(static_cast<Track::Type>(q.value(25).toInt()));
-        track.setAddedTime(q.value(26).toULongLong());
-        track.setModifiedTime(q.value(27).toULongLong());
-        track.setLibraryId(q.value(28).toInt());
-        track.setRelativePath(q.value(29).toString());
-
-        track.generateHash();
-
-        result.push_back(track);
+    if(q.next()) {
+        readToTrack(q, track);
     }
 
     return true;
 }
 
-int TrackDatabase::dbTrackCount() const
+bool TrackDatabase::reloadTracks(TrackList& tracks) const
 {
-    const QString queryText = u"SELECT COUNT(*) FROM Tracks"_s;
-    auto q                  = module()->runQuery(queryText, u"Cannot fetch track count"_s);
+    bool success{true};
 
-    if(!q.hasError() && q.next()) {
-        return q.value(0).toInt();
+    for(auto& track : tracks) {
+        if(!reloadTrack(track)) {
+            success = false;
+        }
     }
-    return -1;
+
+    return success;
+}
+
+TrackList TrackDatabase::getAllTracks() const
+{
+    DatabaseQuery q{this};
+    const QString query = fetchQueryTracks();
+    q.prepareQuery(query);
+
+    TrackList tracks;
+
+    if(!q.execQuery()) {
+        q.error(u"Cannot fetch tracks from database"_s);
+        return {};
+    }
+
+    const int numRows = p->trackCount();
+    if(numRows > 0) {
+        tracks.reserve(numRows);
+    }
+
+    while(q.next()) {
+        Track track;
+        readToTrack(q, track);
+        tracks.push_back(track);
+    }
+
+    return tracks;
+}
+
+TrackList TrackDatabase::tracksByHash(const QString& hash) const
+{
+    DatabaseQuery q{this};
+    const QString query = fetchQueryTracks() + " WHERE TrackHash = :trackHash";
+    q.prepareQuery(query);
+    q.bindQueryValue(u":trackHash"_s, hash);
+
+    TrackList tracks;
+
+    if(!q.execQuery()) {
+        q.error(u"Cannot fetch tracks from database"_s);
+        return tracks;
+    }
+
+    while(q.next()) {
+        Track track;
+        readToTrack(q, track);
+        tracks.push_back(track);
+    }
+
+    return tracks;
 }
 
 bool TrackDatabase::updateTrack(const Track& track)
 {
     if(track.id() < 0 || track.libraryId() < 0) {
-        qDebug() << "Cannot update track (value negative): "
-                 << " TrackID: " << track.id() << " LibraryID: " << track.libraryId();
+        qDebug() << QString{"Cannot update track %1 (TrackID: %2, LibraryID: %3)"}
+                        .arg(track.filepath())
+                        .arg(track.id())
+                        .arg(track.libraryId());
         return false;
     }
 
-    auto bindings = getTrackBindings(track);
-
-    const auto q = module()->update(u"Tracks"_s, bindings, {u"TrackID"_s, QString::number(track.id())},
-                                    "Cannot update track " + track.filepath());
+    auto bindings = trackBindings(track);
+    const auto q  = update(u"Tracks"_s, bindings, {u"TrackID"_s, QString::number(track.id())},
+                           "Cannot update track " + track.filepath());
 
     return !q.hasError();
 }
 
+bool TrackDatabase::updateTrackStats(Track& track)
+{
+    return p->insertOrUpdateStats(track);
+}
+
 bool TrackDatabase::deleteTrack(int id)
 {
-    const QString queryText = u"DELETE FROM Tracks WHERE TrackID = :TrackID;"_s;
-    const auto q            = module()->runQuery(queryText, {":TrackID", QString::number(id)},
-                                                 "Cannot delete track " + QString::number(id));
+    const QString queryText = u"DELETE FROM Tracks WHERE TrackID = :trackID;"_s;
+    const auto q = runQuery(queryText, {":trackID", QString::number(id)}, "Cannot delete track " + QString::number(id));
 
-    return (!q.hasError());
+    return !q.hasError();
 }
 
 bool TrackDatabase::deleteTracks(const TrackList& tracks)
@@ -238,7 +445,7 @@ bool TrackDatabase::deleteTracks(const TrackList& tracks)
         return true;
     }
 
-    if(!module()->db().transaction()) {
+    if(!db().transaction()) {
         qDebug() << "Transaction could not be started";
         return false;
     }
@@ -246,26 +453,15 @@ bool TrackDatabase::deleteTracks(const TrackList& tracks)
     const int fileCount = static_cast<int>(
         std::ranges::count_if(std::as_const(tracks), [this](const Track& track) { return deleteTrack(track.id()); }));
 
-    const auto success = module()->db().commit();
+    const auto success = db().commit();
 
     return (success && (fileCount == static_cast<int>(tracks.size())));
 }
 
-bool TrackDatabase::cleanupTracks()
+void TrackDatabase::cleanupTracks()
 {
-    const QString queryText
-        = u"DELETE FROM Tracks WHERE LibraryID = 0 AND TrackID NOT IN (SELECT TrackID FROM PlaylistTracks);"_s;
-    const auto q = module()->runQuery(queryText, u"Cannot cleanup tracks"_s);
-
-    return (!q.hasError());
-}
-
-int TrackDatabase::insertTrack(const Track& track)
-{
-    auto bindings = getTrackBindings(track);
-
-    const auto query = module()->insert(u"Tracks"_s, bindings, "Cannot insert track " + track.filepath());
-
-    return (query.hasError()) ? -1 : query.lastInsertId().toInt();
+    p->removeUnmanagedTracks();
+    p->markUnusedStatsForDelete();
+    p->deleteExpiredStats();
 }
 } // namespace Fooyin

--- a/src/core/database/trackdatabase.cpp
+++ b/src/core/database/trackdatabase.cpp
@@ -240,7 +240,7 @@ struct TrackDatabase::Private
                     changed = true;
                     bindings.emplace(u"AddedDate"_s, QString::number(track.addedTime()));
                 }
-                else {
+                else if(added > 0) {
                     track.setAddedTime(added);
                 }
             }
@@ -249,7 +249,7 @@ struct TrackDatabase::Private
                     changed = true;
                     bindings.emplace(u"FirstPlayed"_s, QString::number(track.firstPlayed()));
                 }
-                else {
+                else if(firstPlayed > 0) {
                     track.setFirstPlayed(firstPlayed);
                 }
             }
@@ -258,7 +258,7 @@ struct TrackDatabase::Private
                     changed = true;
                     bindings.emplace(u"LastPlayed"_s, QString::number(track.lastPlayed()));
                 }
-                else {
+                else if(lastPlayed > 0) {
                     track.setLastPlayed(lastPlayed);
                 }
             }

--- a/src/core/database/trackdatabase.cpp
+++ b/src/core/database/trackdatabase.cpp
@@ -235,37 +235,42 @@ struct TrackDatabase::Private
             bool changed{false};
             BindingsMap bindings;
 
-            if(track.addedTime() != added) {
-                if(added == 0 || track.addedTime() < added) {
+            const uint64_t trackAdded       = track.addedTime();
+            const uint64_t trackFirstPlayed = track.firstPlayed();
+            const uint64_t trackLastPlayed  = track.lastPlayed();
+            const int trackPlayCount        = track.playCount();
+
+            if(trackAdded != added) {
+                if(added == 0 || (trackAdded > 0 && trackAdded < added)) {
                     changed = true;
-                    bindings.emplace(u"AddedDate"_s, QString::number(track.addedTime()));
+                    bindings.emplace(u"AddedDate"_s, QString::number(trackAdded));
                 }
-                else if(added > 0) {
+                else {
                     track.setAddedTime(added);
                 }
             }
-            if(track.firstPlayed() != firstPlayed) {
-                if(firstPlayed == 0 || track.firstPlayed() < firstPlayed) {
+            if(trackFirstPlayed != firstPlayed) {
+                if(firstPlayed == 0 || (trackFirstPlayed > 0 && trackFirstPlayed < firstPlayed)) {
                     changed = true;
-                    bindings.emplace(u"FirstPlayed"_s, QString::number(track.firstPlayed()));
+                    bindings.emplace(u"FirstPlayed"_s, QString::number(trackFirstPlayed));
                 }
-                else if(firstPlayed > 0) {
+                else {
                     track.setFirstPlayed(firstPlayed);
                 }
             }
-            if(track.lastPlayed() != lastPlayed) {
-                if(track.lastPlayed() > lastPlayed) {
+            if(trackLastPlayed != lastPlayed) {
+                if(trackLastPlayed > lastPlayed) {
                     changed = true;
-                    bindings.emplace(u"LastPlayed"_s, QString::number(track.lastPlayed()));
+                    bindings.emplace(u"LastPlayed"_s, QString::number(trackLastPlayed));
                 }
-                else if(lastPlayed > 0) {
+                else {
                     track.setLastPlayed(lastPlayed);
                 }
             }
-            if(track.playCount() != playCount) {
-                if(track.playCount() > playCount) {
+            if(trackPlayCount != playCount) {
+                if(trackPlayCount > playCount) {
                     changed = true;
-                    bindings.emplace(u"PlayCount"_s, QString::number(track.playCount()));
+                    bindings.emplace(u"PlayCount"_s, QString::number(trackPlayCount));
                 }
                 else {
                     track.setPlayCount(playCount);

--- a/src/core/database/trackdatabase.h
+++ b/src/core/database/trackdatabase.h
@@ -28,22 +28,25 @@ class TrackDatabase : public DatabaseModule
 {
 public:
     explicit TrackDatabase(const QString& connectionName);
+    ~TrackDatabase() override;
 
     bool storeTracks(TrackList& tracksToStore);
 
-    bool getAllTracks(TrackList& result);
-
-    [[nodiscard]] bool dbFetchTracks(DatabaseQuery& q, TrackList& result) const;
-    [[nodiscard]] int dbTrackCount() const;
+    bool reloadTrack(Track& track) const;
+    bool reloadTracks(TrackList& tracks) const;
+    TrackList getAllTracks() const;
+    TrackList tracksByHash(const QString& hash) const;
 
     bool updateTrack(const Track& track);
+    bool updateTrackStats(Track& track);
+
     bool deleteTrack(int id);
     bool deleteTracks(const TrackList& tracks);
-    bool cleanupTracks();
+
+    void cleanupTracks();
 
 private:
-    int insertTrack(const Track& track);
-
-    QString m_connectionName;
+    struct Private;
+    std::unique_ptr<Private> p;
 };
 } // namespace Fooyin

--- a/src/core/library/libraryscanner.cpp
+++ b/src/core/library/libraryscanner.cpp
@@ -23,7 +23,6 @@
 #include "database/trackdatabase.h"
 #include "library/libraryinfo.h"
 #include "tagging/tagreader.h"
-#include "tagging/tagwriter.h"
 
 #include <core/track.h>
 #include <utils/fileutils.h>
@@ -42,7 +41,6 @@ struct LibraryScanner::Private
     TrackDatabase trackDatabase;
 
     TagReader tagReader;
-    TagWriter tagWriter;
 
     int tracksProcessed{0};
     double totalTracks{0};
@@ -266,15 +264,6 @@ void LibraryScanner::scanTracks(const TrackList& libraryTracks, const TrackList&
     emit scannedTracks(tracksScanned);
 
     handleFinished();
-}
-
-void LibraryScanner::updateTracks(const TrackList& tracks)
-{
-    for(const Track& track : tracks) {
-        if(p->tagWriter.writeMetaData(track)) {
-            p->trackDatabase.updateTrack(track);
-        }
-    }
 }
 } // namespace Fooyin
 

--- a/src/core/library/libraryscanner.h
+++ b/src/core/library/libraryscanner.h
@@ -54,7 +54,6 @@ signals:
 public slots:
     void scanLibrary(const LibraryInfo& library, const TrackList& tracks);
     void scanTracks(const TrackList& libraryTracks, const TrackList& tracks);
-    void updateTracks(const TrackList& tracks);
 
 private:
     struct Private;

--- a/src/core/library/librarythreadhandler.cpp
+++ b/src/core/library/librarythreadhandler.cpp
@@ -172,6 +172,8 @@ LibraryThreadHandler::LibraryThreadHandler(Database* database, MusicLibrary* lib
 {
     QObject::connect(&p->trackDatabaseManager, &TrackDatabaseManager::gotTracks, this,
                      &LibraryThreadHandler::gotTracks);
+    QObject::connect(&p->trackDatabaseManager, &TrackDatabaseManager::updatedTracks, this,
+                     &LibraryThreadHandler::tracksUpdated);
     QObject::connect(&p->scanner, &Worker::finished, this, [this]() { p->finishScanRequest(); });
     QObject::connect(&p->scanner, &LibraryScanner::progressChanged, this,
                      [this](int percent) { emit progressChanged(p->currentRequestId, percent); });
@@ -221,7 +223,12 @@ void LibraryThreadHandler::libraryRemoved(int id)
 
 void LibraryThreadHandler::saveUpdatedTracks(const TrackList& tracks)
 {
-    QMetaObject::invokeMethod(&p->scanner, "updateTracks", Q_ARG(const TrackList&, tracks));
+    QMetaObject::invokeMethod(&p->trackDatabaseManager, "updateTracks", Q_ARG(const TrackList&, tracks));
+}
+
+void LibraryThreadHandler::saveUpdatedTrackStats(const Track& track)
+{
+    QMetaObject::invokeMethod(&p->trackDatabaseManager, "updateTrackStats", Q_ARG(const Track&, track));
 }
 
 void LibraryThreadHandler::cleanupTracks()

--- a/src/core/library/librarythreadhandler.h
+++ b/src/core/library/librarythreadhandler.h
@@ -44,6 +44,7 @@ public:
     ScanRequest* scanTracks(const TrackList& tracks);
 
     void saveUpdatedTracks(const TrackList& tracks);
+    void saveUpdatedTrackStats(const Track& track);
     void cleanupTracks();
 
     void libraryRemoved(int id);
@@ -54,6 +55,7 @@ signals:
     void scanUpdate(const ScanResult& result);
     void scannedTracks(const TrackList& tracks);
     void tracksDeleted(const TrackList& tracks);
+    void tracksUpdated(const TrackList& tracks);
 
     void gotTracks(const TrackList& result);
 

--- a/src/core/library/trackdatabasemanager.h
+++ b/src/core/library/trackdatabasemanager.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "database/trackdatabase.h"
+#include "tagging/tagwriter.h"
 
 #include <utils/worker.h>
 
@@ -35,14 +36,19 @@ public:
 
     void closeThread() override;
 
-    void getAllTracks();
-    void cleanupTracks();
-
 signals:
-    void gotTracks(const TrackList& result);
+    void gotTracks(const TrackList& tracks);
+    void updatedTracks(const TrackList& tracks);
+
+public slots:
+    void getAllTracks();
+    void updateTracks(const TrackList& tracks);
+    void updateTrackStats(const Track& track);
+    void cleanupTracks();
 
 private:
     Database* m_database;
     TrackDatabase m_trackDatabase;
+    TagWriter m_tagWriter;
 };
 } // namespace Fooyin

--- a/src/core/library/unifiedmusiclibrary.h
+++ b/src/core/library/unifiedmusiclibrary.h
@@ -50,7 +50,9 @@ public:
     [[nodiscard]] TrackList tracksForIds(const TrackIds& ids) const override;
 
     void updateTrackMetadata(const TrackList& tracks) override;
+    void updateTrackStats(const Track& track) override;
 
+    void trackWasPlayed(const Track& track);
     void cleanupTracks();
 
 private:

--- a/src/core/player/playercontroller.cpp
+++ b/src/core/player/playercontroller.cpp
@@ -113,10 +113,8 @@ void PlayerController::setCurrentPosition(uint64_t ms)
     p->position = ms;
     // TODO: Only increment playCount based on total time listened excluding seeking.
     if(!p->counted && ms >= p->totalDuration / 2) {
-        // TODO: Save playCounts to db.
-        int playCount = p->currentTrack.playCount();
-        p->currentTrack.setPlayCount(++playCount);
         p->counted = true;
+        emit trackPlayed(p->currentTrack);
     }
     emit positionChanged(ms);
 }

--- a/src/core/playlist/playlist.cpp
+++ b/src/core/playlist/playlist.cpp
@@ -116,6 +116,14 @@ TrackList Playlist::tracks() const
     return p->tracks;
 }
 
+std::optional<Track> Playlist::track(int index) const
+{
+    if(p->tracks.empty() || index < 0 || index >= trackCount()) {
+        return {};
+    }
+    return p->tracks.at(index);
+}
+
 int Playlist::trackCount() const
 {
     return static_cast<int>(p->tracks.size());

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -64,6 +64,8 @@ struct Track::Private : public QSharedData
 
     uint64_t addedTime{0};
     uint64_t modifiedTime{0};
+    uint64_t firstPlayed{0};
+    uint64_t lastPlayed{0};
 
     QString sort;
 
@@ -97,7 +99,7 @@ Track& Track::operator=(const Track& other) = default;
 QString Track::generateHash()
 {
     p->hash = Utils::generateHash(p->artists.join(","_L1), p->album, QString::number(p->discNumber),
-                                  QString::number(p->trackNumber), p->title, QString::number(p->duration));
+                                  QString::number(p->trackNumber), p->title);
     return p->hash;
 }
 
@@ -340,6 +342,16 @@ uint64_t Track::modifiedTime() const
     return p->modifiedTime;
 }
 
+uint64_t Track::firstPlayed() const
+{
+    return p->firstPlayed;
+}
+
+uint64_t Track::lastPlayed() const
+{
+    return p->lastPlayed;
+}
+
 QString Track::sort() const
 {
     return p->sort;
@@ -370,6 +382,11 @@ void Track::setType(Type type)
     p->type = type;
 }
 
+void Track::setFilePath(const QString& path)
+{
+    p->filepath = path;
+}
+
 void Track::setRelativePath(const QString& path)
 {
     p->relativePath = path;
@@ -378,16 +395,28 @@ void Track::setRelativePath(const QString& path)
 void Track::setTitle(const QString& title)
 {
     p->title = title;
+
+    if(!p->hash.isEmpty()) {
+        generateHash();
+    }
 }
 
 void Track::setArtists(const QStringList& artists)
 {
     p->artists = artists;
+
+    if(!p->hash.isEmpty()) {
+        generateHash();
+    }
 }
 
 void Track::setAlbum(const QString& title)
 {
     p->album = title;
+
+    if(!p->hash.isEmpty()) {
+        generateHash();
+    }
 }
 
 void Track::setAlbumArtist(const QString& artist)
@@ -398,6 +427,10 @@ void Track::setAlbumArtist(const QString& artist)
 void Track::setTrackNumber(int number)
 {
     p->trackNumber = number;
+
+    if(!p->hash.isEmpty()) {
+        generateHash();
+    }
 }
 
 void Track::setTrackTotal(int total)
@@ -408,6 +441,10 @@ void Track::setTrackTotal(int total)
 void Track::setDiscNumber(int number)
 {
     p->discNumber = number;
+
+    if(!p->hash.isEmpty()) {
+        generateHash();
+    }
 }
 
 void Track::setDiscTotal(int total)
@@ -450,7 +487,12 @@ void Track::setDate(const QString& date)
     p->date = date;
 
     const QStringList dateParts = date.split('-');
-    if(!dateParts.empty()) {
+    if(dateParts.empty()) {
+        if(date.length() == 4) {
+            p->year = p->date.toInt();
+        }
+    }
+    else {
         p->year = dateParts.front().toInt();
     }
 }
@@ -533,6 +575,20 @@ void Track::setAddedTime(uint64_t time)
 void Track::setModifiedTime(uint64_t time)
 {
     p->modifiedTime = time;
+}
+
+void Track::setFirstPlayed(uint64_t time)
+{
+    if(p->firstPlayed == 0) {
+        p->firstPlayed = time;
+    }
+}
+
+void Track::setLastPlayed(uint64_t time)
+{
+    if(time > p->lastPlayed) {
+        p->lastPlayed = time;
+    }
 }
 
 void Track::setSort(const QString& sort)

--- a/src/gui/playlist/playlistcontroller.cpp
+++ b/src/gui/playlist/playlistcontroller.cpp
@@ -82,9 +82,6 @@ struct PlaylistController::Private
             histories.erase(playlist->id());
             states.erase(playlist->id());
         }
-        if(currentPlaylist == playlist) {
-            self->changeCurrentPlaylist(playlist);
-        }
     }
 
     void handlePlaylistRemoved(const Playlist* playlist) const

--- a/src/gui/playlist/playlistmodel.h
+++ b/src/gui/playlist/playlistmodel.h
@@ -87,6 +87,7 @@ public:
 
     QModelIndex indexAtTrackIndex(int index);
     void insertTracks(const TrackGroups& tracks);
+    void updateTracks(const std::vector<int>& indexes);
     void removeTracks(const QModelIndexList& indexes);
     void removeTracks(const TrackGroups& groups);
     void updateHeader(Playlist* playlist);

--- a/src/gui/playlist/playlistmodel_p.cpp
+++ b/src/gui/playlist/playlistmodel_p.cpp
@@ -766,6 +766,7 @@ PlaylistModelPrivate::PlaylistModelPrivate(PlaylistModel* model, MusicLibrary* l
     , isActivePlaylist{false}
     , currentPlaylist{nullptr}
     , currentPlayState{PlayState::Stopped}
+    , currentIndex{-1}
 {
     populator.moveToThread(&populatorThread);
     populatorThread.start();
@@ -1427,8 +1428,6 @@ void PlaylistModelPrivate::removeTracks(const QModelIndexList& indexes)
 {
     const ParentChildRangesList indexGroups = determineRowGroups(indexes);
 
-    model->tracksAboutToBeChanged();
-
     for(const auto& [parent, groups] : indexGroups) {
         for(const auto& children : groups | std::views::reverse) {
             removePlaylistRows(children.first, children.count(), parent);
@@ -1437,8 +1436,6 @@ void PlaylistModelPrivate::removeTracks(const QModelIndexList& indexes)
 
     cleanupHeaders();
     updateTrackIndexes();
-
-    model->tracksChanged();
 }
 
 void PlaylistModelPrivate::coverUpdated(const Track& track)

--- a/src/gui/playlist/playlistmodel_p.h
+++ b/src/gui/playlist/playlistmodel_p.h
@@ -167,5 +167,6 @@ public:
     PlayState currentPlayState;
     Track currentPlayingTrack;
     QPersistentModelIndex currentPlayingIndex;
+    int currentIndex;
 };
 } // namespace Fooyin

--- a/src/gui/playlist/playlistwidget_p.h
+++ b/src/gui/playlist/playlistwidget_p.h
@@ -66,8 +66,12 @@ public:
 
     void resetTree() const;
     [[nodiscard]] PlaylistViewState getState() const;
+    void saveState() const;
     void restoreState() const;
     void resetModel() const;
+
+    std::vector<int> selectedPlaylistIndexes() const;
+    void restoreSelectedPlaylistIndexes(const std::vector<int>& indexes);
 
     [[nodiscard]] bool isHeaderHidden() const;
     [[nodiscard]] bool isScrollbarHidden() const;
@@ -75,13 +79,14 @@ public:
     void setHeaderHidden(bool showHeader) const;
     void setScrollbarHidden(bool showScrollBar) const;
     void selectionChanged() const;
-    void playlistTracksChanged(int index) const;
+    void trackIndexesChanged(int playingIndex) const;
 
     QCoro::Task<void> scanDroppedTracks(TrackList tracks, int index);
     void tracksInserted(const TrackGroups& tracks) const;
     void tracksRemoved() const;
     void tracksMoved(const MoveOperation& operation) const;
     void playlistTracksAdded(Playlist* playlist, const TrackList& tracks, int index) const;
+    void handleTracksChanged(Playlist* playlist, const std::vector<int>& indexes);
 
     QCoro::Task<void> toggleColumnMode();
     void customHeaderMenuRequested(const QPoint& pos);
@@ -91,7 +96,7 @@ public:
     void doubleClicked(const QModelIndex& index) const;
 
     void followCurrentTrack(const Track& track, int index) const;
-    
+
     QCoro::Task<void> sortTracks(QString script);
     QCoro::Task<void> sortColumn(int column, Qt::SortOrder order);
 


### PR DESCRIPTION
Moves playcount, rating and added date to a separate 'TrackStats' table with the hash of the track as the primary key. This allows playback statistics to be shared for the same track in different formats, and also allows the statistics to persist after a track is deleted or moved. Statistics are removed if a track with the associated hash hasn't been seen for more than 4 weeks.

The date of the first and last time a track was played have also been added, along with improvements to updating track metadata (tracks are now only updated in MusicLibrary if the metadata was successfully written to file and database). PlaylistWidget can now also handle track updates rather than resetting the entire model.