### PR TITLE
Store and handle audio data in AudioBuffer

### DIFF
--- a/include/core/engine/audiobuffer.h
+++ b/include/core/engine/audiobuffer.h
@@ -21,24 +21,20 @@
 
 #include <core/engine/audioformat.h>
 
-extern "C"
-{
-#include <libavutil/samplefmt.h>
-}
-
-class QString;
-class AVFrame;
-class AVCodecParameters;
+#include <cstdint>
 
 namespace Fooyin {
-class FFmpegAudioBuffer;
+class AudioBuffer
+{
+public:
+    virtual ~AudioBuffer() { }
 
-namespace Utils {
-void printError(int error);
-void printError(const QString& error);
-AVSampleFormat interleaveFormat(AVSampleFormat planarFormat);
-AudioFormat audioFormatFromCodec(AVCodecParameters* codec);
-void fillSilence(uint8_t* dst, int bytes, const AudioFormat& format);
-void adjustVolumeOfSamples(uint8_t* data, const AudioFormat& format, int bytes, double volume);
-} // namespace Utils
+    virtual AudioFormat format() const = 0;
+    virtual int frameCount() const     = 0;
+    virtual uint64_t startTime() const = 0;
+    virtual uint64_t duration() const  = 0;
+
+    virtual uint8_t* constData() const = 0;
+    virtual uint8_t* data()            = 0;
+};
 } // namespace Fooyin

--- a/include/core/engine/audioformat.h
+++ b/include/core/engine/audioformat.h
@@ -1,0 +1,74 @@
+/*
+ * Fooyin
+ * Copyright 2022-2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fycore_export.h"
+
+#include <cstdint>
+#include <tuple>
+
+namespace Fooyin {
+// TODO: Handle channel layout
+class FYCORE_EXPORT AudioFormat
+{
+public:
+    enum SampleFormat : uint16_t
+    {
+        Unknown,
+        UInt8,
+        Int16,
+        Int32,
+        Float,
+        Double,
+    };
+
+    AudioFormat();
+
+    bool operator==(const AudioFormat& other);
+    bool operator!=(const AudioFormat& other);
+
+    bool isValid() const;
+
+    int sampleRate() const;
+    int channelCount() const;
+    SampleFormat sampleFormat() const;
+
+    void setSampleRate(int sampleRate);
+    void setChannelCount(int channelCount);
+    void setSampleFormat(SampleFormat format);
+
+    int bytesForDuration(uint64_t ms) const;
+    uint64_t durationForBytes(int byteCount) const;
+
+    int bytesForFrames(int frameCount) const;
+    int framesForBytes(int byteCount) const;
+
+    int framesForDuration(uint64_t ms) const;
+    uint64_t durationForFrames(int frameCount) const;
+
+    int bytesPerFrame() const;
+    int bytesPerSample() const;
+
+private:
+    SampleFormat m_sampleFormat;
+    int m_channelCount;
+    int m_sampleRate;
+};
+} // namespace Fooyin

--- a/include/core/engine/audiooutput.h
+++ b/include/core/engine/audiooutput.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <core/engine/audioformat.h>
+
 #include "fycore_export.h"
 
 #include <QString>
@@ -33,19 +35,16 @@ using WriteFunction = std::function<int(uint8_t*, int)>;
 
 struct OutputContext
 {
-    int sampleRate;
+    AudioFormat format;
     AVChannelLayout channelLayout;
-    AVSampleFormat format;
-    int sstride; // Size of a sample
     double volume{1.0};
 
     WriteFunction writeAudioToBuffer;
 
     bool operator==(const OutputContext& other)
     {
-        return std::tie(sampleRate, channelLayout.nb_channels, channelLayout.order, format, sstride)
-            == std::tie(other.sampleRate, other.channelLayout.nb_channels, other.channelLayout.order, other.format,
-                        other.sstride);
+        return std::tie(channelLayout.nb_channels, channelLayout.order, format)
+            == std::tie(other.channelLayout.nb_channels, other.channelLayout.order, other.format);
     }
 };
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
     ${CMAKE_SOURCE_DIR}/include/core/player/playermanager.h
     ${CMAKE_SOURCE_DIR}/include/core/playlist/playlistmanager.h
     track.cpp
+    engine/audioformat.cpp
     engine/audiooutput.cpp
     library/trackfilter.cpp
     library/tracksort.cpp
@@ -40,6 +41,7 @@ set(PRIVATE_SOURCES
     database/databasequery.cpp
     engine/enginehandler.cpp
     engine/audioengine.cpp
+    engine/ffmpeg/ffmpegaudiobuffer.cpp
     engine/ffmpeg/ffmpegclock.cpp
     engine/ffmpeg/ffmpegrenderer.cpp
     engine/ffmpeg/ffmpegworker.cpp

--- a/src/core/engine/audioformat.cpp
+++ b/src/core/engine/audioformat.cpp
@@ -17,7 +17,6 @@
  *
  */
 
-#include <bits/chrono.h>
 #include <core/engine/audioformat.h>
 
 namespace Fooyin {

--- a/src/core/engine/audioformat.cpp
+++ b/src/core/engine/audioformat.cpp
@@ -1,0 +1,147 @@
+/*
+ * Fooyin
+ * Copyright 2022-2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <bits/chrono.h>
+#include <core/engine/audioformat.h>
+
+namespace Fooyin {
+AudioFormat::AudioFormat()
+    : m_sampleFormat{Unknown}
+    , m_channelCount{0}
+    , m_sampleRate{0}
+{ }
+
+bool AudioFormat::operator==(const AudioFormat& other)
+{
+    return std::tie(m_sampleFormat, m_channelCount, m_sampleRate)
+        == std::tie(other.m_sampleFormat, other.m_channelCount, other.m_sampleRate);
+}
+
+bool AudioFormat::operator!=(const AudioFormat& other)
+{
+    return !(*this == other);
+}
+
+bool AudioFormat::isValid() const
+{
+    return m_sampleRate > 0 && m_channelCount > 0 && m_sampleFormat != Unknown;
+}
+
+int AudioFormat::sampleRate() const
+{
+    return m_sampleRate;
+}
+
+int AudioFormat::channelCount() const
+{
+    return m_channelCount;
+}
+
+AudioFormat::SampleFormat AudioFormat::sampleFormat() const
+{
+    return m_sampleFormat;
+}
+
+void AudioFormat::setSampleRate(int sampleRate)
+{
+    m_sampleRate = sampleRate;
+}
+
+void AudioFormat::setChannelCount(int channelCount)
+{
+    m_channelCount = channelCount;
+}
+
+void AudioFormat::setSampleFormat(SampleFormat format)
+{
+    m_sampleFormat = format;
+}
+
+int AudioFormat::bytesForDuration(uint64_t ms) const
+{
+    return bytesPerFrame() * framesForDuration(ms);
+}
+
+uint64_t AudioFormat::durationForBytes(int byteCount) const
+{
+    if(!isValid() || byteCount <= 0) {
+        return 0;
+    }
+
+    return static_cast<uint64_t>((1000LL * (byteCount / bytesPerFrame())) / sampleRate());
+}
+
+int AudioFormat::bytesForFrames(int frameCount) const
+{
+    return frameCount * bytesPerFrame();
+}
+
+int AudioFormat::framesForBytes(int byteCount) const
+{
+    const int size = bytesPerFrame();
+
+    if(size > 0) {
+        return byteCount / size;
+    }
+
+    return 0;
+}
+
+int AudioFormat::framesForDuration(uint64_t ms) const
+{
+    if(!isValid()) {
+        return 0;
+    }
+
+    return static_cast<int>(((ms * sampleRate()) / 1000LL));
+}
+
+uint64_t AudioFormat::durationForFrames(int frameCount) const
+{
+    if(!isValid() || frameCount <= 0) {
+        return 0;
+    }
+
+    return (frameCount * 1000LL) / sampleRate();
+}
+
+int AudioFormat::bytesPerFrame() const
+{
+    return bytesPerSample() * channelCount();
+}
+
+int AudioFormat::bytesPerSample() const
+{
+    switch(m_sampleFormat) {
+        case(Unknown):
+            return 0;
+        case(UInt8):
+            return 1;
+        case(Int16):
+            return 2;
+        case(Int32):
+        case(Float):
+            return 4;
+        case Double:
+            return 8;
+    }
+
+    return 0;
+}
+} // namespace Fooyin

--- a/src/core/engine/ffmpeg/ffmpegaudiobuffer.cpp
+++ b/src/core/engine/ffmpeg/ffmpegaudiobuffer.cpp
@@ -1,0 +1,101 @@
+/*
+ * Fooyin
+ * Copyright 2022-2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ffmpegaudiobuffer.h"
+
+#include <utility>
+
+namespace Fooyin {
+class FFmpegAudioBufferPrivate : public QSharedData
+{
+public:
+    QByteArray data;
+    AudioFormat format;
+    uint64_t startTime;
+
+    FFmpegAudioBufferPrivate(QByteArray data, AudioFormat format, uint64_t startTime)
+        : data{std::move(data)}
+        , format{format}
+        , startTime{startTime}
+    { }
+};
+
+FFmpegAudioBuffer::FFmpegAudioBuffer() = default;
+
+FFmpegAudioBuffer::FFmpegAudioBuffer(QByteArray data, AudioFormat format, uint64_t startTime)
+    : p{new FFmpegAudioBufferPrivate(std::move(data), format, startTime)}
+{ }
+
+FFmpegAudioBuffer::~FFmpegAudioBuffer() = default;
+
+FFmpegAudioBuffer::FFmpegAudioBuffer(FFmpegAudioBuffer&& other) noexcept = default;
+FFmpegAudioBuffer::FFmpegAudioBuffer(const FFmpegAudioBuffer& other)     = default;
+
+FFmpegAudioBuffer& FFmpegAudioBuffer::operator=(const FFmpegAudioBuffer& other) = default;
+
+bool FFmpegAudioBuffer::isValid() const
+{
+    return !!p;
+}
+
+void FFmpegAudioBuffer::detach()
+{
+    p = new FFmpegAudioBufferPrivate(*p);
+}
+
+AudioFormat FFmpegAudioBuffer::format() const
+{
+    return !!p ? p->format : AudioFormat{};
+}
+
+int FFmpegAudioBuffer::frameCount() const
+{
+    return !!p ? p->format.framesForBytes(byteCount()) : 0;
+}
+
+int FFmpegAudioBuffer::sampleCount() const
+{
+    return frameCount() * format().channelCount();
+}
+
+int FFmpegAudioBuffer::byteCount() const
+{
+    return !!p ? static_cast<int>(p->data.size()) : 0;
+}
+
+uint64_t FFmpegAudioBuffer::startTime() const
+{
+    return !!p ? p->startTime : -1;
+}
+
+uint64_t FFmpegAudioBuffer::duration() const
+{
+    return format().durationForFrames(frameCount());
+}
+
+uint8_t* FFmpegAudioBuffer::constData() const
+{
+    return std::bit_cast<uint8_t*>(p->data.constData());
+}
+
+uint8_t* FFmpegAudioBuffer::data()
+{
+    return std::bit_cast<uint8_t*>(p->data.data());
+}
+} // namespace Fooyin

--- a/src/core/engine/ffmpeg/ffmpegaudiobuffer.h
+++ b/src/core/engine/ffmpeg/ffmpegaudiobuffer.h
@@ -1,0 +1,62 @@
+/*
+ * Fooyin
+ * Copyright 2022-2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/engine/audiobuffer.h>
+#include <core/engine/audioformat.h>
+
+extern "C"
+{
+#include <libavutil/samplefmt.h>
+}
+
+#include <QExplicitlySharedDataPointer>
+
+namespace Fooyin {
+class FFmpegAudioBufferPrivate;
+
+class FFmpegAudioBuffer : public AudioBuffer
+{
+public:
+    FFmpegAudioBuffer();
+    FFmpegAudioBuffer(QByteArray data, AudioFormat format, uint64_t startTime);
+    ~FFmpegAudioBuffer() override;
+
+    FFmpegAudioBuffer(const FFmpegAudioBuffer& other);
+    FFmpegAudioBuffer& operator=(const FFmpegAudioBuffer& other);
+    FFmpegAudioBuffer(FFmpegAudioBuffer&& other) noexcept;
+
+    bool isValid() const;
+    void detach();
+
+    AudioFormat format() const override;
+    int frameCount() const override;
+    int sampleCount() const;
+    int byteCount() const;
+    uint64_t startTime() const override;
+    uint64_t duration() const override;
+
+    uint8_t* constData() const override;
+    uint8_t* data() override;
+
+private:
+    QExplicitlySharedDataPointer<FFmpegAudioBufferPrivate> p;
+};
+} // namespace Fooyin

--- a/src/core/engine/ffmpeg/ffmpegdecoder.h
+++ b/src/core/engine/ffmpeg/ffmpegdecoder.h
@@ -19,13 +19,14 @@
 
 #pragma once
 
-#include "ffmpegframe.h"
 #include "ffmpegworker.h"
 
 class AVFormatContext;
 
 namespace Fooyin {
+class AudioFormat;
 class Codec;
+class FFmpegAudioBuffer;
 
 class Decoder : public EngineWorker
 {
@@ -35,15 +36,15 @@ public:
     explicit Decoder(QObject* parent = nullptr);
     ~Decoder() override;
 
-    void run(AVFormatContext* context, Codec* codec);
+    void run(AVFormatContext* context, Codec* codec, const AudioFormat& format);
     void reset() override;
     void kill() override;
 
 public slots:
-    void onFrameProcessed();
+    void onBufferProcessed();
 
 signals:
-    void requestHandleFrame(Frame frame);
+    void audioBufferDecoded(const FFmpegAudioBuffer& buffer);
 
 protected:
     bool canDoNextStep() const override;

--- a/src/core/engine/ffmpeg/ffmpegrenderer.h
+++ b/src/core/engine/ffmpeg/ffmpegrenderer.h
@@ -19,13 +19,13 @@
 
 #pragma once
 
-#include "ffmpegframe.h"
 #include "ffmpegworker.h"
 
 namespace Fooyin {
 class AudioOutput;
 class Codec;
 struct OutputContext;
+class FFmpegAudioBuffer;
 
 class Renderer : public EngineWorker
 {
@@ -45,10 +45,10 @@ public:
     void updateVolume(double volume);
 
 public slots:
-    void render(Frame frame);
+    void render(const FFmpegAudioBuffer& buffer);
 
 signals:
-    void frameProcessed(Frame frame);
+    void audioBufferProcessed(const FFmpegAudioBuffer& buffer);
 
 private:
     bool canDoNextStep() const override;


### PR DESCRIPTION
Stores audio data in a more general AudioBuffer structure rather than passing around Frames (AVFrames). This will open up the public API to support audio probes in the future which can receive audio data as it's played.

Additionally create an AudioFormat structure to better represent the supported audio formats and move away from relying on the specific FFmpeg constructs. This also allows us to provide a range of convenience methods for querying an audio format (sample rate, stride, bps etc).