### PR TITLE
Add a directory browser widget

### DIFF
--- a/include/gui/guiconstants.h
+++ b/include/gui/guiconstants.h
@@ -150,5 +150,6 @@ constexpr auto LibraryTreeAppearance = "Fooyin.Page.Widgets.LibraryTree.Appearan
 constexpr auto StatusWidget          = "Fooyin.Page.Widgets.Status";
 constexpr auto Plugins               = "Fooyin.Page.Plugins";
 constexpr auto Shortcuts             = "Fooyin.Page.Shortcuts";
+constexpr auto DirBrowser            = "Fooyin.Page.Widgets.DirBrowser";
 } // namespace Page
 } // namespace Fooyin::Constants

--- a/include/utils/fileutils.h
+++ b/include/utils/fileutils.h
@@ -36,6 +36,7 @@ FYUTILS_EXPORT bool createDirectories(const QString& path);
 FYUTILS_EXPORT void openDirectory(const QString& dir);
 
 FYUTILS_EXPORT QStringList getFilesInDir(const QDir& baseDirectory, const QStringList& fileExtensions = {});
+FYUTILS_EXPORT QList<QUrl> getUrlsInDir(const QDir& baseDirectory, const QStringList& fileExtensions = {});
 FYUTILS_EXPORT QStringList getFiles(const QStringList& paths, const QStringList& fileExtensions = {});
 FYUTILS_EXPORT QStringList getFiles(const QList<QUrl>& urls, const QStringList& fileExtensions = {});
 FYUTILS_EXPORT QStringList getAllSubdirectories(const QDir& dir);

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -135,6 +135,8 @@ set(SOURCES
     settings/generalpage.h
     settings/guigeneralpage.cpp
     settings/guigeneralpage.h
+    settings/dirbrowser/dirbrowserpage.cpp
+    settings/dirbrowser/dirbrowserpage.h
     settings/library/librarygeneralpage.cpp
     settings/library/librarygeneralpage.h
     settings/library/librarymodel.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -41,6 +41,8 @@ set(SOURCES
     dialog/propertiesdialog.cpp
     dirbrowser/dirbrowser.cpp
     dirbrowser/dirbrowser.h
+    dirbrowser/dirdelegate.cpp
+    dirbrowser/dirdelegate.h
     dirbrowser/dirproxymodel.cpp
     dirbrowser/dirproxymodel.h
     dirbrowser/dirtree.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -43,6 +43,8 @@ set(SOURCES
     dirbrowser/dirbrowser.h
     dirbrowser/dirproxymodel.cpp
     dirbrowser/dirproxymodel.h
+    dirbrowser/dirtree.cpp
+    dirbrowser/dirtree.h
     info/infodelegate.cpp
     info/infodelegate.h
     info/infomodel.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -39,6 +39,10 @@ set(SOURCES
     dialog/aboutdialog.cpp
     dialog/aboutdialog.h
     dialog/propertiesdialog.cpp
+    dirbrowser/dirbrowser.cpp
+    dirbrowser/dirbrowser.h
+    dirbrowser/dirproxymodel.cpp
+    dirbrowser/dirproxymodel.h
     info/infodelegate.cpp
     info/infodelegate.h
     info/infomodel.cpp

--- a/src/gui/dirbrowser/dirbrowser.cpp
+++ b/src/gui/dirbrowser/dirbrowser.cpp
@@ -19,6 +19,7 @@
 
 #include "dirbrowser.h"
 
+#include "dirtree.h"
 #include "internalguisettings.h"
 #include "playlist/playlistcontroller.h"
 
@@ -49,7 +50,7 @@ DirBrowser::DirBrowser(TrackSelectionController* selectionController, PlaylistCo
     , m_selectionController{selectionController}
     , m_settings{settings}
     , m_iconProvider{std::make_unique<QFileIconProvider>()}
-    , m_dirTree{new QTreeView(this)}
+    , m_dirTree{new DirTree(this)}
     , m_model{new QFileSystemModel(this)}
     , m_proxyModel{new DirProxyModel(m_iconProvider.get(), this)}
     , m_playlist{nullptr}
@@ -68,13 +69,9 @@ DirBrowser::DirBrowser(TrackSelectionController* selectionController, PlaylistCo
     m_model->setNameFilters(Track::supportedFileExtensions());
     m_model->setNameFilterDisables(false);
     m_model->setReadOnly(true);
-
     m_model->setIconProvider(m_iconProvider.get());
 
     m_dirTree->setModel(m_proxyModel);
-    m_dirTree->setIndentation(0);
-    m_dirTree->setExpandsOnDoubleClick(false);
-    m_dirTree->setHeaderHidden(true);
 
     QString rootPath = m_settings->value<Settings::Gui::Internal::DirBrowserPath>();
     if(rootPath.isEmpty()) {

--- a/src/gui/dirbrowser/dirbrowser.cpp
+++ b/src/gui/dirbrowser/dirbrowser.cpp
@@ -62,6 +62,7 @@ DirBrowser::DirBrowser(TrackSelectionController* selectionController, PlaylistCo
     layout->addWidget(m_dirTree);
 
     m_proxyModel->setSourceModel(m_model);
+    m_proxyModel->setIconsEnabled(m_settings->value<Settings::Gui::Internal::DirBrowserIcons>());
 
     m_model->setFilter(QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot | QDir::NoSymLinks);
     m_model->setNameFilters(Track::supportedFileExtensions());
@@ -100,6 +101,9 @@ DirBrowser::DirBrowser(TrackSelectionController* selectionController, PlaylistCo
                              m_proxyModel->setPlayingIndex(track.indexInPlaylist);
                          }
                      });
+
+    m_settings->subscribe<Settings::Gui::Internal::DirBrowserIcons>(
+        this, [this](bool enabled) { m_proxyModel->setIconsEnabled(enabled); });
 }
 
 DirBrowser::~DirBrowser()
@@ -121,6 +125,14 @@ void DirBrowser::contextMenuEvent(QContextMenuEvent* event)
 {
     auto* menu = new QMenu(this);
     menu->setAttribute(Qt::WA_DeleteOnClose);
+
+    auto* showIcons = new QAction(tr("Show icons"), menu);
+    showIcons->setCheckable(true);
+    showIcons->setChecked(m_settings->value<Settings::Gui::Internal::DirBrowserIcons>());
+    QObject::connect(showIcons, &QAction::triggered, this,
+                     [this](bool checked) { m_settings->set<Settings::Gui::Internal::DirBrowserIcons>(checked); });
+
+    menu->addAction(showIcons);
 
     menu->popup(event->globalPos());
 }

--- a/src/gui/dirbrowser/dirbrowser.cpp
+++ b/src/gui/dirbrowser/dirbrowser.cpp
@@ -1,0 +1,186 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "dirbrowser.h"
+
+#include "internalguisettings.h"
+#include "playlist/playlistcontroller.h"
+
+#include <core/player/playercontroller.h>
+#include <core/playlist/playlist.h>
+#include <core/playlist/playlisthandler.h>
+#include <core/track.h>
+#include <utils/fileutils.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QActionGroup>
+#include <QContextMenuEvent>
+#include <QFileSystemModel>
+#include <QMenu>
+#include <QStandardPaths>
+#include <QTreeView>
+#include <QVBoxLayout>
+
+constexpr auto DirPlaylist = "␟DirBrowserPlaylist␟";
+
+using namespace std::chrono_literals;
+
+namespace Fooyin {
+DirBrowser::DirBrowser(TrackSelectionController* selectionController, PlaylistController* playlistController,
+                       SettingsManager* settings, QWidget* parent)
+    : FyWidget{parent}
+    , m_playlistController{playlistController}
+    , m_selectionController{selectionController}
+    , m_settings{settings}
+    , m_iconProvider{std::make_unique<QFileIconProvider>()}
+    , m_dirTree{new QTreeView(this)}
+    , m_model{new QFileSystemModel(this)}
+    , m_proxyModel{new DirProxyModel(m_iconProvider.get(), this)}
+    , m_playlist{nullptr}
+{
+    Q_UNUSED(m_selectionController)
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    layout->addWidget(m_dirTree);
+
+    m_proxyModel->setSourceModel(m_model);
+
+    m_model->setFilter(QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot | QDir::NoSymLinks);
+    m_model->setNameFilters(Track::supportedFileExtensions());
+    m_model->setNameFilterDisables(false);
+    m_model->setReadOnly(true);
+
+    m_model->setIconProvider(m_iconProvider.get());
+
+    m_dirTree->setModel(m_proxyModel);
+    m_dirTree->setIndentation(0);
+    m_dirTree->setExpandsOnDoubleClick(false);
+    m_dirTree->setHeaderHidden(true);
+
+    QString rootPath = m_settings->value<Settings::Gui::Internal::DirBrowserPath>();
+    if(rootPath.isEmpty()) {
+        rootPath = QDir::homePath();
+    }
+
+    m_dirTree->setRootIndex(m_proxyModel->mapFromSource(m_model->setRootPath(rootPath)));
+
+    QObject::connect(m_dirTree, &QTreeView::doubleClicked, this, &DirBrowser::handleDoubleClick);
+
+    QObject::connect(m_model, &QFileSystemModel::layoutChanged, this, [this]() {
+        const QModelIndex root = m_model->setRootPath(m_model->rootPath());
+        m_dirTree->setRootIndex(m_proxyModel->mapFromSource(root));
+        m_proxyModel->reset(root);
+        setUpdatesEnabled(true);
+    });
+
+    QObject::connect(m_playlistController->playerController(), &PlayerController::playStateChanged, this,
+                     [this](PlayState state) { m_proxyModel->setPlayState(state); });
+
+    QObject::connect(m_playlistController->playerController(), &PlayerController::playlistTrackChanged, this,
+                     [this](const PlaylistTrack& track) {
+                         if(m_playlist && m_playlist->id() == track.playlistId) {
+                             m_proxyModel->setPlayingIndex(track.indexInPlaylist);
+                         }
+                     });
+}
+
+DirBrowser::~DirBrowser()
+{
+    m_settings->set<Settings::Gui::Internal::DirBrowserPath>(m_model->rootPath());
+}
+
+QString DirBrowser::name() const
+{
+    return QStringLiteral("Directory Browser");
+}
+
+QString DirBrowser::layoutName() const
+{
+    return QStringLiteral("DirectoryBrowser");
+}
+
+void DirBrowser::contextMenuEvent(QContextMenuEvent* event)
+{
+    auto* menu = new QMenu(this);
+    menu->setAttribute(Qt::WA_DeleteOnClose);
+
+    menu->popup(event->globalPos());
+}
+
+void DirBrowser::handleDoubleClick(const QModelIndex& index)
+{
+    if(!index.isValid()) {
+        return;
+    }
+
+    const QFileInfo filePath{index.data(QFileSystemModel::FilePathRole).toString()};
+
+    if(!filePath.exists()) {
+        return;
+    }
+
+    if(filePath.isDir()) {
+        setUpdatesEnabled(false);
+        updateDir(filePath.absoluteFilePath());
+        return;
+    }
+
+    const QStringList files = Utils::File::getFilesInDir(filePath.absolutePath(), Track::supportedFileExtensions());
+    if(files.empty()) {
+        return;
+    }
+
+    TrackList tracks;
+    std::ranges::transform(files, std::back_inserter(tracks), [](const QString& file) { return Track{file}; });
+
+    m_playlistDir = filePath.absolutePath();
+
+    if(!m_playlist) {
+        m_playlist = m_playlistController->playlistHandler()->createTempPlaylist(QString::fromLatin1(DirPlaylist));
+    }
+
+    m_playlistController->playlistHandler()->replacePlaylistTracks(m_playlist->id(), tracks);
+
+    int row = index.row();
+
+    if(m_proxyModel->canGoUp()) {
+        --row;
+    }
+
+    m_playlist->changeCurrentIndex(row);
+    m_playlistController->playlistHandler()->startPlayback(m_playlist);
+}
+
+void DirBrowser::updateDir(const QString& dir)
+{
+    const QModelIndex root = m_model->setRootPath(dir);
+    m_dirTree->setRootIndex(m_proxyModel->mapFromSource(root));
+
+    if(dir != m_playlistDir) {
+        m_proxyModel->setPlayingIndex(-1);
+    }
+    else if(m_playlist) {
+        m_proxyModel->setPlayingIndex(m_playlist->currentTrackIndex());
+    }
+}
+} // namespace Fooyin
+
+#include "moc_dirbrowser.cpp"

--- a/src/gui/dirbrowser/dirbrowser.cpp
+++ b/src/gui/dirbrowser/dirbrowser.cpp
@@ -162,6 +162,7 @@ void DirBrowser::contextMenuEvent(QContextMenuEvent* event)
     QObject::connect(sendNew, &QAction::triggered, this, [this]() { handleAction(TrackAction::SendNewPlaylist); });
 
     menu->addAction(playAction);
+    menu->addSeparator();
     menu->addAction(addCurrent);
     menu->addAction(addActive);
     menu->addAction(sendCurrent);

--- a/src/gui/dirbrowser/dirbrowser.cpp
+++ b/src/gui/dirbrowser/dirbrowser.cpp
@@ -19,6 +19,7 @@
 
 #include "dirbrowser.h"
 
+#include "dirdelegate.h"
 #include "dirtree.h"
 #include "internalguisettings.h"
 #include "playlist/playlistcontroller.h"
@@ -73,6 +74,7 @@ DirBrowser::DirBrowser(TrackSelectionController* selectionController, PlaylistCo
     m_model->setReadOnly(true);
     m_model->setIconProvider(m_iconProvider.get());
 
+    m_dirTree->setItemDelegate(new DirDelegate(this));
     m_dirTree->setModel(m_proxyModel);
 
     QString rootPath = m_settings->value<Settings::Gui::Internal::DirBrowserPath>();

--- a/src/gui/dirbrowser/dirbrowser.h
+++ b/src/gui/dirbrowser/dirbrowser.h
@@ -22,6 +22,7 @@
 #include "dirproxymodel.h"
 
 #include <gui/fywidget.h>
+#include <gui/trackselectioncontroller.h>
 
 #include <QFileIconProvider>
 
@@ -30,7 +31,6 @@ class QFileSystemModel;
 namespace Fooyin {
 class PlaylistController;
 class SettingsManager;
-class TrackSelectionController;
 class Playlist;
 class DirTree;
 
@@ -50,7 +50,11 @@ protected:
     void contextMenuEvent(QContextMenuEvent* event) override;
 
 private:
+    void handleAction(TrackAction action);
     void handleDoubleClick(const QModelIndex& index);
+    void handleMiddleClick();
+
+    void startPlayback(const TrackList& tracks, int row);
     void updateDir(const QString& dir);
 
     PlaylistController* m_playlistController;
@@ -65,5 +69,8 @@ private:
 
     Playlist* m_playlist;
     QString m_playlistDir;
+
+    TrackAction m_doubleClickAction;
+    TrackAction m_middleClickAction;
 };
 } // namespace Fooyin

--- a/src/gui/dirbrowser/dirbrowser.h
+++ b/src/gui/dirbrowser/dirbrowser.h
@@ -1,0 +1,69 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "dirproxymodel.h"
+
+#include <gui/fywidget.h>
+
+#include <QFileIconProvider>
+
+class QFileSystemModel;
+class QTreeView;
+
+namespace Fooyin {
+class PlaylistController;
+class SettingsManager;
+class TrackSelectionController;
+class Playlist;
+
+class DirBrowser : public FyWidget
+{
+    Q_OBJECT
+
+public:
+    explicit DirBrowser(TrackSelectionController* selectionController, PlaylistController* playlistController,
+                        SettingsManager* settings, QWidget* parent = nullptr);
+    ~DirBrowser() override;
+
+    [[nodiscard]] QString name() const override;
+    [[nodiscard]] QString layoutName() const override;
+
+protected:
+    void contextMenuEvent(QContextMenuEvent* event) override;
+
+private:
+    void handleDoubleClick(const QModelIndex& index);
+    void updateDir(const QString& dir);
+
+    PlaylistController* m_playlistController;
+    TrackSelectionController* m_selectionController;
+    SettingsManager* m_settings;
+
+    std::unique_ptr<QFileIconProvider> m_iconProvider;
+
+    QTreeView* m_dirTree;
+    QFileSystemModel* m_model;
+    DirProxyModel* m_proxyModel;
+
+    Playlist* m_playlist;
+    QString m_playlistDir;
+};
+} // namespace Fooyin

--- a/src/gui/dirbrowser/dirbrowser.h
+++ b/src/gui/dirbrowser/dirbrowser.h
@@ -26,13 +26,13 @@
 #include <QFileIconProvider>
 
 class QFileSystemModel;
-class QTreeView;
 
 namespace Fooyin {
 class PlaylistController;
 class SettingsManager;
 class TrackSelectionController;
 class Playlist;
+class DirTree;
 
 class DirBrowser : public FyWidget
 {
@@ -59,7 +59,7 @@ private:
 
     std::unique_ptr<QFileIconProvider> m_iconProvider;
 
-    QTreeView* m_dirTree;
+    DirTree* m_dirTree;
     QFileSystemModel* m_model;
     DirProxyModel* m_proxyModel;
 

--- a/src/gui/dirbrowser/dirdelegate.cpp
+++ b/src/gui/dirbrowser/dirdelegate.cpp
@@ -31,8 +31,10 @@ void DirDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, c
 
     painter->save();
 
-    painter->fillRect(option.rect, opt.backgroundBrush);
-    opt.backgroundBrush = {};
+    if(opt.backgroundBrush.style() != Qt::NoBrush) {
+        painter->fillRect(option.rect, opt.backgroundBrush);
+        opt.backgroundBrush = {};
+    }
     style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, option.widget);
 
     painter->restore();

--- a/src/gui/dirbrowser/dirdelegate.cpp
+++ b/src/gui/dirbrowser/dirdelegate.cpp
@@ -1,0 +1,40 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "dirdelegate.h"
+
+#include <QApplication>
+
+namespace Fooyin {
+void DirDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+    QStyleOptionViewItem opt = option;
+    initStyleOption(&opt, index);
+
+    QStyle* style = option.widget ? option.widget->style() : QApplication::style();
+
+    painter->save();
+
+    painter->fillRect(option.rect, opt.backgroundBrush);
+    opt.backgroundBrush = {};
+    style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, option.widget);
+
+    painter->restore();
+}
+} // namespace Fooyin

--- a/src/gui/dirbrowser/dirdelegate.h
+++ b/src/gui/dirbrowser/dirdelegate.h
@@ -1,0 +1,34 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <QStyledItemDelegate>
+
+namespace Fooyin {
+class DirDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+public:
+    using QStyledItemDelegate::QStyledItemDelegate;
+
+    void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+};
+} // namespace Fooyin

--- a/src/gui/dirbrowser/dirproxymodel.cpp
+++ b/src/gui/dirbrowser/dirproxymodel.cpp
@@ -1,0 +1,244 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "dirproxymodel.h"
+
+#include <gui/guiconstants.h>
+#include <utils/utils.h>
+
+#include <QAbstractFileIconProvider>
+#include <QFileSystemModel>
+
+namespace Fooyin {
+DirProxyModel::DirProxyModel(QAbstractFileIconProvider* iconProvider, QObject* parent)
+    : QAbstractProxyModel{parent}
+    , m_iconProvider{iconProvider}
+    , m_playingState{PlayState::Stopped}
+    , m_currentPlayingIndex{-1}
+    , m_playingIcon{Utils::iconFromTheme(Constants::Icons::Play).pixmap(20, 20)}
+    , m_pausedIcon{Utils::iconFromTheme(Constants::Icons::Pause).pixmap(20, 20)}
+{ }
+
+void DirProxyModel::reset(const QModelIndex& root)
+{
+    if(!sourceModel()) {
+        return;
+    }
+
+    beginResetModel();
+
+    QDir path{root.data(QFileSystemModel::FilePathRole).toString()};
+    m_goUpPath   = path.cdUp() ? path.absolutePath() : QString{};
+    m_sourceRoot = root;
+    populate();
+
+    endResetModel();
+}
+
+void DirProxyModel::setSourceModel(QAbstractItemModel* model)
+{
+    if(model == sourceModel()) {
+        return;
+    }
+
+    if(sourceModel()) {
+        disconnect(sourceModel(), nullptr, this, nullptr);
+    }
+
+    if(!qobject_cast<QFileSystemModel*>(model)) {
+        qDebug() << "sourceModel expected be of type QFileSystemModel";
+        return;
+    }
+
+    QAbstractProxyModel::setSourceModel(model);
+}
+
+Qt::ItemFlags DirProxyModel::flags(const QModelIndex& index) const
+{
+    if(!index.isValid()) {
+        return Qt::NoItemFlags;
+    }
+
+    if(canGoUp() && index.row() <= 0) {
+        return sourceModel()->flags(m_sourceRoot);
+    }
+
+    return sourceModel()->flags(mapToSource(index));
+}
+
+QVariant DirProxyModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if(role == Qt::TextAlignmentRole) {
+        return (Qt::AlignHCenter);
+    }
+
+    return sourceModel()->headerData(section, orientation, role);
+}
+
+QVariant DirProxyModel::data(const QModelIndex& proxyIndex, int role) const
+{
+    if(!proxyIndex.isValid()) {
+        return {};
+    }
+
+    if(canGoUp() && proxyIndex.row() == 0 && proxyIndex.column() == 0) {
+        if(role == Qt::DisplayRole) {
+            return QStringLiteral("…");
+        }
+        if(role == QFileSystemModel::FilePathRole) {
+            return m_goUpPath;
+        }
+        if(role == Qt::TextAlignmentRole) {
+            return Qt::AlignBottom;
+        }
+        if(role == Qt::DecorationRole) {
+            return m_iconProvider->icon(QAbstractFileIconProvider::IconType::Folder);
+        }
+    }
+
+    if(proxyIndex.row() == m_currentPlayingIndex) {
+        if(role == Qt::DecorationRole) {
+            switch(m_playingState) {
+                case(PlayState::Playing):
+                    return m_playingIcon;
+                case(PlayState::Paused):
+                    return m_pausedIcon;
+                case(PlayState::Stopped):
+                    break;
+            }
+        }
+    }
+
+    const QModelIndex sourceIndex = mapToSource(proxyIndex);
+
+    return sourceModel()->data(sourceIndex, role);
+}
+
+QModelIndex DirProxyModel::parent(const QModelIndex& /*child*/) const
+{
+    return {};
+}
+
+bool DirProxyModel::hasChildren(const QModelIndex& parent) const
+{
+    return !parent.isValid();
+}
+
+QModelIndex DirProxyModel::index(int row, int column, const QModelIndex& parent) const
+{
+    if(!hasIndex(row, column, parent)) {
+        return {};
+    }
+
+    if(canGoUp() && row == 0) {
+        return createIndex(row, column, nullptr);
+    }
+
+    return createIndex(row, column, m_nodes.at(row).get());
+}
+
+int DirProxyModel::rowCount(const QModelIndex& parent) const
+{
+    return parent.isValid() ? 0 : nodeCount();
+}
+
+int DirProxyModel::columnCount(const QModelIndex& /*index*/) const
+{
+    return 1;
+}
+
+QModelIndex DirProxyModel::mapFromSource(const QModelIndex& index) const
+{
+    if(!index.isValid() || m_nodes.empty()) {
+        return {};
+    }
+
+    for(int row{0}; const auto& node : m_nodes) {
+        if(node->sourceIndex == index) {
+            return createIndex(row++, 0, node.get());
+        }
+    }
+
+    return {};
+}
+
+QModelIndex DirProxyModel::mapToSource(const QModelIndex& index) const
+{
+    if(!index.isValid() || m_nodes.empty()) {
+        return {};
+    }
+
+    if(auto* node = static_cast<DirNode*>(index.internalPointer())) {
+        return node->sourceIndex;
+    }
+
+    return {};
+}
+
+bool DirProxyModel::canGoUp() const
+{
+    return !m_goUpPath.isEmpty();
+}
+
+void DirProxyModel::setPlayState(PlayState state)
+{
+    m_playingState = state;
+    emit dataChanged({}, {}, {Qt::DecorationRole});
+}
+
+void DirProxyModel::setPlayingIndex(int index)
+{
+    m_currentPlayingIndex = index;
+
+    if(index >= 0 && canGoUp()) {
+        ++m_currentPlayingIndex;
+    }
+
+    emit dataChanged({}, {}, {Qt::DecorationRole});
+}
+
+void DirProxyModel::populate()
+{
+    m_nodes.clear();
+
+    if(canGoUp()) {
+        m_nodes.emplace_back(std::make_unique<DirNode>(QModelIndex{}));
+    }
+
+    const int rowCount = sourceModel()->rowCount(m_sourceRoot);
+
+    if(rowCount <= 0) {
+        return;
+    }
+
+    const int first = canGoUp() ? 1 : 0;
+    const int last  = rowCount - 1;
+
+    m_nodes.resize(m_nodes.size() + rowCount);
+
+    for(int i{first}, row{0}; row <= last; ++i, ++row) {
+        m_nodes[i] = std::make_unique<DirNode>(sourceModel()->index(row, 0, m_sourceRoot));
+    }
+}
+
+int DirProxyModel::nodeCount() const
+{
+    return static_cast<int>(m_nodes.size());
+}
+} // namespace Fooyin

--- a/src/gui/dirbrowser/dirproxymodel.cpp
+++ b/src/gui/dirbrowser/dirproxymodel.cpp
@@ -23,6 +23,7 @@
 #include <utils/utils.h>
 
 #include <QAbstractFileIconProvider>
+#include <QApplication>
 #include <QFileSystemModel>
 
 namespace Fooyin {
@@ -32,9 +33,12 @@ DirProxyModel::DirProxyModel(QAbstractFileIconProvider* iconProvider, QObject* p
     , m_playingState{PlayState::Stopped}
     , m_currentPlayingIndex{-1}
     , m_showIcons{true}
+    , m_playingColour{QApplication::palette().highlight().color()}
     , m_playingIcon{Utils::iconFromTheme(Constants::Icons::Play).pixmap(20, 20)}
     , m_pausedIcon{Utils::iconFromTheme(Constants::Icons::Pause).pixmap(20, 20)}
-{ }
+{
+    m_playingColour.setAlpha(90);
+}
 
 void DirProxyModel::reset(const QModelIndex& root)
 {
@@ -114,6 +118,9 @@ QVariant DirProxyModel::data(const QModelIndex& proxyIndex, int role) const
     }
 
     if(proxyIndex.row() == m_currentPlayingIndex) {
+        if(role == Qt::BackgroundRole) {
+            return m_playingColour;
+        }
         if(role == Qt::DecorationRole) {
             switch(m_playingState) {
                 case(PlayState::Playing):

--- a/src/gui/dirbrowser/dirproxymodel.cpp
+++ b/src/gui/dirbrowser/dirproxymodel.cpp
@@ -31,6 +31,7 @@ DirProxyModel::DirProxyModel(QAbstractFileIconProvider* iconProvider, QObject* p
     , m_iconProvider{iconProvider}
     , m_playingState{PlayState::Stopped}
     , m_currentPlayingIndex{-1}
+    , m_showIcons{true}
     , m_playingIcon{Utils::iconFromTheme(Constants::Icons::Play).pixmap(20, 20)}
     , m_pausedIcon{Utils::iconFromTheme(Constants::Icons::Pause).pixmap(20, 20)}
 { }
@@ -107,7 +108,7 @@ QVariant DirProxyModel::data(const QModelIndex& proxyIndex, int role) const
         if(role == Qt::TextAlignmentRole) {
             return Qt::AlignBottom;
         }
-        if(role == Qt::DecorationRole) {
+        if(m_showIcons && role == Qt::DecorationRole) {
             return m_iconProvider->icon(QAbstractFileIconProvider::IconType::Folder);
         }
     }
@@ -123,6 +124,10 @@ QVariant DirProxyModel::data(const QModelIndex& proxyIndex, int role) const
                     break;
             }
         }
+    }
+
+    if(!m_showIcons && role == Qt::DecorationRole) {
+        return {};
     }
 
     const QModelIndex sourceIndex = mapToSource(proxyIndex);
@@ -194,6 +199,12 @@ QModelIndex DirProxyModel::mapToSource(const QModelIndex& index) const
 bool DirProxyModel::canGoUp() const
 {
     return !m_goUpPath.isEmpty();
+}
+
+void DirProxyModel::setIconsEnabled(bool enabled)
+{
+    m_showIcons = enabled;
+    emit dataChanged({}, {}, {Qt::DecorationRole});
 }
 
 void DirProxyModel::setPlayState(PlayState state)

--- a/src/gui/dirbrowser/dirproxymodel.h
+++ b/src/gui/dirbrowser/dirproxymodel.h
@@ -61,6 +61,7 @@ public:
 
     [[nodiscard]] bool canGoUp() const;
 
+    void setIconsEnabled(bool enabled);
     void setPlayState(PlayState state);
     void setPlayingIndex(int index);
 
@@ -78,6 +79,8 @@ private:
 
     PlayState m_playingState;
     int m_currentPlayingIndex;
+
+    bool m_showIcons;
     QPixmap m_playingIcon;
     QPixmap m_pausedIcon;
 };

--- a/src/gui/dirbrowser/dirproxymodel.h
+++ b/src/gui/dirbrowser/dirproxymodel.h
@@ -1,0 +1,84 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/player/playerdefs.h>
+
+#include <QAbstractProxyModel>
+#include <QPixmap>
+
+class QAbstractFileIconProvider;
+class QDir;
+
+namespace Fooyin {
+struct DirNode
+{
+    QPersistentModelIndex sourceIndex;
+
+    explicit DirNode(const QModelIndex& index)
+        : sourceIndex{index}
+    { }
+};
+
+class DirProxyModel : public QAbstractProxyModel
+{
+    Q_OBJECT
+
+public:
+    explicit DirProxyModel(QAbstractFileIconProvider* iconProvider, QObject* parent = nullptr);
+
+    void reset(const QModelIndex& root);
+
+    void setSourceModel(QAbstractItemModel* model) override;
+
+    [[nodiscard]] Qt::ItemFlags flags(const QModelIndex& index) const override;
+    [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
+    [[nodiscard]] QVariant data(const QModelIndex& index, int role) const override;
+    [[nodiscard]] QModelIndex index(int row, int column, const QModelIndex& parent = {}) const override;
+    [[nodiscard]] int rowCount(const QModelIndex& index) const override;
+    [[nodiscard]] int columnCount(const QModelIndex& index) const override;
+    [[nodiscard]] QModelIndex mapFromSource(const QModelIndex& index) const override;
+    [[nodiscard]] QModelIndex mapToSource(const QModelIndex& index) const override;
+    [[nodiscard]] QModelIndex parent(const QModelIndex& index) const override;
+    [[nodiscard]] bool hasChildren(const QModelIndex& parent) const override;
+
+    [[nodiscard]] bool canGoUp() const;
+
+    void setPlayState(PlayState state);
+    void setPlayingIndex(int index);
+
+private:
+    void populate();
+    [[nodiscard]] int nodeCount() const;
+
+    QAbstractFileIconProvider* m_iconProvider;
+
+    QString m_rootPath;
+    QString m_goUpPath;
+
+    QPersistentModelIndex m_sourceRoot;
+    std::vector<std::unique_ptr<DirNode>> m_nodes;
+
+    PlayState m_playingState;
+    int m_currentPlayingIndex;
+    QPixmap m_playingIcon;
+    QPixmap m_pausedIcon;
+};
+} // namespace Fooyin

--- a/src/gui/dirbrowser/dirproxymodel.h
+++ b/src/gui/dirbrowser/dirproxymodel.h
@@ -81,6 +81,7 @@ private:
     int m_currentPlayingIndex;
 
     bool m_showIcons;
+    QColor m_playingColour;
     QPixmap m_playingIcon;
     QPixmap m_pausedIcon;
 };

--- a/src/gui/dirbrowser/dirtree.cpp
+++ b/src/gui/dirbrowser/dirtree.cpp
@@ -1,0 +1,55 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "dirtree.h"
+
+namespace Fooyin {
+DirTree::DirTree(QWidget* parent)
+    : QTreeView{parent}
+{
+    setUniformRowHeights(true);
+    setSelectionMode(QAbstractItemView::ExtendedSelection);
+    setDragEnabled(true);
+    setDragDropMode(QAbstractItemView::DragOnly);
+    setDefaultDropAction(Qt::CopyAction);
+    setDropIndicatorShown(true);
+    setIndentation(0);
+    setExpandsOnDoubleClick(false);
+    setHeaderHidden(true);
+    setTextElideMode(Qt::ElideRight);
+}
+
+void DirTree::mousePressEvent(QMouseEvent* event)
+{
+    QTreeView::mousePressEvent(event);
+    if(event->button() == Qt::MiddleButton) {
+        emit middleClicked();
+    }
+}
+
+void DirTree::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    if(event->button() == Qt::MiddleButton) {
+        return;
+    }
+    QTreeView::mouseDoubleClickEvent(event);
+}
+} // namespace Fooyin
+
+#include "moc_dirtree.cpp"

--- a/src/gui/dirbrowser/dirtree.h
+++ b/src/gui/dirbrowser/dirtree.h
@@ -1,0 +1,39 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <QTreeView>
+
+namespace Fooyin {
+class DirTree : public QTreeView
+{
+    Q_OBJECT
+
+public:
+    DirTree(QWidget* parent = nullptr);
+
+signals:
+    void middleClicked();
+
+protected:
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
+};
+} // namespace Fooyin

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -24,6 +24,7 @@
 #include "controls/seekbar.h"
 #include "controls/volumecontrol.h"
 #include "core/internalcoresettings.h"
+#include "dirbrowser/dirbrowser.h"
 #include "info/infowidget.h"
 #include "internalguisettings.h"
 #include "librarytree/librarytreewidget.h"
@@ -411,6 +412,15 @@ struct GuiApplication::Private
             QStringLiteral("SearchBar"),
             [this]() { return new SearchWidget(searchController, settingsManager, mainWindow.get()); },
             QStringLiteral("Search Bar"));
+
+        widgetProvider.registerWidget(
+            QStringLiteral("DirectoryBrowser"),
+            [this]() {
+                return new DirBrowser(&selectionController, playlistController.get(), settingsManager,
+                                            mainWindow.get());
+            },
+            QStringLiteral("Directory Browser"));
+        widgetProvider.setLimit(QStringLiteral("DirectoryBrowser"), 1);
     }
 
     void createPropertiesTabs()

--- a/src/gui/guiapplication.cpp
+++ b/src/gui/guiapplication.cpp
@@ -42,6 +42,7 @@
 #include "playlist/playlistwidget.h"
 #include "search/searchcontroller.h"
 #include "search/searchwidget.h"
+#include "settings/dirbrowser/dirbrowserpage.h"
 #include "settings/enginepage.h"
 #include "settings/generalpage.h"
 #include "settings/guigeneralpage.h"
@@ -131,6 +132,7 @@ struct GuiApplication::Private
     PlaylistPresetsPage playlistPresetsPage;
     PlaylistColumnPage playlistColumnPage;
     EnginePage enginePage;
+    DirBrowserPage dirBrowserPage;
     LibraryTreePage libraryTreePage;
     LibraryTreeGuiPage libraryTreeGuiPage;
     StatusWidgetPage statusWidgetPage;
@@ -175,6 +177,7 @@ struct GuiApplication::Private
         , playlistPresetsPage{settingsManager}
         , playlistColumnPage{actionManager, settingsManager}
         , enginePage{settingsManager, engine}
+        , dirBrowserPage{settingsManager}
         , libraryTreePage{actionManager, settingsManager}
         , libraryTreeGuiPage{settingsManager}
         , statusWidgetPage{settingsManager}
@@ -381,7 +384,9 @@ struct GuiApplication::Private
 
         widgetProvider.registerWidget(
             QStringLiteral("SelectionInfo"),
-            [this]() { return new InfoWidget(playerController, &selectionController, settingsManager, mainWindow.get()); },
+            [this]() {
+                return new InfoWidget(playerController, &selectionController, settingsManager, mainWindow.get());
+            },
             QStringLiteral("Selection Info"));
 
         widgetProvider.registerWidget(
@@ -417,7 +422,7 @@ struct GuiApplication::Private
             QStringLiteral("DirectoryBrowser"),
             [this]() {
                 return new DirBrowser(&selectionController, playlistController.get(), settingsManager,
-                                            mainWindow.get());
+                                      mainWindow.get());
             },
             QStringLiteral("Directory Browser"));
         widgetProvider.setLimit(QStringLiteral("DirectoryBrowser"), 1);

--- a/src/gui/internalguisettings.cpp
+++ b/src/gui/internalguisettings.cpp
@@ -81,5 +81,9 @@ GuiSettings::GuiSettings(SettingsManager* settingsManager)
     m_settings->createSetting<Internal::SeekBarLabels>(true, QStringLiteral("SeekBar/Labels"));
     m_settings->createSetting<Internal::DirBrowserPath>(QStringLiteral(""), QStringLiteral("DirectoryBrowser/Path"));
     m_settings->createSetting<Internal::DirBrowserIcons>(true, QStringLiteral("DirectoryBrowser/Icons"));
+    m_settings->createSetting<Internal::DirBrowserDoubleClick>(1,
+                                                               QStringLiteral("DirectoryBrowser/DoubleClickBehaviour"));
+    m_settings->createSetting<Internal::DirBrowserMiddleClick>(
+        0, QStringLiteral("DirectoryBrowser/MiddleClickkBehaviour"));
 }
 } // namespace Fooyin

--- a/src/gui/internalguisettings.cpp
+++ b/src/gui/internalguisettings.cpp
@@ -79,7 +79,7 @@ GuiSettings::GuiSettings(SettingsManager* settingsManager)
                                                            QStringLiteral("LibraryTree/Appearance"));
     m_settings->createTempSetting<Internal::SystemIconTheme>(QIcon::themeName());
     m_settings->createSetting<Internal::SeekBarLabels>(true, QStringLiteral("SeekBar/Labels"));
-    m_settings->createSetting<Internal::DirBrowserPath>(QStringLiteral(""),
-                                                              QStringLiteral("DirectoryBrowser/Path"));
+    m_settings->createSetting<Internal::DirBrowserPath>(QStringLiteral(""), QStringLiteral("DirectoryBrowser/Path"));
+    m_settings->createSetting<Internal::DirBrowserIcons>(true, QStringLiteral("DirectoryBrowser/Icons"));
 }
 } // namespace Fooyin

--- a/src/gui/internalguisettings.cpp
+++ b/src/gui/internalguisettings.cpp
@@ -79,5 +79,7 @@ GuiSettings::GuiSettings(SettingsManager* settingsManager)
                                                            QStringLiteral("LibraryTree/Appearance"));
     m_settings->createTempSetting<Internal::SystemIconTheme>(QIcon::themeName());
     m_settings->createSetting<Internal::SeekBarLabels>(true, QStringLiteral("SeekBar/Labels"));
+    m_settings->createSetting<Internal::DirBrowserPath>(QStringLiteral(""),
+                                                              QStringLiteral("DirectoryBrowser/Path"));
 }
 } // namespace Fooyin

--- a/src/gui/internalguisettings.h
+++ b/src/gui/internalguisettings.h
@@ -66,6 +66,8 @@ enum GuiInternalSettings : uint32_t
     SeekBarLabels          = 27 | Type::Bool,
     DirBrowserPath         = 28 | Type::String,
     DirBrowserIcons        = 29 | Type::Bool,
+    DirBrowserDoubleClick  = 30 | Type::Int,
+    DirBrowserMiddleClick  = 31 | Type::Int,
 };
 Q_ENUM_NS(GuiInternalSettings)
 } // namespace Settings::Gui::Internal

--- a/src/gui/internalguisettings.h
+++ b/src/gui/internalguisettings.h
@@ -64,6 +64,7 @@ enum GuiInternalSettings : uint32_t
     LibTreeAppearance      = 25 | Type::Variant,
     SystemIconTheme        = 26 | Type::String,
     SeekBarLabels          = 27 | Type::Bool,
+    DirBrowserPath   = 28 | Type::String,
 };
 Q_ENUM_NS(GuiInternalSettings)
 } // namespace Settings::Gui::Internal

--- a/src/gui/internalguisettings.h
+++ b/src/gui/internalguisettings.h
@@ -64,7 +64,8 @@ enum GuiInternalSettings : uint32_t
     LibTreeAppearance      = 25 | Type::Variant,
     SystemIconTheme        = 26 | Type::String,
     SeekBarLabels          = 27 | Type::Bool,
-    DirBrowserPath   = 28 | Type::String,
+    DirBrowserPath         = 28 | Type::String,
+    DirBrowserIcons        = 29 | Type::Bool,
 };
 Q_ENUM_NS(GuiInternalSettings)
 } // namespace Settings::Gui::Internal

--- a/src/gui/playlist/playlistcontroller.h
+++ b/src/gui/playlist/playlistcontroller.h
@@ -90,8 +90,9 @@ public:
     void undoPlaylistChanges();
     void redoPlaylistChanges();
 
-    void filesToCurrentPlaylist(const QList<QUrl>& urls);
+    void filesToCurrentPlaylist(const QList<QUrl>& urls, bool replace = false);
     void filesToNewPlaylist(const QString& playlistName, const QList<QUrl>& urls);
+    void filesToActivePlaylist(const QList<QUrl>& urls);
     void filesToTracks(const QList<QUrl>& urls, const std::function<void(const TrackList&)>& func);
 
 signals:

--- a/src/gui/settings/dirbrowser/dirbrowserpage.cpp
+++ b/src/gui/settings/dirbrowser/dirbrowserpage.cpp
@@ -1,0 +1,145 @@
+/*
+ * Fooyin
+ * Copyright © 2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "dirbrowserpage.h"
+
+#include "internalguisettings.h"
+
+#include <gui/guiconstants.h>
+#include <gui/trackselectioncontroller.h>
+#include <utils/settings/settingsmanager.h>
+
+#include <QAction>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QTableView>
+
+namespace Fooyin {
+class DirBrowserPageWidget : public SettingsPageWidget
+{
+    Q_OBJECT
+
+public:
+    explicit DirBrowserPageWidget(SettingsManager* settings);
+
+    void load() override;
+    void apply() override;
+    void reset() override;
+
+private:
+    SettingsManager* m_settings;
+
+    QCheckBox* m_showIcons;
+
+    QComboBox* m_middleClick;
+    QComboBox* m_doubleClick;
+};
+
+DirBrowserPageWidget::DirBrowserPageWidget(SettingsManager* settings)
+    : m_settings{settings}
+    , m_showIcons{new QCheckBox(tr("Show icons"), this)}
+    , m_middleClick{new QComboBox(this)}
+    , m_doubleClick{new QComboBox(this)}
+{
+    auto* clickBehaviour       = new QGroupBox(tr("Click Behaviour"), this);
+    auto* clickBehaviourLayout = new QGridLayout(clickBehaviour);
+
+    auto* doubleClickLabel = new QLabel(tr("Double-click") + QStringLiteral(":"), this);
+    auto* middleClickLabel = new QLabel(tr("Middle-click") + QStringLiteral(":"), this);
+
+    clickBehaviourLayout->addWidget(doubleClickLabel, 0, 0);
+    clickBehaviourLayout->addWidget(m_doubleClick, 0, 1);
+    clickBehaviourLayout->addWidget(middleClickLabel, 1, 0);
+    clickBehaviourLayout->addWidget(m_middleClick, 1, 1);
+
+    auto* mainLayout = new QGridLayout(this);
+    mainLayout->addWidget(m_showIcons, 0, 0, 1, 3);
+    mainLayout->addWidget(clickBehaviour, 1, 0);
+    mainLayout->setRowStretch(mainLayout->rowCount(), 1);
+
+    using ActionIndexMap = std::map<int, int>;
+    ActionIndexMap doubleActions;
+    ActionIndexMap middleActions;
+
+    auto addTrackAction = [](QComboBox* box, const QString& text, TrackAction action, ActionIndexMap& actionMap) {
+        const int actionValue = static_cast<int>(action);
+        actionMap.emplace(actionValue, box->count());
+        box->addItem(text, actionValue);
+    };
+
+    addTrackAction(m_doubleClick, tr("Play"), TrackAction::Play, doubleActions);
+    addTrackAction(m_doubleClick, tr("Add to current playlist"), TrackAction::AddCurrentPlaylist, doubleActions);
+    addTrackAction(m_doubleClick, tr("Add to active playlist"), TrackAction::AddActivePlaylist, doubleActions);
+    addTrackAction(m_doubleClick, tr("Send to current playlist"), TrackAction::SendCurrentPlaylist, doubleActions);
+    addTrackAction(m_doubleClick, tr("Send to new playlist"), TrackAction::SendNewPlaylist, doubleActions);
+
+    addTrackAction(m_middleClick, tr("None"), TrackAction::None, middleActions);
+    addTrackAction(m_middleClick, tr("Add to current playlist"), TrackAction::AddCurrentPlaylist, middleActions);
+    addTrackAction(m_middleClick, tr("Add to active playlist"), TrackAction::AddActivePlaylist, middleActions);
+    addTrackAction(m_middleClick, tr("Send to current playlist"), TrackAction::SendCurrentPlaylist, middleActions);
+    addTrackAction(m_middleClick, tr("Send to new playlist"), TrackAction::SendNewPlaylist, middleActions);
+
+    auto doubleAction = m_settings->value<Settings::Gui::Internal::DirBrowserDoubleClick>();
+    if(doubleActions.contains(doubleAction)) {
+        m_doubleClick->setCurrentIndex(doubleActions.at(doubleAction));
+    }
+
+    auto middleAction = m_settings->value<Settings::Gui::Internal::DirBrowserMiddleClick>();
+    if(middleActions.contains(middleAction)) {
+        m_middleClick->setCurrentIndex(middleActions.at(middleAction));
+    }
+}
+
+void DirBrowserPageWidget::load()
+{
+    m_showIcons->setChecked(m_settings->value<Settings::Gui::Internal::DirBrowserIcons>());
+}
+
+void DirBrowserPageWidget::apply()
+{
+    m_settings->set<Settings::Gui::Internal::DirBrowserDoubleClick>(m_doubleClick->currentData().toInt());
+    m_settings->set<Settings::Gui::Internal::DirBrowserMiddleClick>(m_middleClick->currentData().toInt());
+    m_settings->set<Settings::Gui::Internal::DirBrowserIcons>(m_showIcons->isChecked());
+}
+
+void DirBrowserPageWidget::reset()
+{
+    m_settings->reset<Settings::Gui::Internal::DirBrowserDoubleClick>();
+    m_settings->reset<Settings::Gui::Internal::DirBrowserMiddleClick>();
+    m_settings->reset<Settings::Gui::Internal::DirBrowserIcons>();
+}
+
+DirBrowserPage::DirBrowserPage(SettingsManager* settings)
+    : SettingsPage{settings->settingsDialog()}
+{
+    setId(Constants::Page::DirBrowser);
+    setName(tr("General"));
+    setCategory({tr("Widgets"), tr("Directory Browser")});
+    setWidgetCreator([settings] { return new DirBrowserPageWidget(settings); });
+}
+} // namespace Fooyin
+
+#include "dirbrowserpage.moc"
+#include "moc_dirbrowserpage.cpp"

--- a/src/gui/settings/dirbrowser/dirbrowserpage.h
+++ b/src/gui/settings/dirbrowser/dirbrowserpage.h
@@ -1,0 +1,34 @@
+/*
+ * Fooyin
+ * Copyright © 2023, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <utils/settings/settingspage.h>
+
+namespace Fooyin {
+class SettingsManager;
+
+class DirBrowserPage : public SettingsPage
+{
+    Q_OBJECT
+
+public:
+    DirBrowserPage(SettingsManager* settings);
+};
+} // namespace Fooyin

--- a/src/utils/fileutils.cpp
+++ b/src/utils/fileutils.cpp
@@ -114,6 +114,25 @@ QStringList getFilesInDir(const QDir& baseDirectory, const QStringList& fileExte
     return ret;
 }
 
+QList<QUrl> getUrlsInDir(const QDir& baseDirectory, const QStringList& fileExtensions)
+{
+    QList<QUrl> ret;
+    QList<QDir> stack{baseDirectory};
+
+    while(!stack.isEmpty()) {
+        const QDir dir              = stack.takeFirst();
+        const QFileInfoList subDirs = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+        for(const auto& subDir : subDirs) {
+            stack.append(QDir{subDir.absoluteFilePath()});
+        }
+        const QFileInfoList files = dir.entryInfoList(fileExtensions, QDir::Files);
+        for(const auto& file : files) {
+            ret.append(QUrl::fromLocalFile(file.absoluteFilePath()));
+        }
+    }
+    return ret;
+}
+
 QStringList getFiles(const QStringList& paths, const QStringList& fileExtensions)
 {
     QStringList files;


### PR DESCRIPTION
Adds a directory browser to navigate and play files from the users local file system. Tracks can currently be played directly from the browser.

![dirbrowser](https://github.com/ludouzi/fooyin/assets/45490980/f2a5cf2e-b7c8-4d47-9da2-46d8636db9a2)

Address #54 