### PR TITLE
Add formatting to FooScript

### DIFF
--- a/include/core/scripting/scriptparser.h
+++ b/include/core/scripting/scriptparser.h
@@ -68,15 +68,6 @@ public:
 
     void clearCache();
 
-protected:
-    ScriptResult evalExpression(const Expression& exp, const auto& tracks) const;
-    ScriptResult evalLiteral(const Expression& exp) const;
-    ScriptResult evalVariable(const Expression& exp, const auto& tracks) const;
-    ScriptResult evalVariableList(const Expression& exp, const auto& tracks) const;
-    ScriptResult evalFunction(const Expression& exp, const auto& tracks) const;
-    ScriptResult evalFunctionArg(const Expression& exp, const auto& tracks) const;
-    ScriptResult evalConditional(const Expression& exp, const auto& tracks) const;
-
 private:
     struct Private;
     std::unique_ptr<Private> p;

--- a/include/core/scripting/scriptparser.h
+++ b/include/core/scripting/scriptparser.h
@@ -68,6 +68,15 @@ public:
 
     void clearCache();
 
+protected:
+    ScriptResult evalExpression(const Expression& exp, const auto& tracks) const;
+    ScriptResult evalLiteral(const Expression& exp) const;
+    ScriptResult evalVariable(const Expression& exp, const auto& tracks) const;
+    ScriptResult evalVariableList(const Expression& exp, const auto& tracks) const;
+    ScriptResult evalFunction(const Expression& exp, const auto& tracks) const;
+    ScriptResult evalFunctionArg(const Expression& exp, const auto& tracks) const;
+    ScriptResult evalConditional(const Expression& exp, const auto& tracks) const;
+
 private:
     struct Private;
     std::unique_ptr<Private> p;

--- a/include/core/scripting/scriptscanner.h
+++ b/include/core/scripting/scriptscanner.h
@@ -39,6 +39,9 @@ public:
         TokRightParen  = ')',
         TokLeftSquare  = '[',
         TokRightSquare = ']',
+        TokSlash       = '/',
+        TokColon       = ':',
+        TokEquals      = '=',
         TokEscape      = '\\',
         TokEos         = '\0',
         TokError,
@@ -47,15 +50,17 @@ public:
 
     struct Token
     {
-        TokenType type;
+        TokenType type{TokError};
         QStringView value;
         int position{0};
     };
 
     void setup(const QString& input);
-    Token scanNext();
+    Token next();
+    Token peekNext(int delta = 1);
 
 private:
+    Token scanNext();
     [[nodiscard]] Token makeToken(TokenType type) const;
     Token literal();
 
@@ -66,5 +71,8 @@ private:
     QStringView m_input;
     const QChar* m_start;
     const QChar* m_current;
+
+    std::vector<Token> m_tokens;
+    int m_currentTokenIndex;
 };
 } // namespace Fooyin

--- a/include/gui/scripting/richtext.h
+++ b/include/gui/scripting/richtext.h
@@ -1,0 +1,71 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <QFont>
+#include <QColor>
+
+namespace Fooyin {
+struct RichFormatting
+{
+    QFont font;
+    QColor colour;
+
+    bool operator==(const RichFormatting& other) const
+    {
+        return std::tie(font, colour) == std::tie(other.font, other.colour);
+    };
+};
+
+struct RichTextBlock
+{
+    QString text;
+    RichFormatting format;
+
+    bool operator==(const RichTextBlock& other) const
+    {
+        return std::tie(text, format) == std::tie(other.text, other.format);
+    };
+};
+using RichText = std::vector<RichTextBlock>;
+
+struct RichScript
+{
+    QString script;
+    RichText text;
+
+    bool operator==(const RichScript& other) const
+    {
+        return std::tie(script, text) == std::tie(other.script, other.text);
+    };
+
+    friend QDataStream& operator<<(QDataStream& stream, const RichScript& richScript)
+    {
+        stream << richScript.script;
+        return stream;
+    }
+
+    friend QDataStream& operator>>(QDataStream& stream, RichScript& richScript)
+    {
+        stream >> richScript.script;
+        return stream;
+    }
+};
+} // namespace Fooyin

--- a/include/gui/scripting/scriptformatter.h
+++ b/include/gui/scripting/scriptformatter.h
@@ -21,34 +21,13 @@
 
 #include "fygui_export.h"
 
+#include <gui/scripting/richtext.h>
+
 #include <QColor>
 #include <QFont>
 
 namespace Fooyin {
 class ScriptFormatterRegistry;
-
-struct Formatting
-{
-    QFont font;
-    QColor colour;
-
-    bool operator==(const Formatting& other) const
-    {
-        return std::tie(font, colour) == std::tie(other.font, other.colour);
-    };
-};
-
-struct FormattedTextBlock
-{
-    QString text;
-    Formatting format;
-
-    bool operator==(const FormattedTextBlock& other) const
-    {
-        return std::tie(text, format) == std::tie(other.text, other.format);
-    };
-};
-using FormattedText = std::vector<FormattedTextBlock>;
 
 class FYGUI_EXPORT ScriptFormatter
 {
@@ -56,7 +35,7 @@ public:
     ScriptFormatter();
     ~ScriptFormatter();
 
-    FormattedText evaluate(const QString& input);
+    RichText evaluate(const QString& input);
 
 private:
     struct Private;

--- a/include/gui/scripting/scriptformatter.h
+++ b/include/gui/scripting/scriptformatter.h
@@ -1,0 +1,65 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fygui_export.h"
+
+#include <QColor>
+#include <QFont>
+
+namespace Fooyin {
+class ScriptFormatterRegistry;
+
+struct Formatting
+{
+    QFont font;
+    QColor colour;
+
+    bool operator==(const Formatting& other) const
+    {
+        return std::tie(font, colour) == std::tie(other.font, other.colour);
+    };
+};
+
+struct FormattedTextBlock
+{
+    QString text;
+    Formatting format;
+
+    bool operator==(const FormattedTextBlock& other) const
+    {
+        return std::tie(text, format) == std::tie(other.text, other.format);
+    };
+};
+using FormattedText = std::vector<FormattedTextBlock>;
+
+class FYGUI_EXPORT ScriptFormatter
+{
+public:
+    ScriptFormatter();
+    ~ScriptFormatter();
+
+    FormattedText evaluate(const QString& input);
+
+private:
+    struct Private;
+    std::unique_ptr<Private> p;
+};
+} // namespace Fooyin

--- a/include/gui/scripting/scriptformatterregistry.h
+++ b/include/gui/scripting/scriptformatterregistry.h
@@ -22,6 +22,7 @@
 #include "fygui_export.h"
 
 #include <core/scripting/scriptregistry.h>
+#include <gui/scripting/richtext.h>
 
 namespace Fooyin {
 struct FormattedTextBlock;
@@ -33,7 +34,7 @@ public:
     ~ScriptFormatterRegistry();
 
     bool isFormatFunc(const QString& option) const;
-    void format(FormattedTextBlock& text, const QString& func, const QString& option = {}) const;
+    void format(RichFormatting& formatting, const QString& func, const QString& option = {}) const;
 
 private:
     struct Private;

--- a/include/gui/scripting/scriptformatterregistry.h
+++ b/include/gui/scripting/scriptformatterregistry.h
@@ -1,0 +1,42 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fygui_export.h"
+
+#include <core/scripting/scriptregistry.h>
+
+namespace Fooyin {
+struct FormattedTextBlock;
+
+class FYGUI_EXPORT ScriptFormatterRegistry
+{
+public:
+    ScriptFormatterRegistry();
+    ~ScriptFormatterRegistry();
+
+    bool isFormatFunc(const QString& option) const;
+    void format(FormattedTextBlock& text, const QString& func, const QString& option = {}) const;
+
+private:
+    struct Private;
+    std::unique_ptr<Private> p;
+};
+} // namespace Fooyin

--- a/src/core/scripting/scriptparser.cpp
+++ b/src/core/scripting/scriptparser.cpp
@@ -50,6 +50,8 @@ QStringList evalStringList(const Fooyin::ScriptResult& evalExpr, const QStringLi
 namespace Fooyin {
 struct ScriptParser::Private
 {
+    ScriptParser* self;
+
     ScriptScanner scanner;
     ScriptRegistry* registry;
 
@@ -60,15 +62,16 @@ struct ScriptParser::Private
     std::unordered_map<QString, ParsedScript> parsedScripts;
     QStringList currentResult;
 
-    explicit Private(ScriptRegistry* registry_)
-        : registry{registry_}
+    explicit Private(ScriptParser* self_, ScriptRegistry* registry_)
+        : self{self_}
+        , registry{registry_}
     { }
 
     void advance()
     {
         previous = current;
 
-        current = scanner.scanNext();
+        current = scanner.next();
         if(current.type == TokenType::TokError) {
             errorAtCurrent(current.value.toString());
         }
@@ -128,137 +131,6 @@ struct ScriptParser::Private
         errorAt(previous, message);
     }
 
-    ScriptResult evalExpression(const Expression& exp, const auto& tracks) const
-    {
-        switch(exp.type) {
-            case(Expr::Literal):
-                return evalLiteral(exp);
-            case(Expr::Variable):
-                return evalVariable(exp, tracks);
-            case(Expr::VariableList):
-                return evalVariableList(exp, tracks);
-            case(Expr::Function):
-                return evalFunction(exp, tracks);
-            case(Expr::FunctionArg):
-                return evalFunctionArg(exp, tracks);
-            case(Expr::Conditional):
-                return evalConditional(exp, tracks);
-            case(Expr::Null):
-            default:
-                return {};
-        }
-    }
-
-    ScriptResult evalLiteral(const Expression& exp) const
-    {
-        ScriptResult result;
-        result.value = std::get<QString>(exp.value);
-        result.cond  = true;
-        return result;
-    }
-
-    ScriptResult evalVariable(const Expression& exp, const auto& tracks) const
-    {
-        const QString var   = std::get<QString>(exp.value);
-        ScriptResult result = registry->value(var, tracks);
-
-        if(!result.cond) {
-            return {};
-        }
-
-        if(result.value.contains(u"\037")) {
-            result.value = result.value.replace(QStringLiteral("\037"), QStringLiteral(", "));
-        }
-
-        return result;
-    }
-
-    ScriptResult evalVariableList(const Expression& exp, const auto& tracks) const
-    {
-        const QString var = std::get<QString>(exp.value);
-        return registry->value(var, tracks);
-    }
-
-    ScriptResult evalFunction(const Expression& exp, const auto& tracks) const
-    {
-        auto func = std::get<FuncValue>(exp.value);
-        ScriptValueList args;
-        std::ranges::transform(func.args, std::back_inserter(args),
-                               [this, &tracks](const Expression& arg) { return evalExpression(arg, tracks); });
-        return registry->function(func.name, args);
-    }
-
-    ScriptResult evalFunctionArg(const Expression& exp, const auto& tracks) const
-    {
-        ScriptResult result;
-        bool allPassed{true};
-
-        auto arg = std::get<ExpressionList>(exp.value);
-        for(const Expression& subArg : arg) {
-            const auto subExpr = evalExpression(subArg, tracks);
-            if(!subExpr.cond) {
-                allPassed = false;
-            }
-            if(subExpr.value.contains(u"\037")) {
-                QStringList newResult;
-                const auto values = subExpr.value.split(QStringLiteral("\037"));
-                std::ranges::transform(values, std::back_inserter(newResult),
-                                       [&](const auto& value) { return result.value + value; });
-                result.value = newResult.join(u"\037");
-            }
-            else {
-                result.value = result.value + subExpr.value;
-            }
-        }
-        result.cond = allPassed;
-        return result;
-    }
-
-    ScriptResult evalConditional(const Expression& exp, const auto& tracks) const
-    {
-        ScriptResult result;
-        QStringList exprResult;
-        result.cond = true;
-
-        auto arg = std::get<ExpressionList>(exp.value);
-        for(const Expression& subArg : arg) {
-            const auto subExpr = evalExpression(subArg, tracks);
-
-            // Literals return false
-            if(subArg.type != Expr::Literal) {
-                if(!subExpr.cond || subExpr.value.isEmpty()) {
-                    // No need to evaluate rest
-                    result.value.clear();
-                    result.cond = false;
-                    return result;
-                }
-            }
-            if(subExpr.value.contains(u"\037")) {
-                const QStringList evalList = evalStringList(subExpr, exprResult);
-                if(!evalList.empty()) {
-                    exprResult = evalList;
-                }
-            }
-            else {
-                if(exprResult.empty()) {
-                    exprResult.append(subExpr.value);
-                }
-                else {
-                    std::ranges::transform(exprResult, exprResult.begin(), [&](const QString& retValue) -> QString {
-                        return retValue + subExpr.value;
-                    });
-                }
-            }
-        }
-        if(exprResult.size() == 1) {
-            result.value = exprResult.constFirst();
-        }
-        else if(exprResult.size() > 1) {
-            result.value = exprResult.join(u"\037");
-        }
-        return result;
-    }
-
     Expression expression(const auto& tracks)
     {
         advance();
@@ -280,6 +152,9 @@ struct ScriptParser::Private
             case(TokenType::TokLeftParen):
             case(TokenType::TokRightParen):
             case(TokenType::TokRightSquare):
+            case(TokenType::TokSlash):
+            case(TokenType::TokColon):
+            case(TokenType::TokEquals):
             case(TokenType::TokLiteral):
                 return literal();
             case(TokenType::TokEos):
@@ -436,7 +311,7 @@ struct ScriptParser::Private
 
         const ExpressionList expressions = input.expressions;
         for(const auto& expr : expressions) {
-            const auto evalExpr = evalExpression(expr, tracks);
+            const auto evalExpr = self->evalExpression(expr, tracks);
 
             if(evalExpr.value.isNull()) {
                 continue;
@@ -475,7 +350,7 @@ struct ScriptParser::Private
 };
 
 ScriptParser::ScriptParser(ScriptRegistry* registry)
-    : p{std::make_unique<Private>(registry)}
+    : p{std::make_unique<Private>(this, registry)}
 { }
 
 ScriptParser::~ScriptParser() = default;
@@ -530,5 +405,135 @@ QString ScriptParser::evaluate(const ParsedScript& input, const TrackList& track
 void ScriptParser::clearCache()
 {
     p->parsedScripts.clear();
+}
+
+ScriptResult ScriptParser::evalExpression(const Expression& exp, const auto& tracks) const
+{
+    switch(exp.type) {
+        case(Expr::Literal):
+            return evalLiteral(exp);
+        case(Expr::Variable):
+            return evalVariable(exp, tracks);
+        case(Expr::VariableList):
+            return evalVariableList(exp, tracks);
+        case(Expr::Function):
+            return evalFunction(exp, tracks);
+        case(Expr::FunctionArg):
+            return evalFunctionArg(exp, tracks);
+        case(Expr::Conditional):
+            return evalConditional(exp, tracks);
+        case(Expr::Null):
+        default:
+            return {};
+    }
+}
+
+ScriptResult ScriptParser::evalLiteral(const Expression& exp) const
+{
+    ScriptResult result;
+    result.value = std::get<QString>(exp.value);
+    result.cond  = true;
+    return result;
+}
+
+ScriptResult ScriptParser::evalVariable(const Expression& exp, const auto& tracks) const
+{
+    const QString var   = std::get<QString>(exp.value);
+    ScriptResult result = p->registry->value(var, tracks);
+
+    if(!result.cond) {
+        return {};
+    }
+
+    if(result.value.contains(u"\037")) {
+        result.value = result.value.replace(QStringLiteral("\037"), QStringLiteral(", "));
+    }
+
+    return result;
+}
+
+ScriptResult ScriptParser::evalVariableList(const Expression& exp, const auto& tracks) const
+{
+    const QString var = std::get<QString>(exp.value);
+    return p->registry->value(var, tracks);
+}
+
+ScriptResult ScriptParser::evalFunction(const Expression& exp, const auto& tracks) const
+{
+    auto func = std::get<FuncValue>(exp.value);
+    ScriptValueList args;
+    std::ranges::transform(func.args, std::back_inserter(args),
+                           [this, &tracks](const Expression& arg) { return evalExpression(arg, tracks); });
+    return p->registry->function(func.name, args);
+}
+
+ScriptResult ScriptParser::evalFunctionArg(const Expression& exp, const auto& tracks) const
+{
+    ScriptResult result;
+    bool allPassed{true};
+
+    auto arg = std::get<ExpressionList>(exp.value);
+    for(const Expression& subArg : arg) {
+        const auto subExpr = evalExpression(subArg, tracks);
+        if(!subExpr.cond) {
+            allPassed = false;
+        }
+        if(subExpr.value.contains(u"\037")) {
+            QStringList newResult;
+            const auto values = subExpr.value.split(QStringLiteral("\037"));
+            std::ranges::transform(values, std::back_inserter(newResult),
+                                   [&](const auto& value) { return result.value + value; });
+            result.value = newResult.join(u"\037");
+        }
+        else {
+            result.value = result.value + subExpr.value;
+        }
+    }
+    result.cond = allPassed;
+    return result;
+}
+
+ScriptResult ScriptParser::evalConditional(const Expression& exp, const auto& tracks) const
+{
+    ScriptResult result;
+    QStringList exprResult;
+    result.cond = true;
+
+    auto arg = std::get<ExpressionList>(exp.value);
+    for(const Expression& subArg : arg) {
+        const auto subExpr = evalExpression(subArg, tracks);
+
+        // Literals return false
+        if(subArg.type != Expr::Literal) {
+            if(!subExpr.cond || subExpr.value.isEmpty()) {
+                // No need to evaluate rest
+                result.value.clear();
+                result.cond = false;
+                return result;
+            }
+        }
+        if(subExpr.value.contains(u"\037")) {
+            const QStringList evalList = evalStringList(subExpr, exprResult);
+            if(!evalList.empty()) {
+                exprResult = evalList;
+            }
+        }
+        else {
+            if(exprResult.empty()) {
+                exprResult.append(subExpr.value);
+            }
+            else {
+                std::ranges::transform(exprResult, exprResult.begin(),
+                                       [&](const QString& retValue) -> QString { return retValue + subExpr.value; });
+            }
+        }
+    }
+    if(exprResult.size() == 1) {
+        result.value = exprResult.constFirst();
+    }
+    else if(exprResult.size() > 1) {
+        result.value = exprResult.join(u"\037");
+    }
+    return result;
 }
 } // namespace Fooyin

--- a/src/core/scripting/scriptscanner.cpp
+++ b/src/core/scripting/scriptscanner.cpp
@@ -33,6 +33,9 @@ bool isLiteral(const QChar ch)
         case(ScriptScanner::TokVar):
         case(ScriptScanner::TokLeftAngle):
         case(ScriptScanner::TokRightAngle):
+        case(ScriptScanner::TokSlash):
+        case(ScriptScanner::TokColon):
+        case(ScriptScanner::TokEquals):
         case(ScriptScanner::TokEscape):
             return false;
         default:
@@ -45,6 +48,33 @@ void ScriptScanner::setup(const QString& input)
     m_input   = input;
     m_start   = m_input.cbegin();
     m_current = m_start;
+
+    m_tokens.clear();
+    m_currentTokenIndex = 0;
+
+    while(!isAtEnd()) {
+        m_tokens.emplace_back(scanNext());
+    }
+}
+
+ScriptScanner::Token ScriptScanner::next()
+{
+    if(m_currentTokenIndex < 0 || std::cmp_greater_equal(m_currentTokenIndex, m_tokens.size())) {
+        return makeToken(TokEos);
+    }
+
+    return m_tokens.at(m_currentTokenIndex++);
+}
+
+ScriptScanner::Token ScriptScanner::peekNext(int delta)
+{
+    const int next = m_currentTokenIndex + delta - 1;
+
+    if(next < 0 || std::cmp_greater_equal(next, m_tokens.size())) {
+        return makeToken(TokEos);
+    }
+
+    return m_tokens.at(next);
 }
 
 ScriptScanner::Token ScriptScanner::scanNext()
@@ -78,6 +108,12 @@ ScriptScanner::Token ScriptScanner::scanNext()
             return makeToken(TokComma);
         case('"'):
             return makeToken(TokQuote);
+        case('/'):
+            return makeToken(TokSlash);
+        case(':'):
+            return makeToken(TokColon);
+        case('='):
+            return makeToken(TokEquals);
         case('\\'):
             return makeToken(TokEscape);
         default:

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -14,6 +14,8 @@ set(SOURCES
     ${CMAKE_SOURCE_DIR}/include/gui/windowcontroller.h
     ${CMAKE_SOURCE_DIR}/include/gui/plugins/guiplugin.h
     ${CMAKE_SOURCE_DIR}/include/gui/plugins/guiplugincontext.h
+    ${CMAKE_SOURCE_DIR}/include/gui/scripting/scriptformatter.h
+    ${CMAKE_SOURCE_DIR}/include/gui/scripting/scriptformatterregistry.h
     ${CMAKE_SOURCE_DIR}/include/gui/widgets/customisableinput.h
     ${CMAKE_SOURCE_DIR}/include/gui/widgets/toolbutton.h
     coverprovider.cpp
@@ -130,6 +132,8 @@ set(SOURCES
     sandbox/sandboxdialog.h
     sandbox/scripthighlighter.cpp
     sandbox/scripthighlighter.h
+    scripting/scriptformatter.cpp
+    scripting/scriptformatterregistry.cpp
     search/searchcontroller.cpp
     search/searchcontroller.h
     search/searchwidget.cpp

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     ${CMAKE_SOURCE_DIR}/include/gui/windowcontroller.h
     ${CMAKE_SOURCE_DIR}/include/gui/plugins/guiplugin.h
     ${CMAKE_SOURCE_DIR}/include/gui/plugins/guiplugincontext.h
+    ${CMAKE_SOURCE_DIR}/include/gui/scripting/richtext.h
     ${CMAKE_SOURCE_DIR}/include/gui/scripting/scriptformatter.h
     ${CMAKE_SOURCE_DIR}/include/gui/scripting/scriptformatterregistry.h
     ${CMAKE_SOURCE_DIR}/include/gui/widgets/customisableinput.h

--- a/src/gui/playlist/playlistdelegate.cpp
+++ b/src/gui/playlist/playlistdelegate.cpp
@@ -40,8 +40,8 @@ DrawTextResult drawTextBlocks(QPainter* painter, const QStyleOptionViewItem& opt
     const auto colour = option.state & QStyle::State_Selected ? QPalette::HighlightedText : QPalette::NoRole;
 
     for(const auto& block : blocks) {
-        painter->setFont(block.font);
-        painter->setPen(block.colour);
+        painter->setFont(block.format.font);
+        painter->setPen(block.format.colour);
         result.bound = painter->boundingRect(rect, alignment | Qt::TextWrapAnywhere, block.text);
         option.widget->style()->drawItemText(
             painter, rect, alignment, option.palette, true,
@@ -76,10 +76,10 @@ void paintHeader(QPainter* painter, const QStyleOptionViewItem& option, const QM
     lineColour.setAlpha(40);
     linePen.setColor(lineColour);
 
-    const auto title    = index.data(PlaylistItem::Role::Title).value<TextBlockList>();
-    const auto subtitle = index.data(PlaylistItem::Role::Subtitle).value<TextBlockList>();
-    const auto side     = index.data(PlaylistItem::Role::Right).value<TextBlockList>();
-    const auto info     = index.data(PlaylistItem::Role::Info).value<TextBlockList>();
+    const auto title    = index.data(PlaylistItem::Role::Title).value<FormattedText>();
+    const auto subtitle = index.data(PlaylistItem::Role::Subtitle).value<FormattedText>();
+    const auto side     = index.data(PlaylistItem::Role::Right).value<FormattedText>();
+    const auto info     = index.data(PlaylistItem::Role::Info).value<FormattedText>();
     const auto cover    = index.data(Qt::DecorationRole).value<QPixmap>();
 
     const QRect& rect    = opt.rect;
@@ -161,8 +161,8 @@ void paintSimpleHeader(QPainter* painter, const QStyleOptionViewItem& option, co
     lineColour.setAlpha(40);
     linePen.setColor(lineColour);
 
-    const auto title    = index.data(PlaylistItem::Role::Title).value<TextBlockList>();
-    const auto subtitle = index.data(PlaylistItem::Role::Right).value<TextBlockList>();
+    const auto title    = index.data(PlaylistItem::Role::Title).value<FormattedText>();
+    const auto subtitle = index.data(PlaylistItem::Role::Right).value<FormattedText>();
 
     const QRect& rect    = opt.rect;
     const int height     = rect.height();
@@ -206,8 +206,8 @@ void paintSubheader(QPainter* painter, const QStyleOptionViewItem& option, const
     lineColour.setAlpha(40);
     linePen.setColor(lineColour);
 
-    const auto title    = index.data(PlaylistItem::Role::Title).value<TextBlockList>();
-    const auto subtitle = index.data(PlaylistItem::Role::Subtitle).value<TextBlockList>();
+    const auto title    = index.data(PlaylistItem::Role::Title).value<FormattedText>();
+    const auto subtitle = index.data(PlaylistItem::Role::Subtitle).value<FormattedText>();
 
     const QRect& rect    = opt.rect;
     const int height     = rect.height();
@@ -259,23 +259,33 @@ void paintTrack(QPainter* painter, const QStyleOptionViewItem& option, const QMo
 
     style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, option.widget);
 
+    const int textMargin = style->pixelMetric(QStyle::PM_FocusFrameHMargin, nullptr, option.widget) + 1;
+
     if(singleColumn) {
         const int indent     = icon.isNull() ? index.data(PlaylistItem::Role::Indentation).toInt() : 0;
-        const auto leftSide  = index.data(PlaylistItem::Role::Left).value<TextBlockList>();
-        const auto rightSide = index.data(PlaylistItem::Role::Right).value<TextBlockList>();
-        const int offset     = 5;
+        const auto leftSide  = index.data(PlaylistItem::Role::Left).value<FormattedText>();
+        const auto rightSide = index.data(PlaylistItem::Role::Right).value<FormattedText>();
 
         const QRect textRect = style->subElementRect(QStyle::SE_ItemViewItemText, &option);
 
-        const QRect rightRect     = textRect.adjusted(textRect.center().x() - textRect.left(), 0, -offset, 0);
+        const QRect rightRect     = textRect.adjusted(textRect.center().x() - textRect.left(), 0, -textMargin, 0);
         auto [_, totalRightWidth] = drawTextBlocks(painter, opt, rightRect, rightSide | std::views::reverse,
                                                    Qt::AlignVCenter | Qt::AlignRight);
 
-        const QRect leftRect = textRect.adjusted(indent + offset, 0, -totalRightWidth, 0);
+        const QRect leftRect = textRect.adjusted(indent + textMargin, 0, -totalRightWidth, 0);
         drawTextBlocks(painter, opt, leftRect, leftSide, Qt::AlignVCenter | Qt::AlignLeft);
     }
-    else if(!icon.isNull()) {
-        style->drawItemPixmap(painter, opt.rect, static_cast<int>(opt.displayAlignment), icon);
+    else {
+        const auto columnText = index.data(PlaylistItem::Role::Column).value<FormattedText>();
+
+        const QRect textRect = style->subElementRect(QStyle::SE_ItemViewItemText, &option);
+
+        const QRect columnRect = textRect.adjusted(textMargin, 0, -textMargin, 0);
+        drawTextBlocks(painter, opt, columnRect, columnText, Qt::AlignVCenter | opt.displayAlignment);
+
+        if(!icon.isNull()) {
+            style->drawItemPixmap(painter, opt.rect, static_cast<int>(opt.displayAlignment), icon);
+        }
     }
 }
 

--- a/src/gui/playlist/playlistdelegate.cpp
+++ b/src/gui/playlist/playlistdelegate.cpp
@@ -76,10 +76,10 @@ void paintHeader(QPainter* painter, const QStyleOptionViewItem& option, const QM
     lineColour.setAlpha(40);
     linePen.setColor(lineColour);
 
-    const auto title    = index.data(PlaylistItem::Role::Title).value<FormattedText>();
-    const auto subtitle = index.data(PlaylistItem::Role::Subtitle).value<FormattedText>();
-    const auto side     = index.data(PlaylistItem::Role::Right).value<FormattedText>();
-    const auto info     = index.data(PlaylistItem::Role::Info).value<FormattedText>();
+    const auto title    = index.data(PlaylistItem::Role::Title).value<RichText>();
+    const auto subtitle = index.data(PlaylistItem::Role::Subtitle).value<RichText>();
+    const auto side     = index.data(PlaylistItem::Role::Right).value<RichText>();
+    const auto info     = index.data(PlaylistItem::Role::Info).value<RichText>();
     const auto cover    = index.data(Qt::DecorationRole).value<QPixmap>();
 
     const QRect& rect    = opt.rect;
@@ -161,8 +161,8 @@ void paintSimpleHeader(QPainter* painter, const QStyleOptionViewItem& option, co
     lineColour.setAlpha(40);
     linePen.setColor(lineColour);
 
-    const auto title    = index.data(PlaylistItem::Role::Title).value<FormattedText>();
-    const auto subtitle = index.data(PlaylistItem::Role::Right).value<FormattedText>();
+    const auto title    = index.data(PlaylistItem::Role::Title).value<RichText>();
+    const auto subtitle = index.data(PlaylistItem::Role::Right).value<RichText>();
 
     const QRect& rect    = opt.rect;
     const int height     = rect.height();
@@ -206,8 +206,8 @@ void paintSubheader(QPainter* painter, const QStyleOptionViewItem& option, const
     lineColour.setAlpha(40);
     linePen.setColor(lineColour);
 
-    const auto title    = index.data(PlaylistItem::Role::Title).value<FormattedText>();
-    const auto subtitle = index.data(PlaylistItem::Role::Subtitle).value<FormattedText>();
+    const auto title    = index.data(PlaylistItem::Role::Title).value<RichText>();
+    const auto subtitle = index.data(PlaylistItem::Role::Subtitle).value<RichText>();
 
     const QRect& rect    = opt.rect;
     const int height     = rect.height();
@@ -263,8 +263,8 @@ void paintTrack(QPainter* painter, const QStyleOptionViewItem& option, const QMo
 
     if(singleColumn) {
         const int indent     = icon.isNull() ? index.data(PlaylistItem::Role::Indentation).toInt() : 0;
-        const auto leftSide  = index.data(PlaylistItem::Role::Left).value<FormattedText>();
-        const auto rightSide = index.data(PlaylistItem::Role::Right).value<FormattedText>();
+        const auto leftSide  = index.data(PlaylistItem::Role::Left).value<RichText>();
+        const auto rightSide = index.data(PlaylistItem::Role::Right).value<RichText>();
 
         const QRect textRect = style->subElementRect(QStyle::SE_ItemViewItemText, &option);
 
@@ -276,7 +276,7 @@ void paintTrack(QPainter* painter, const QStyleOptionViewItem& option, const QMo
         drawTextBlocks(painter, opt, leftRect, leftSide, Qt::AlignVCenter | Qt::AlignLeft);
     }
     else {
-        const auto columnText = index.data(PlaylistItem::Role::Column).value<FormattedText>();
+        const auto columnText = index.data(PlaylistItem::Role::Column).value<RichText>();
 
         const QRect textRect = style->subElementRect(QStyle::SE_ItemViewItemText, &option);
 

--- a/src/gui/playlist/playlistitem.h
+++ b/src/gui/playlist/playlistitem.h
@@ -53,6 +53,7 @@ public:
         Index,
         BaseKey,
         SingleColumnMode,
+        Column,
     };
 
     enum class State

--- a/src/gui/playlist/playlistitemmodels.cpp
+++ b/src/gui/playlist/playlistitemmodels.cpp
@@ -36,22 +36,22 @@ int PlaylistContainerItem::trackCount() const
     return static_cast<int>(m_tracks.size());
 }
 
-TextBlockList PlaylistContainerItem::title() const
+FormattedScript PlaylistContainerItem::title() const
 {
     return m_title;
 }
 
-TextBlockList PlaylistContainerItem::subtitle() const
+FormattedScript PlaylistContainerItem::subtitle() const
 {
     return m_subtitle;
 }
 
-TextBlockList PlaylistContainerItem::sideText() const
+FormattedScript PlaylistContainerItem::sideText() const
 {
     return m_sideText;
 }
 
-TextBlockList PlaylistContainerItem::info() const
+FormattedScript PlaylistContainerItem::info() const
 {
     return m_info;
 }
@@ -66,21 +66,20 @@ QSize PlaylistContainerItem::size() const
     return m_size;
 }
 
-void PlaylistContainerItem::updateGroupText(ScriptParser* parser)
+void PlaylistContainerItem::updateGroupText(ScriptParser* parser, ScriptFormatter* formatter)
 {
     if(m_tracks.empty()) {
         return;
     }
 
-    if(!parser) {
+    if(!parser || !formatter) {
         return;
     }
 
-    auto evaluateBlocks = [this, parser](TextBlockList& blocks) {
-        std::erase_if(blocks, [parser, this](TextBlock& block) {
-            block.text = parser->evaluate(block.script, m_tracks);
-            return block.text.isNull();
-        });
+    auto evaluateBlocks = [this, parser, formatter](FormattedScript& script) {
+        script.text.clear();
+        const auto evalScript = parser->evaluate(script.script, m_tracks);
+        script.text           = formatter->evaluate(evalScript);
     };
 
     evaluateBlocks(m_title);
@@ -89,22 +88,22 @@ void PlaylistContainerItem::updateGroupText(ScriptParser* parser)
     evaluateBlocks(m_sideText);
 }
 
-void PlaylistContainerItem::setTitle(const TextBlockList& title)
+void PlaylistContainerItem::setTitle(const FormattedScript& title)
 {
     m_title = title;
 }
 
-void PlaylistContainerItem::setSubtitle(const TextBlockList& subtitle)
+void PlaylistContainerItem::setSubtitle(const FormattedScript& subtitle)
 {
     m_subtitle = subtitle;
 }
 
-void PlaylistContainerItem::setSideText(const TextBlockList& text)
+void PlaylistContainerItem::setSideText(const FormattedScript& text)
 {
     m_sideText = text;
 }
 
-void PlaylistContainerItem::setInfo(const TextBlockList& info)
+void PlaylistContainerItem::setInfo(const FormattedScript& info)
 {
     m_info = info;
 }
@@ -138,10 +137,10 @@ void PlaylistContainerItem::calculateSize()
 
     QSize totalSize;
 
-    auto addSize = [&totalSize](const TextBlockList& blocks, bool addToTotal = true) {
+    auto addSize = [&totalSize](const FormattedScript& script, bool addToTotal = true) {
         QSize blockSize;
-        for(const auto& title : blocks) {
-            const QFontMetrics fm{title.font};
+        for(const auto& title : script.text) {
+            const QFontMetrics fm{title.format.font};
             const QRect br = fm.boundingRect(title.text);
             blockSize.setWidth(blockSize.width() + br.width());
             blockSize.setHeight(std::max(blockSize.height(), br.height()));
@@ -153,17 +152,17 @@ void PlaylistContainerItem::calculateSize()
         return blockSize;
     };
 
-    if(!m_title.empty()) {
+    if(!m_title.text.empty()) {
         addSize(m_title);
     }
 
     QSize subtitleSize;
 
-    if(!m_subtitle.empty()) {
+    if(!m_subtitle.text.empty()) {
         subtitleSize = addSize(m_subtitle, false);
     }
 
-    if(!m_sideText.empty()) {
+    if(!m_sideText.text.empty()) {
         QSize sideSize = addSize(m_sideText, false);
         subtitleSize.setWidth(subtitleSize.width() + sideSize.width());
         subtitleSize.setHeight(std::max(subtitleSize.height(), sideSize.height()));
@@ -172,25 +171,44 @@ void PlaylistContainerItem::calculateSize()
     totalSize.setWidth(totalSize.width() + subtitleSize.width());
     totalSize.setHeight(totalSize.height() + subtitleSize.height() + 4);
 
-    if(!m_info.empty()) {
+    if(!m_info.text.empty()) {
         addSize(m_info);
     }
 
     m_size = totalSize;
 }
 
-PlaylistTrackItem::PlaylistTrackItem(TextBlockList left, TextBlockList right, const Track& track)
+PlaylistTrackItem::PlaylistTrackItem(FormattedScript left, FormattedScript right, const Track& track)
     : m_left{std::move(left)}
     , m_right{std::move(right)}
     , m_track{track}
 { }
 
-TextBlockList PlaylistTrackItem::left() const
+std::vector<FormattedScript> PlaylistTrackItem::columns() const
+{
+    return m_columns;
+}
+
+FormattedScript PlaylistTrackItem::column(int column) const
+{
+    if(column < 0 || std::cmp_greater_equal(column, m_columns.size())) {
+        return {};
+    }
+
+    return m_columns.at(column);
+}
+
+PlaylistTrackItem::PlaylistTrackItem(std::vector<FormattedScript> columns, const Track& track)
+    : m_columns{std::move(columns)}
+    , m_track{track}
+{ }
+
+FormattedScript PlaylistTrackItem::left() const
 {
     return m_left;
 }
 
-TextBlockList PlaylistTrackItem::right() const
+FormattedScript PlaylistTrackItem::right() const
 {
     return m_right;
 }

--- a/src/gui/playlist/playlistitemmodels.cpp
+++ b/src/gui/playlist/playlistitemmodels.cpp
@@ -36,22 +36,22 @@ int PlaylistContainerItem::trackCount() const
     return static_cast<int>(m_tracks.size());
 }
 
-FormattedScript PlaylistContainerItem::title() const
+RichScript PlaylistContainerItem::title() const
 {
     return m_title;
 }
 
-FormattedScript PlaylistContainerItem::subtitle() const
+RichScript PlaylistContainerItem::subtitle() const
 {
     return m_subtitle;
 }
 
-FormattedScript PlaylistContainerItem::sideText() const
+RichScript PlaylistContainerItem::sideText() const
 {
     return m_sideText;
 }
 
-FormattedScript PlaylistContainerItem::info() const
+RichScript PlaylistContainerItem::info() const
 {
     return m_info;
 }
@@ -76,7 +76,7 @@ void PlaylistContainerItem::updateGroupText(ScriptParser* parser, ScriptFormatte
         return;
     }
 
-    auto evaluateBlocks = [this, parser, formatter](FormattedScript& script) {
+    auto evaluateBlocks = [this, parser, formatter](RichScript& script) {
         script.text.clear();
         const auto evalScript = parser->evaluate(script.script, m_tracks);
         script.text           = formatter->evaluate(evalScript);
@@ -88,22 +88,22 @@ void PlaylistContainerItem::updateGroupText(ScriptParser* parser, ScriptFormatte
     evaluateBlocks(m_sideText);
 }
 
-void PlaylistContainerItem::setTitle(const FormattedScript& title)
+void PlaylistContainerItem::setTitle(const RichScript& title)
 {
     m_title = title;
 }
 
-void PlaylistContainerItem::setSubtitle(const FormattedScript& subtitle)
+void PlaylistContainerItem::setSubtitle(const RichScript& subtitle)
 {
     m_subtitle = subtitle;
 }
 
-void PlaylistContainerItem::setSideText(const FormattedScript& text)
+void PlaylistContainerItem::setSideText(const RichScript& text)
 {
     m_sideText = text;
 }
 
-void PlaylistContainerItem::setInfo(const FormattedScript& info)
+void PlaylistContainerItem::setInfo(const RichScript& info)
 {
     m_info = info;
 }
@@ -137,7 +137,7 @@ void PlaylistContainerItem::calculateSize()
 
     QSize totalSize;
 
-    auto addSize = [&totalSize](const FormattedScript& script, bool addToTotal = true) {
+    auto addSize = [&totalSize](const RichScript& script, bool addToTotal = true) {
         QSize blockSize;
         for(const auto& title : script.text) {
             const QFontMetrics fm{title.format.font};
@@ -178,18 +178,18 @@ void PlaylistContainerItem::calculateSize()
     m_size = totalSize;
 }
 
-PlaylistTrackItem::PlaylistTrackItem(FormattedScript left, FormattedScript right, const Track& track)
+PlaylistTrackItem::PlaylistTrackItem(RichScript left, RichScript right, const Track& track)
     : m_left{std::move(left)}
     , m_right{std::move(right)}
     , m_track{track}
 { }
 
-std::vector<FormattedScript> PlaylistTrackItem::columns() const
+std::vector<RichScript> PlaylistTrackItem::columns() const
 {
     return m_columns;
 }
 
-FormattedScript PlaylistTrackItem::column(int column) const
+RichScript PlaylistTrackItem::column(int column) const
 {
     if(column < 0 || std::cmp_greater_equal(column, m_columns.size())) {
         return {};
@@ -198,17 +198,17 @@ FormattedScript PlaylistTrackItem::column(int column) const
     return m_columns.at(column);
 }
 
-PlaylistTrackItem::PlaylistTrackItem(std::vector<FormattedScript> columns, const Track& track)
+PlaylistTrackItem::PlaylistTrackItem(std::vector<RichScript> columns, const Track& track)
     : m_columns{std::move(columns)}
     , m_track{track}
 { }
 
-FormattedScript PlaylistTrackItem::left() const
+RichScript PlaylistTrackItem::left() const
 {
     return m_left;
 }
 
-FormattedScript PlaylistTrackItem::right() const
+RichScript PlaylistTrackItem::right() const
 {
     return m_right;
 }

--- a/src/gui/playlist/playlistitemmodels.h
+++ b/src/gui/playlist/playlistitemmodels.h
@@ -37,19 +37,19 @@ public:
     [[nodiscard]] TrackList tracks() const;
     [[nodiscard]] int trackCount() const;
 
-    [[nodiscard]] FormattedScript title() const;
-    [[nodiscard]] FormattedScript subtitle() const;
-    [[nodiscard]] FormattedScript sideText() const;
-    [[nodiscard]] FormattedScript info() const;
+    [[nodiscard]] RichScript title() const;
+    [[nodiscard]] RichScript subtitle() const;
+    [[nodiscard]] RichScript sideText() const;
+    [[nodiscard]] RichScript info() const;
     [[nodiscard]] int rowHeight() const;
     [[nodiscard]] QSize size() const;
 
     void updateGroupText(ScriptParser* parser, ScriptFormatter* formatter);
 
-    void setTitle(const FormattedScript& title);
-    void setSubtitle(const FormattedScript& subtitle);
-    void setSideText(const FormattedScript& text);
-    void setInfo(const FormattedScript& info);
+    void setTitle(const RichScript& title);
+    void setSubtitle(const RichScript& subtitle);
+    void setSideText(const RichScript& text);
+    void setInfo(const RichScript& info);
     void setRowHeight(int height);
 
     void addTrack(const Track& track);
@@ -61,10 +61,10 @@ public:
 private:
     TrackList m_tracks;
 
-    FormattedScript m_title;
-    FormattedScript m_subtitle;
-    FormattedScript m_sideText;
-    FormattedScript m_info;
+    RichScript m_title;
+    RichScript m_subtitle;
+    RichScript m_sideText;
+    RichScript m_info;
 
     QSize m_size;
     int m_rowHeight;
@@ -74,19 +74,19 @@ class PlaylistTrackItem
 {
 public:
     PlaylistTrackItem() = default;
-    PlaylistTrackItem(std::vector<FormattedScript> columns, const Track& track);
-    PlaylistTrackItem(FormattedScript left, FormattedScript right, const Track& track);
+    PlaylistTrackItem(std::vector<RichScript> columns, const Track& track);
+    PlaylistTrackItem(RichScript left, RichScript right, const Track& track);
 
-    [[nodiscard]] std::vector<FormattedScript> columns() const;
-    [[nodiscard]] FormattedScript column(int column) const;
-    [[nodiscard]] FormattedScript left() const;
-    [[nodiscard]] FormattedScript right() const;
+    [[nodiscard]] std::vector<RichScript> columns() const;
+    [[nodiscard]] RichScript column(int column) const;
+    [[nodiscard]] RichScript left() const;
+    [[nodiscard]] RichScript right() const;
     [[nodiscard]] Track track() const;
 
 private:
-    std::vector<FormattedScript> m_columns;
-    FormattedScript m_left;
-    FormattedScript m_right;
+    std::vector<RichScript> m_columns;
+    RichScript m_left;
+    RichScript m_right;
 
     Track m_track;
 };

--- a/src/gui/playlist/playlistitemmodels.h
+++ b/src/gui/playlist/playlistitemmodels.h
@@ -22,6 +22,7 @@
 #include "playlistpreset.h"
 
 #include <core/track.h>
+#include <gui/scripting/scriptformatter.h>
 
 #include <QSize>
 
@@ -36,19 +37,19 @@ public:
     [[nodiscard]] TrackList tracks() const;
     [[nodiscard]] int trackCount() const;
 
-    [[nodiscard]] TextBlockList title() const;
-    [[nodiscard]] TextBlockList subtitle() const;
-    [[nodiscard]] TextBlockList sideText() const;
-    [[nodiscard]] TextBlockList info() const;
+    [[nodiscard]] FormattedScript title() const;
+    [[nodiscard]] FormattedScript subtitle() const;
+    [[nodiscard]] FormattedScript sideText() const;
+    [[nodiscard]] FormattedScript info() const;
     [[nodiscard]] int rowHeight() const;
     [[nodiscard]] QSize size() const;
 
-    void updateGroupText(ScriptParser* parser);
+    void updateGroupText(ScriptParser* parser, ScriptFormatter* formatter);
 
-    void setTitle(const TextBlockList& title);
-    void setSubtitle(const TextBlockList& subtitle);
-    void setSideText(const TextBlockList& text);
-    void setInfo(const TextBlockList& info);
+    void setTitle(const FormattedScript& title);
+    void setSubtitle(const FormattedScript& subtitle);
+    void setSideText(const FormattedScript& text);
+    void setInfo(const FormattedScript& info);
     void setRowHeight(int height);
 
     void addTrack(const Track& track);
@@ -60,10 +61,10 @@ public:
 private:
     TrackList m_tracks;
 
-    TextBlockList m_title;
-    TextBlockList m_subtitle;
-    TextBlockList m_sideText;
-    TextBlockList m_info;
+    FormattedScript m_title;
+    FormattedScript m_subtitle;
+    FormattedScript m_sideText;
+    FormattedScript m_info;
 
     QSize m_size;
     int m_rowHeight;
@@ -73,15 +74,19 @@ class PlaylistTrackItem
 {
 public:
     PlaylistTrackItem() = default;
-    PlaylistTrackItem(TextBlockList left, TextBlockList right, const Track& track);
+    PlaylistTrackItem(std::vector<FormattedScript> columns, const Track& track);
+    PlaylistTrackItem(FormattedScript left, FormattedScript right, const Track& track);
 
-    [[nodiscard]] TextBlockList left() const;
-    [[nodiscard]] TextBlockList right() const;
+    [[nodiscard]] std::vector<FormattedScript> columns() const;
+    [[nodiscard]] FormattedScript column(int column) const;
+    [[nodiscard]] FormattedScript left() const;
+    [[nodiscard]] FormattedScript right() const;
     [[nodiscard]] Track track() const;
 
 private:
-    TextBlockList m_left;
-    TextBlockList m_right;
+    std::vector<FormattedScript> m_columns;
+    FormattedScript m_left;
+    FormattedScript m_right;
 
     Track m_track;
 };

--- a/src/gui/playlist/playlistmodel.cpp
+++ b/src/gui/playlist/playlistmodel.cpp
@@ -1204,17 +1204,17 @@ QVariant PlaylistModel::trackData(PlaylistItem* item, int column, int role) cons
                         && m_currentPlayingTrack.indexInPlaylist == item->index();
 
     switch(role) {
-        case(Qt::DisplayRole): {
-            if(!singleColumnMode && column >= 0 && std::cmp_less(column, track.left().size())) {
-                return track.left().at(column).text;
+        case(PlaylistItem::Role::Column): {
+            if(!singleColumnMode) {
+                return QVariant::fromValue(track.column(column).text);
             }
-            return {};
+            break;
         }
         case(PlaylistItem::Role::Left): {
-            return track.left();
+            return QVariant::fromValue(track.left().text);
         }
         case(PlaylistItem::Role::Right): {
-            return track.right();
+            return QVariant::fromValue(track.right().text);
         }
         case(PlaylistItem::Role::ItemData): {
             return QVariant::fromValue<Track>(track.track());
@@ -1239,12 +1239,6 @@ QVariant PlaylistModel::trackData(PlaylistItem* item, int column, int role) cons
         }
         case(Qt::SizeHintRole): {
             return QSize{0, m_currentPreset.track.rowHeight};
-        }
-        case(Qt::FontRole): {
-            if(!m_columns.empty() && column >= 0 && column < static_cast<int>(track.left().size())) {
-                return track.left().at(column).font;
-            }
-            break;
         }
         case(Qt::DecorationRole): {
             if(m_columns.empty() || m_columns.at(column).field == QString::fromLatin1(PlayingIcon)) {
@@ -1289,19 +1283,19 @@ QVariant PlaylistModel::headerData(PlaylistItem* item, int column, int role) con
 
     switch(role) {
         case(PlaylistItem::Role::Title): {
-            return header.title();
+            return QVariant::fromValue(header.title().text);
         }
         case(PlaylistItem::Role::Simple): {
             return m_currentPreset.header.simple;
         }
         case(PlaylistItem::Role::Subtitle): {
-            return header.subtitle();
+            return QVariant::fromValue(header.subtitle().text);
         }
         case(PlaylistItem::Role::Info): {
-            return header.info();
+            return QVariant::fromValue(header.info().text);
         }
         case(PlaylistItem::Role::Right): {
-            return header.sideText();
+            return QVariant::fromValue(header.sideText().text);
         }
         case(Qt::DecorationRole): {
             if(m_currentPreset.header.simple || !m_currentPreset.header.showCover) {
@@ -1328,10 +1322,10 @@ QVariant PlaylistModel::subheaderData(PlaylistItem* item, int column, int role) 
 
     switch(role) {
         case(PlaylistItem::Role::Title): {
-            return header.title();
+            return QVariant::fromValue(header.title().text);
         }
         case(PlaylistItem::Role::Subtitle): {
-            return header.subtitle();
+            return QVariant::fromValue(header.subtitle().text);
         }
         case(PlaylistItem::Role::Indentation): {
             return item->indentation();

--- a/src/gui/playlist/playlistpopulator.cpp
+++ b/src/gui/playlist/playlistpopulator.cpp
@@ -109,7 +109,7 @@ struct PlaylistPopulator::Private
             return;
         }
 
-        auto evaluateBlocks = [this, track](FormattedScript& script) -> QString {
+        auto evaluateBlocks = [this, track](RichScript& script) -> QString {
             script.text.clear();
             const auto evalScript = parser.evaluate(script.script, track);
             if(!evalScript.isEmpty()) {
@@ -230,7 +230,7 @@ struct PlaylistPopulator::Private
             return nullptr;
         }
 
-        auto evaluateTrack = [this, &track](FormattedScript& script) {
+        auto evaluateTrack = [this, &track](RichScript& script) {
             script.text.clear();
             const auto evalScript = parser.evaluate(script.script, track);
             if(!evalScript.isEmpty()) {

--- a/src/gui/playlist/playlistpopulator.cpp
+++ b/src/gui/playlist/playlistpopulator.cpp
@@ -44,6 +44,8 @@ struct PlaylistPopulator::Private
     std::unique_ptr<PlaylistScriptRegistry> registry;
     ScriptParser parser;
 
+    ScriptFormatter formatter;
+
     QString prevBaseHeaderKey;
     QString prevHeaderKey;
     std::vector<QString> prevBaseSubheaderKey;
@@ -73,17 +75,6 @@ struct PlaylistPopulator::Private
         prevHeaderKey.clear();
     }
 
-    void updateScripts()
-    {
-        if(!columns.empty()) {
-            TextBlockList columnBlocks;
-            for(const auto& column : columns) {
-                columnBlocks.emplace_back(column.field);
-            }
-            currentPreset.track.leftText = columnBlocks;
-        }
-    }
-
     PlaylistItem* getOrInsertItem(const QString& key, PlaylistItem::ItemType type, const Data& item,
                                   PlaylistItem* parent, const QString& baseKey)
     {
@@ -107,7 +98,7 @@ struct PlaylistPopulator::Private
     void updateContainers()
     {
         for(const auto& [key, container] : headers) {
-            container->updateGroupText(&parser);
+            container->updateGroupText(&parser, &formatter);
         }
     }
 
@@ -118,25 +109,18 @@ struct PlaylistPopulator::Private
             return;
         }
 
-        auto evaluateBlocks = [this, track](const TextBlockList& presetBlocks, TextBlockList& headerBlocks) -> QString {
-            QString key;
-            headerBlocks.clear();
-            for(const TextBlock& block : presetBlocks) {
-                TextBlock headerBlock{block};
-                headerBlock.text = parser.evaluate(headerBlock.script, track);
-                if(!headerBlock.text.isEmpty()) {
-                    headerBlocks.push_back(headerBlock);
-                }
-                key += headerBlock.text;
+        auto evaluateBlocks = [this, track](FormattedScript& script) -> QString {
+            script.text.clear();
+            const auto evalScript = parser.evaluate(script.script, track);
+            if(!evalScript.isEmpty()) {
+                script.text = formatter.evaluate(evalScript);
             }
-            return key;
+            return evalScript;
         };
 
-        auto generateHeaderKey = [this, &row, &evaluateBlocks]() {
-            return Utils::generateHash(evaluateBlocks(currentPreset.header.title, row.title),
-                                       evaluateBlocks(currentPreset.header.subtitle, row.subtitle),
-                                       evaluateBlocks(currentPreset.header.sideText, row.sideText),
-                                       evaluateBlocks(currentPreset.header.info, row.info));
+        auto generateHeaderKey = [&row, &evaluateBlocks]() {
+            return Utils::generateHash(evaluateBlocks(row.title), evaluateBlocks(row.subtitle),
+                                       evaluateBlocks(row.sideText), evaluateBlocks(row.info));
         };
 
         const QString baseKey = generateHeaderKey();
@@ -171,12 +155,10 @@ struct PlaylistPopulator::Private
     void iterateSubheaders(const Track& track, PlaylistItem*& parent)
     {
         for(auto& subheader : currentPreset.subHeaders) {
-            for(auto& block : subheader.leftText) {
-                block.text = parser.evaluate(block.script, track);
-            }
-            for(auto& block : subheader.rightText) {
-                block.text = parser.evaluate(block.script, track);
-            }
+            const auto leftScript    = parser.evaluate(subheader.leftText.script, track);
+            subheader.leftText.text  = formatter.evaluate(leftScript);
+            const auto rightScript   = parser.evaluate(subheader.rightText.script, track);
+            subheader.rightText.text = formatter.evaluate(rightScript);
 
             PlaylistContainerItem currentContainer;
             currentContainer.setTitle(subheader.leftText);
@@ -192,10 +174,10 @@ struct PlaylistPopulator::Private
 
         auto generateSubheaderKey = [](const PlaylistContainerItem& subheader) {
             QString subheaderKey;
-            for(const TextBlock& block : subheader.title()) {
+            for(const auto& block : subheader.title().text) {
                 subheaderKey += block.text;
             }
-            for(const TextBlock& block : subheader.subtitle()) {
+            for(const auto& block : subheader.subtitle().text) {
                 subheaderKey += block.text;
             }
             return subheaderKey;
@@ -248,21 +230,32 @@ struct PlaylistPopulator::Private
             return nullptr;
         }
 
-        auto evaluateTrack = [this, &track](const TextBlockList& blocks, TextBlockList& trackRow) {
-            for(const TextBlock& block : blocks) {
-                TextBlock trackBlock{block};
-                trackBlock.text = parser.evaluate(block.script, track);
-                trackRow.push_back(trackBlock);
+        auto evaluateTrack = [this, &track](FormattedScript& script) {
+            script.text.clear();
+            const auto evalScript = parser.evaluate(script.script, track);
+            if(!evalScript.isEmpty()) {
+                script.text = formatter.evaluate(evalScript);
             }
         };
 
         registry->setTrackIndex(index);
 
-        TrackRow trackRow;
-        evaluateTrack(currentPreset.track.leftText, trackRow.leftText);
-        evaluateTrack(currentPreset.track.rightText, trackRow.rightText);
+        TrackRow trackRow{currentPreset.track};
+        PlaylistTrackItem playlistTrack;
 
-        PlaylistTrackItem playlistTrack{trackRow.leftText, trackRow.rightText, track};
+        if(!columns.empty()) {
+            for(const auto& column : columns) {
+                const auto evalScript = parser.evaluate(column.field, track);
+                trackRow.columns.emplace_back(column.field, formatter.evaluate(evalScript));
+            }
+            playlistTrack = {trackRow.columns, track};
+        }
+        else {
+            evaluateTrack(trackRow.leftText);
+            evaluateTrack(trackRow.rightText);
+
+            playlistTrack = {trackRow.leftText, trackRow.rightText, track};
+        }
 
         const QString baseKey = Utils::generateHash(parent->key(), track.hash(), QString::number(index));
         const QString key     = Utils::generateRandomHash();
@@ -358,7 +351,6 @@ void PlaylistPopulator::run(const Id& playlistId, const PlaylistPreset& preset, 
     p->pendingTracks   = tracks;
     p->registry->setup(playlistId, p->playerController->playbackQueue());
 
-    p->updateScripts();
     p->runBatch(TrackPreloadSize, 0);
 
     emit finished();
@@ -378,7 +370,6 @@ void PlaylistPopulator::runTracks(const Id& playlistId, const PlaylistPreset& pr
     p->columns         = columns;
     p->registry->setup(playlistId, p->playerController->playbackQueue());
 
-    p->updateScripts();
     p->runTracksGroup(tracks);
 
     setState(Idle);
@@ -392,7 +383,7 @@ void PlaylistPopulator::updateHeaders(const ItemList& headers)
 
     for(const PlaylistItem& item : headers) {
         PlaylistContainerItem& header = std::get<1>(item.data());
-        header.updateGroupText(&p->parser);
+        header.updateGroupText(&p->parser, &p->formatter);
         updatedHeaders.emplace(item.key(), item);
     }
 

--- a/src/gui/playlist/playlistpreset.cpp
+++ b/src/gui/playlist/playlistpreset.cpp
@@ -23,70 +23,15 @@
 #include <QPalette>
 
 namespace Fooyin {
-TextBlock::TextBlock()
-    : TextBlock{QStringLiteral("")}
-{ }
-
-TextBlock::TextBlock(QString script_, int fontDelta)
-    : script{std::move(script_)}
-    , colour{QApplication::palette().text().color()}
+QDataStream& operator<<(QDataStream& stream, const FormattedScript& script)
 {
-    font.setPointSize(font.pointSize() + fontDelta);
-}
-
-QDataStream& operator<<(QDataStream& stream, const TextBlock& block)
-{
-    stream << block.script;
-    stream << block.fontChanged;
-    if(block.fontChanged) {
-        stream << block.font;
-    }
-    stream << block.colourChanged;
-    if(block.colourChanged) {
-        stream << block.colour;
-    }
+    stream << script.script;
     return stream;
 }
 
-QDataStream& operator>>(QDataStream& stream, TextBlock& block)
+QDataStream& operator>>(QDataStream& stream, FormattedScript& script)
 {
-    stream >> block.script;
-    stream >> block.fontChanged;
-    if(block.fontChanged) {
-        stream >> block.font;
-    }
-    stream >> block.colourChanged;
-    if(block.colourChanged) {
-        stream >> block.colour;
-    }
-    return stream;
-}
-
-QDataStream& operator<<(QDataStream& stream, const TextBlockList& blocks)
-{
-    stream << static_cast<int>(blocks.size());
-
-    for(const auto& block : blocks) {
-        stream << block;
-    }
-
-    return stream;
-}
-
-QDataStream& operator>>(QDataStream& stream, TextBlockList& blocks)
-{
-    int size;
-    stream >> size;
-
-    while(size > 0) {
-        --size;
-
-        TextBlock block;
-        stream >> block;
-
-        blocks.push_back(block);
-    }
-
+    stream >> script.script;
     return stream;
 }
 

--- a/src/gui/playlist/playlistpreset.cpp
+++ b/src/gui/playlist/playlistpreset.cpp
@@ -23,18 +23,6 @@
 #include <QPalette>
 
 namespace Fooyin {
-QDataStream& operator<<(QDataStream& stream, const FormattedScript& script)
-{
-    stream << script.script;
-    return stream;
-}
-
-QDataStream& operator>>(QDataStream& stream, FormattedScript& script)
-{
-    stream >> script.script;
-    return stream;
-}
-
 QDataStream& operator<<(QDataStream& stream, const HeaderRow& header)
 {
     stream << header.title;

--- a/src/gui/playlist/playlistpreset.h
+++ b/src/gui/playlist/playlistpreset.h
@@ -31,26 +31,12 @@
 #include <QVariant>
 
 namespace Fooyin {
-struct FormattedScript
-{
-    QString script;
-    FormattedText text;
-
-    bool operator==(const FormattedScript& other) const
-    {
-        return std::tie(script, text) == std::tie(other.script, other.text);
-    };
-
-    friend QDataStream& operator<<(QDataStream& stream, const FormattedScript& script);
-    friend QDataStream& operator>>(QDataStream& stream, FormattedScript& script);
-};
-
 struct HeaderRow
 {
-    FormattedScript title;
-    FormattedScript subtitle;
-    FormattedScript sideText;
-    FormattedScript info;
+    RichScript title;
+    RichScript subtitle;
+    RichScript sideText;
+    RichScript info;
 
     int rowHeight{0};
     bool showCover{true};
@@ -75,8 +61,8 @@ struct HeaderRow
 
 struct SubheaderRow
 {
-    FormattedScript leftText;
-    FormattedScript rightText;
+    RichScript leftText;
+    RichScript rightText;
 
     int rowHeight{0};
 
@@ -97,9 +83,9 @@ using SubheaderRows = QList<SubheaderRow>;
 
 struct TrackRow
 {
-    std::vector<FormattedScript> columns;
-    FormattedScript leftText;
-    FormattedScript rightText;
+    std::vector<RichScript> columns;
+    RichScript leftText;
+    RichScript rightText;
 
     int rowHeight{0};
 

--- a/src/gui/playlist/presetregistry.cpp
+++ b/src/gui/playlist/presetregistry.cpp
@@ -44,11 +44,11 @@ void PresetRegistry::loadDefaults()
 
     preset.name = QStringLiteral("Album - Disc");
 
-    preset.header.title.script    = QStringLiteral("<b><sized=2>$if2(%albumartist%,Unknown Artist)</sized></b>");
-    preset.header.subtitle.script = QStringLiteral("<sized=1>$if2(%album%,Unknown Album)</sized>");
+    preset.header.title.script    = QStringLiteral("<b><sized=2>$if2(%albumartist%,Unknown Artist)");
+    preset.header.subtitle.script = QStringLiteral("<sized=1>$if2(%album%,Unknown Album)");
     preset.header.sideText.script = QStringLiteral("<b><sized=2>%year%</sized></b>");
-    preset.header.info.script     = QStringLiteral(
-        "<sized=-1>[%genres% | ]%trackcount% $ifgreater(%trackcount%,1,Tracks,Track) | %playtime%</sized>");
+    preset.header.info.script
+        = QStringLiteral("<sized=-1>[%genres% | ]%trackcount% $ifgreater(%trackcount%,1,Tracks,Track) | %playtime%");
 
     SubheaderRow subheader;
     subheader.leftText.script  = QStringLiteral("$ifgreater(%disctotal%,1,Disc #%disc%)");
@@ -62,7 +62,7 @@ void PresetRegistry::loadDefaults()
     preset.name = QStringLiteral("Split Discs");
 
     preset.header.subtitle.script
-        = QStringLiteral("<sized=1>$if2(%album%,Unknown Album)$ifgreater(%disctotal%,1, ▪ Disc #%disc%)</sized>");
+        = QStringLiteral("<sized=1>$if2(%album%,Unknown Album)$ifgreater(%disctotal%,1, ▪ Disc #%disc%)");
 
     addDefaultItem(preset);
 
@@ -71,7 +71,7 @@ void PresetRegistry::loadDefaults()
     preset.header.simple = true;
     preset.header.subtitle.script.clear();
     preset.header.title.script
-        = QStringLiteral("<b><sized=2>$if2(%albumartist%,Unknown Artist) ▪ $if2(%album%,Unknown Album)</sized></b>");
+        = QStringLiteral("<b><sized=2>$if2(%albumartist%,Unknown Artist) ▪ $if2(%album%,Unknown Album)");
 
     addDefaultItem(preset);
 }

--- a/src/gui/playlist/presetregistry.cpp
+++ b/src/gui/playlist/presetregistry.cpp
@@ -44,13 +44,13 @@ void PresetRegistry::loadDefaults()
 
     preset.name = QStringLiteral("Album - Disc");
 
-    preset.header.title.script    = QStringLiteral("$if2(%albumartist%,Unknown Artist)");
-    preset.header.subtitle.script = QStringLiteral("$if2(%album%,Unknown Album)");
-    preset.header.sideText.script = QStringLiteral("%year%");
-    preset.header.info.script
-        = QStringLiteral("[%genres% | ]%trackcount% $ifgreater(%trackcount%,1,Tracks,Track) | %playtime%");
+    preset.header.title.script    = QStringLiteral("<b><sized=2>$if2(%albumartist%,Unknown Artist)</sized></b>");
+    preset.header.subtitle.script = QStringLiteral("<sized=1>$if2(%album%,Unknown Album)</sized>");
+    preset.header.sideText.script = QStringLiteral("<b><sized=2>%year%</sized></b>");
+    preset.header.info.script     = QStringLiteral(
+        "<sized=-1>[%genres% | ]%trackcount% $ifgreater(%trackcount%,1,Tracks,Track) | %playtime%</sized>");
 
-    Fooyin::SubheaderRow subheader;
+    SubheaderRow subheader;
     subheader.leftText.script  = QStringLiteral("$ifgreater(%disctotal%,1,Disc #%disc%)");
     subheader.rightText.script = QStringLiteral("$ifgreater(%disctotal%,1,%playtime%)");
     preset.subHeaders.push_back(subheader);
@@ -62,7 +62,7 @@ void PresetRegistry::loadDefaults()
     preset.name = QStringLiteral("Split Discs");
 
     preset.header.subtitle.script
-        = QStringLiteral("$if2(%album%,Unknown Album)$ifgreater(%disctotal%,1, ▪ Disc #%disc%)");
+        = QStringLiteral("<sized=1>$if2(%album%,Unknown Album)$ifgreater(%disctotal%,1, ▪ Disc #%disc%)</sized>");
 
     addDefaultItem(preset);
 
@@ -70,7 +70,8 @@ void PresetRegistry::loadDefaults()
 
     preset.header.simple = true;
     preset.header.subtitle.script.clear();
-    preset.header.title.script = QStringLiteral("$if2(%albumartist%,Unknown Artist) ▪ $if2(%album%,Unknown Album)");
+    preset.header.title.script
+        = QStringLiteral("<b><sized=2>$if2(%albumartist%,Unknown Artist) ▪ $if2(%album%,Unknown Album)</sized></b>");
 
     addDefaultItem(preset);
 }

--- a/src/gui/playlist/presetregistry.cpp
+++ b/src/gui/playlist/presetregistry.cpp
@@ -37,28 +37,22 @@ void PresetRegistry::loadDefaults()
 
     preset.name = QStringLiteral("Track Table");
 
-    preset.track.leftText.emplace_back(QStringLiteral("$num(%track%,2).   "));
-    preset.track.leftText.emplace_back(QStringLiteral("%title%"));
-    preset.track.rightText.emplace_back(QStringLiteral("$ifgreater(%playcount%,0,%playcount% |)      "));
-    preset.track.rightText.emplace_back(QStringLiteral("$timems(%duration%)"));
+    preset.track.leftText.script  = QStringLiteral("$num(%track%,2).   %title%");
+    preset.track.rightText.script = QStringLiteral("$ifgreater(%playcount%,0,%playcount% |)      $timems(%duration%)");
 
     addDefaultItem(preset);
 
     preset.name = QStringLiteral("Album - Disc");
 
-    TextBlock titleBlock{QStringLiteral("$if2(%albumartist%,Unknown Artist)"), 2};
-    titleBlock.font.setBold(true);
-    preset.header.title.emplace_back(titleBlock);
-    preset.header.subtitle.emplace_back(QStringLiteral("$if2(%album%,Unknown Album)"), 1);
-    TextBlock sideBlock{QStringLiteral("%year%"), 1};
-    sideBlock.font.setBold(true);
-    preset.header.sideText.emplace_back(sideBlock);
-    preset.header.info.emplace_back(
-        QStringLiteral("[%genres% | ]%trackcount% $ifgreater(%trackcount%,1,Tracks,Track) | %playtime%"), -1);
+    preset.header.title.script    = QStringLiteral("$if2(%albumartist%,Unknown Artist)");
+    preset.header.subtitle.script = QStringLiteral("$if2(%album%,Unknown Album)");
+    preset.header.sideText.script = QStringLiteral("%year%");
+    preset.header.info.script
+        = QStringLiteral("[%genres% | ]%trackcount% $ifgreater(%trackcount%,1,Tracks,Track) | %playtime%");
 
     Fooyin::SubheaderRow subheader;
-    subheader.leftText.emplace_back(QStringLiteral("$ifgreater(%disctotal%,1,Disc #%disc%)"));
-    subheader.rightText.emplace_back(QStringLiteral("$ifgreater(%disctotal%,1,%playtime%)"));
+    subheader.leftText.script  = QStringLiteral("$ifgreater(%disctotal%,1,Disc #%disc%)");
+    subheader.rightText.script = QStringLiteral("$ifgreater(%disctotal%,1,%playtime%)");
     preset.subHeaders.push_back(subheader);
 
     addDefaultItem(preset);
@@ -67,19 +61,16 @@ void PresetRegistry::loadDefaults()
 
     preset.name = QStringLiteral("Split Discs");
 
-    preset.header.subtitle.clear();
-    preset.header.subtitle.emplace_back(
-        QStringLiteral("$if2(%album%,Unknown Album)$ifgreater(%disctotal%,1, ▪ Disc #%disc%)"), 1);
+    preset.header.subtitle.script
+        = QStringLiteral("$if2(%album%,Unknown Album)$ifgreater(%disctotal%,1, ▪ Disc #%disc%)");
 
     addDefaultItem(preset);
 
     preset.name = QStringLiteral("Simple Header");
 
     preset.header.simple = true;
-    preset.header.title.clear();
-    preset.header.subtitle.clear();
-    preset.header.title.emplace_back(QStringLiteral("$if2(%albumartist%,Unknown Artist) ▪ $if2(%album%,Unknown Album)"),
-                                     2);
+    preset.header.subtitle.script.clear();
+    preset.header.title.script = QStringLiteral("$if2(%albumartist%,Unknown Artist) ▪ $if2(%album%,Unknown Album)");
 
     addDefaultItem(preset);
 }

--- a/src/gui/sandbox/scripthighlighter.cpp
+++ b/src/gui/sandbox/scripthighlighter.cpp
@@ -70,6 +70,9 @@ void ScriptHighlighter::expression()
         case(ScriptScanner::TokRightParen):
         case(ScriptScanner::TokRightSquare):
         case(ScriptScanner::TokLiteral):
+        case(ScriptScanner::TokSlash):
+        case(ScriptScanner::TokColon):
+        case(ScriptScanner::TokEquals):
         case(ScriptScanner::TokEos):
         case(ScriptScanner::TokError):
             break;
@@ -140,7 +143,7 @@ void ScriptHighlighter::setTokenFormat(const QTextCharFormat& format)
 void ScriptHighlighter::advance()
 {
     m_previous = m_current;
-    m_current  = m_scanner.scanNext();
+    m_current  = m_scanner.next();
 }
 
 bool ScriptHighlighter::currentToken(ScriptScanner::TokenType type) const

--- a/src/gui/scripting/scriptformatter.cpp
+++ b/src/gui/scripting/scriptformatter.cpp
@@ -1,0 +1,262 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <gui/scripting/scriptformatter.h>
+
+#include <core/scripting/scriptparser.h>
+#include <core/scripting/scriptscanner.h>
+#include <gui/scripting/scriptformatterregistry.h>
+
+#include <QApplication>
+#include <QPalette>
+
+#include <stack>
+
+namespace Fooyin {
+struct ScriptFormatter::Private
+{
+    ScriptScanner scanner;
+    ScriptFormatterRegistry registry;
+
+    ScriptScanner::Token current;
+    ScriptScanner::Token previous;
+
+    ErrorList errors;
+
+    FormattedTextBlock currentFormat;
+    std::stack<FormattedTextBlock> formatStack;
+    std::vector<FormattedTextBlock> nestedFormats;
+
+    FormattedText formatResult;
+
+    void advance()
+    {
+        previous = current;
+
+        current = scanner.next();
+        if(current.type == ScriptScanner::TokError) {
+            errorAtCurrent(current.value.toString());
+        }
+    }
+
+    void consume(ScriptScanner::TokenType type, const QString& message)
+    {
+        if(current.type == type) {
+            advance();
+            return;
+        }
+        errorAtCurrent(message);
+    }
+
+    void errorAtCurrent(const QString& message)
+    {
+        errorAt(current, message);
+    }
+
+    void error(const QString& message)
+    {
+        errorAt(previous, message);
+    }
+
+    void errorAt(const ScriptScanner::Token& token, const QString& message)
+    {
+        QString errorMsg = QStringLiteral("[%1] Error").arg(token.position);
+
+        if(token.type == ScriptScanner::TokEos) {
+            errorMsg += QStringLiteral(" at end of string");
+        }
+        else {
+            errorMsg += QStringLiteral(": '") + token.value.toString() + QStringLiteral("'");
+        }
+
+        errorMsg += QString::fromLatin1(" (%1)").arg(message);
+
+        ScriptError currentError;
+        currentError.value    = token.value.toString();
+        currentError.position = token.position;
+        currentError.message  = errorMsg;
+
+        errors.emplace_back(currentError);
+    }
+
+    void expression()
+    {
+        advance();
+        switch(previous.type) {
+            case(ScriptScanner::TokLeftAngle):
+                formatBlock();
+                break;
+            case(ScriptScanner::TokVar):
+            case(ScriptScanner::TokFunc):
+            case(ScriptScanner::TokQuote):
+            case(ScriptScanner::TokLeftSquare):
+            case(ScriptScanner::TokEscape):
+            case(ScriptScanner::TokRightAngle):
+            case(ScriptScanner::TokComma):
+            case(ScriptScanner::TokLeftParen):
+            case(ScriptScanner::TokRightParen):
+            case(ScriptScanner::TokRightSquare):
+            case(ScriptScanner::TokSlash):
+            case(ScriptScanner::TokColon):
+            case(ScriptScanner::TokEquals):
+            case(ScriptScanner::TokLiteral):
+                currentFormat.text += previous.value.toString();
+            case(ScriptScanner::TokEos):
+            case(ScriptScanner::TokError):
+                break;
+        }
+    }
+
+    void formatBlock()
+    {
+        QString func;
+        QString option;
+
+        bool formatOption{false};
+        while(current.type != ScriptScanner::TokRightAngle && current.type != ScriptScanner::TokEos) {
+            advance();
+            if(previous.type == ScriptScanner::TokEquals) {
+                formatOption = true;
+                advance();
+            }
+
+            if(formatOption) {
+                option.append(previous.value.toString());
+            }
+            else {
+                func.append(previous.value.toString());
+            }
+        }
+
+        processFormat(func, option);
+        closeFormat(func);
+        closeBlock();
+    }
+
+    void processFormat(const QString& func, const QString& option)
+    {
+        if(registry.isFormatFunc(func)) {
+            addBlock();
+            registry.format(currentFormat, func, option);
+        }
+        else {
+            error(QStringLiteral("Format option not found"));
+        }
+
+        consume(ScriptScanner::TokRightAngle, QStringLiteral("Expected '>' after expression"));
+
+        while(current.type != ScriptScanner::TokEos
+              && (current.type != ScriptScanner::TokLeftAngle
+                  || (scanner.peekNext().type != ScriptScanner::TokSlash && scanner.peekNext(2).value != func))) {
+            expression();
+        }
+
+        consume(ScriptScanner::TokLeftAngle, QStringLiteral("Expected '<' after expression"));
+        consume(ScriptScanner::TokSlash, QStringLiteral("Expected '/' after expression"));
+    }
+
+    void closeFormat(const QString& func)
+    {
+        QString closeOption;
+
+        while(current.type != ScriptScanner::TokRightAngle && current.type != ScriptScanner::TokEos) {
+            advance();
+            closeOption.append(previous.value.toString());
+        }
+
+        if(closeOption != func) {
+            error(QStringLiteral("Formatting option not closed"));
+        }
+
+        consume(ScriptScanner::TokRightAngle, QStringLiteral("Expected '>' after expression"));
+    }
+
+    void addBlock()
+    {
+        if(!currentFormat.text.isEmpty()) {
+            if(nestedFormats.empty()) {
+                formatResult.emplace_back(currentFormat);
+            }
+            else {
+                formatStack.emplace(currentFormat);
+            }
+            currentFormat.text.clear();
+        }
+    }
+
+    void closeBlock()
+    {
+        if(!currentFormat.text.isEmpty()) {
+            if(formatStack.empty()) {
+                formatResult.emplace_back(currentFormat);
+            }
+            else {
+                nestedFormats.emplace_back(currentFormat);
+            }
+        }
+
+        if(!formatStack.empty()) {
+            currentFormat = formatStack.top();
+            formatStack.pop();
+        }
+        else {
+            std::ranges::reverse(nestedFormats);
+            formatResult.insert(formatResult.end(), nestedFormats.cbegin(), nestedFormats.cend());
+            nestedFormats.clear();
+            resetFormat();
+        }
+    }
+
+    void resetFormat()
+    {
+        currentFormat               = {};
+        currentFormat.format.colour = qApp->palette().text().color();
+    }
+};
+
+ScriptFormatter::ScriptFormatter()
+    : p{std::make_unique<Private>()}
+{ }
+
+ScriptFormatter::~ScriptFormatter() = default;
+
+FormattedText ScriptFormatter::evaluate(const QString& input)
+{
+    if(input.isEmpty()) {
+        return {};
+    }
+
+    p->resetFormat();
+    p->formatResult.clear();
+    p->scanner.setup(input);
+
+    p->advance();
+    while(p->current.type != ScriptScanner::TokEos) {
+        p->expression();
+    }
+
+    p->consume(ScriptScanner::TokEos, QStringLiteral("Expected end of expression"));
+
+    if(!p->currentFormat.text.isEmpty()) {
+        p->formatResult.emplace_back(p->currentFormat);
+    }
+
+    return p->formatResult;
+}
+} // namespace Fooyin

--- a/src/gui/scripting/scriptformatter.cpp
+++ b/src/gui/scripting/scriptformatter.cpp
@@ -55,6 +55,13 @@ struct ScriptFormatter::Private
         }
     }
 
+    void consume(ScriptScanner::TokenType type)
+    {
+        if(current.type == type) {
+            advance();
+        }
+    }
+
     void consume(ScriptScanner::TokenType type, const QString& message)
     {
         if(current.type == type) {
@@ -145,7 +152,6 @@ struct ScriptFormatter::Private
         }
 
         processFormat(func, option);
-        closeFormat(func);
         closeBlock();
     }
 
@@ -167,12 +173,9 @@ struct ScriptFormatter::Private
             expression();
         }
 
-        consume(ScriptScanner::TokLeftAngle, QStringLiteral("Expected '<' after expression"));
-        consume(ScriptScanner::TokSlash, QStringLiteral("Expected '/' after expression"));
-    }
+        consume(ScriptScanner::TokLeftAngle);
+        consume(ScriptScanner::TokSlash);
 
-    void closeFormat(const QString& func)
-    {
         QString closeOption;
 
         while(current.type != ScriptScanner::TokRightAngle && current.type != ScriptScanner::TokEos) {
@@ -180,11 +183,7 @@ struct ScriptFormatter::Private
             closeOption.append(previous.value.toString());
         }
 
-        if(closeOption != func) {
-            error(QStringLiteral("Formatting option not closed"));
-        }
-
-        consume(ScriptScanner::TokRightAngle, QStringLiteral("Expected '>' after expression"));
+        consume(ScriptScanner::TokRightAngle);
     }
 
     void addBlock()

--- a/src/gui/scripting/scriptformatterregistry.cpp
+++ b/src/gui/scripting/scriptformatterregistry.cpp
@@ -22,28 +22,28 @@
 #include <gui/scripting/scriptformatter.h>
 
 namespace Fooyin {
-using FormatFunc = std::function<void(FormattedTextBlock&, const QString&)>;
+using FormatFunc = std::function<void(RichFormatting&, const QString&)>;
 
-void bold(FormattedTextBlock& text, const QString& /*option*/)
+void bold(RichFormatting& formatting, const QString& /*option*/)
 {
-    text.format.font.setBold(true);
+    formatting.font.setBold(true);
 }
 
-void italic(FormattedTextBlock& text, const QString& /*option*/)
+void italic(RichFormatting& formatting, const QString& /*option*/)
 {
-    text.format.font.setItalic(true);
+    formatting.font.setItalic(true);
 }
 
-void fontFamily(FormattedTextBlock& text, const QString& option)
+void fontFamily(RichFormatting& formatting, const QString& option)
 {
     if(option.isEmpty()) {
         return;
     }
 
-    text.format.font.setFamily(option);
+    formatting.font.setFamily(option);
 }
 
-void fontSize(FormattedTextBlock& text, const QString& option)
+void fontSize(RichFormatting& formatting, const QString& option)
 {
     if(option.isEmpty()) {
         return;
@@ -53,11 +53,11 @@ void fontSize(FormattedTextBlock& text, const QString& option)
     const int size = option.toInt(&isInt);
 
     if(isInt) {
-        text.format.font.setPointSize(size);
+        formatting.font.setPointSize(size);
     }
 }
 
-void fontDelta(FormattedTextBlock& text, const QString& option)
+void fontDelta(RichFormatting& formatting, const QString& option)
 {
     if(option.isEmpty()) {
         return;
@@ -67,11 +67,11 @@ void fontDelta(FormattedTextBlock& text, const QString& option)
     const int delta = option.toInt(&isInt);
 
     if(isInt) {
-        text.format.font.setPointSize(text.format.font.pointSize() + delta);
+        formatting.font.setPointSize(formatting.font.pointSize() + delta);
     }
 }
 
-void colourAlpha(FormattedTextBlock& text, const QString& option)
+void colourAlpha(RichFormatting& formatting, const QString& option)
 {
     if(option.isEmpty()) {
         return;
@@ -81,11 +81,11 @@ void colourAlpha(FormattedTextBlock& text, const QString& option)
     const int alpha = option.toInt(&isInt);
 
     if(isInt) {
-        text.format.colour.setAlpha(alpha);
+        formatting.colour.setAlpha(alpha);
     }
 }
 
-void colourRgb(FormattedTextBlock& text, const QString& option)
+void colourRgb(RichFormatting& formatting, const QString& option)
 {
     if(option.isEmpty()) {
         return;
@@ -104,7 +104,7 @@ void colourRgb(FormattedTextBlock& text, const QString& option)
     const int alpha = (rgb.size() == 4) ? rgb.at(3).toInt(&isInt) : 255;
 
     if(isInt) {
-        text.format.colour.setRgb(red, green, blue, alpha);
+        formatting.colour.setRgb(red, green, blue, alpha);
     }
 }
 
@@ -129,12 +129,12 @@ bool ScriptFormatterRegistry::isFormatFunc(const QString& option) const
     return p->funcs.contains(option);
 }
 
-void ScriptFormatterRegistry::format(FormattedTextBlock& text, const QString& func, const QString& option) const
+void ScriptFormatterRegistry::format(RichFormatting& formatting, const QString& func, const QString& option) const
 {
     if(!isFormatFunc(func)) {
         return;
     }
 
-    p->funcs.at(func)(text, option);
+    p->funcs.at(func)(formatting, option);
 }
 } // namespace Fooyin

--- a/src/gui/scripting/scriptformatterregistry.cpp
+++ b/src/gui/scripting/scriptformatterregistry.cpp
@@ -1,0 +1,140 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <gui/scripting/scriptformatterregistry.h>
+
+#include <gui/scripting/scriptformatter.h>
+
+namespace Fooyin {
+using FormatFunc = std::function<void(FormattedTextBlock&, const QString&)>;
+
+void bold(FormattedTextBlock& text, const QString& /*option*/)
+{
+    text.format.font.setBold(true);
+}
+
+void italic(FormattedTextBlock& text, const QString& /*option*/)
+{
+    text.format.font.setItalic(true);
+}
+
+void fontFamily(FormattedTextBlock& text, const QString& option)
+{
+    if(option.isEmpty()) {
+        return;
+    }
+
+    text.format.font.setFamily(option);
+}
+
+void fontSize(FormattedTextBlock& text, const QString& option)
+{
+    if(option.isEmpty()) {
+        return;
+    }
+
+    bool isInt{false};
+    const int size = option.toInt(&isInt);
+
+    if(isInt) {
+        text.format.font.setPointSize(size);
+    }
+}
+
+void fontDelta(FormattedTextBlock& text, const QString& option)
+{
+    if(option.isEmpty()) {
+        return;
+    }
+
+    bool isInt{false};
+    const int delta = option.toInt(&isInt);
+
+    if(isInt) {
+        text.format.font.setPointSize(text.format.font.pointSize() + delta);
+    }
+}
+
+void colourAlpha(FormattedTextBlock& text, const QString& option)
+{
+    if(option.isEmpty()) {
+        return;
+    }
+
+    bool isInt{false};
+    const int alpha = option.toInt(&isInt);
+
+    if(isInt) {
+        text.format.colour.setAlpha(alpha);
+    }
+}
+
+void colourRgb(FormattedTextBlock& text, const QString& option)
+{
+    if(option.isEmpty()) {
+        return;
+    }
+
+    const QStringList rgb = option.split(QStringLiteral(","));
+
+    if(rgb.size() < 3) {
+        return;
+    }
+
+    bool isInt{false};
+    const int red   = rgb.at(0).toInt(&isInt);
+    const int green = rgb.at(1).toInt(&isInt);
+    const int blue  = rgb.at(2).toInt(&isInt);
+    const int alpha = (rgb.size() == 4) ? rgb.at(3).toInt(&isInt) : 255;
+
+    if(isInt) {
+        text.format.colour.setRgb(red, green, blue, alpha);
+    }
+}
+
+struct ScriptFormatterRegistry::Private
+{
+    std::unordered_map<QString, FormatFunc> funcs{
+        {QStringLiteral("b"), bold},          {QStringLiteral("i"), italic},
+        {QStringLiteral("font"), fontFamily}, {QStringLiteral("size"), fontSize},
+        {QStringLiteral("sized"), fontDelta}, {QStringLiteral("alpha"), colourAlpha},
+        {QStringLiteral("rgb"), colourRgb},
+    };
+};
+
+ScriptFormatterRegistry::ScriptFormatterRegistry()
+    : p{std::make_unique<Private>()}
+{ }
+
+ScriptFormatterRegistry::~ScriptFormatterRegistry() = default;
+
+bool ScriptFormatterRegistry::isFormatFunc(const QString& option) const
+{
+    return p->funcs.contains(option);
+}
+
+void ScriptFormatterRegistry::format(FormattedTextBlock& text, const QString& func, const QString& option) const
+{
+    if(!isFormatFunc(func)) {
+        return;
+    }
+
+    p->funcs.at(func)(text, option);
+}
+} // namespace Fooyin

--- a/src/gui/settings/playlist/playlistpresetspage.cpp
+++ b/src/gui/settings/playlist/playlistpresetspage.cpp
@@ -51,8 +51,8 @@ public:
         : ExpandableInput{ExpandableInput::CustomWidget, parent}
         , m_groupBox{new QGroupBox(this)}
         , m_rowHeight{new QSpinBox(this)}
-        , m_leftScript{new QTextEdit(tr("Left-aligned text") + QStringLiteral(":"), this)}
-        , m_rightScript{new QTextEdit(tr("Right-aligned text") + QStringLiteral(":"), this)}
+        , m_leftScript{new QTextEdit(this)}
+        , m_rightScript{new QTextEdit(this)}
     {
         auto* layout = new QVBoxLayout(this);
         layout->setContentsMargins(0, 0, 0, 0);
@@ -64,10 +64,15 @@ public:
 
         auto* rowHeightLabel = new QLabel(tr("Row height") + QStringLiteral(":"), this);
 
+        auto* leftScript  = new QLabel(tr("Left-aligned") + QStringLiteral(":"), this);
+        auto* rightScript = new QLabel(tr("Right-aligned") + QStringLiteral(":"), this);
+
         groupLayout->addWidget(rowHeightLabel, 0, 0);
         groupLayout->addWidget(m_rowHeight, 0, 1);
-        groupLayout->addWidget(m_leftScript, 1, 0, 1, 3);
-        groupLayout->addWidget(m_rightScript, 2, 0, 1, 3);
+        groupLayout->addWidget(leftScript, 1, 0, 1, 3);
+        groupLayout->addWidget(m_leftScript, 2, 0, 1, 3);
+        groupLayout->addWidget(rightScript, 3, 0, 1, 3);
+        groupLayout->addWidget(m_rightScript, 4, 0, 1, 3);
 
         groupLayout->setColumnStretch(2, 1);
     }
@@ -200,10 +205,10 @@ PlaylistPresetsPageWidget::PlaylistPresetsPageWidget(SettingsManager* settings)
     , m_presetRegistry{settings}
     , m_presetBox{new QComboBox(this)}
     , m_presetTabs{new QTabWidget(this)}
-    , m_headerTitle{new QTextEdit(tr("Title") + QStringLiteral(":"), this)}
-    , m_headerSubtitle{new QTextEdit(tr("Subtitle") + QStringLiteral(":"), this)}
-    , m_headerSideText{new QTextEdit(tr("Side text") + QStringLiteral(":"), this)}
-    , m_headerInfo{new QTextEdit(tr("Info") + QStringLiteral(":"), this)}
+    , m_headerTitle{new QTextEdit(this)}
+    , m_headerSubtitle{new QTextEdit(this)}
+    , m_headerSideText{new QTextEdit(this)}
+    , m_headerInfo{new QTextEdit(this)}
     , m_headerRowHeight{new QSpinBox(this)}
     , m_trackLeftText{new QTextEdit(tr("Left-aligned text") + QStringLiteral(":"), this)}
     , m_trackRightText{new QTextEdit(tr("Right-aligned text") + QStringLiteral(":"), this)}
@@ -232,14 +237,23 @@ PlaylistPresetsPageWidget::PlaylistPresetsPageWidget(SettingsManager* settings)
 
     auto* headerRowHeight = new QLabel(tr("Row height") + QStringLiteral(":"), this);
 
+    auto* headerTitle    = new QLabel(tr("Title") + QStringLiteral(":"), this);
+    auto* headerSubtitle = new QLabel(tr("Subtitle") + QStringLiteral(":"), this);
+    auto* headerSide     = new QLabel(tr("Side") + QStringLiteral(":"), this);
+    auto* headerInfo     = new QLabel(tr("Info") + QStringLiteral(":"), this);
+
     headerLayout->addWidget(headerRowHeight, 0, 0);
     headerLayout->addWidget(m_headerRowHeight, 0, 1);
     headerLayout->addWidget(m_simpleHeader, 1, 0, 1, 2);
     headerLayout->addWidget(m_showCover, 2, 0, 1, 2);
-    headerLayout->addWidget(m_headerTitle, 3, 0, 1, 5);
-    headerLayout->addWidget(m_headerSubtitle, 4, 0, 1, 5);
-    headerLayout->addWidget(m_headerSideText, 5, 0, 1, 5);
-    headerLayout->addWidget(m_headerInfo, 6, 0, 1, 5);
+    headerLayout->addWidget(headerTitle, 3, 0, 1, 5);
+    headerLayout->addWidget(m_headerTitle, 4, 0, 1, 5);
+    headerLayout->addWidget(headerSubtitle, 5, 0, 1, 5);
+    headerLayout->addWidget(m_headerSubtitle, 6, 0, 1, 5);
+    headerLayout->addWidget(headerSide, 7, 0, 1, 5);
+    headerLayout->addWidget(m_headerSideText, 8, 0, 1, 5);
+    headerLayout->addWidget(headerInfo, 9, 0, 1, 5);
+    headerLayout->addWidget(m_headerInfo, 10, 0, 1, 5);
 
     headerLayout->setColumnStretch(4, 1);
     headerLayout->setRowStretch(headerLayout->rowCount(), 1);
@@ -267,10 +281,15 @@ PlaylistPresetsPageWidget::PlaylistPresetsPageWidget(SettingsManager* settings)
 
     auto* trackRowHeight = new QLabel(tr("Row height") + QStringLiteral(":"), this);
 
+    auto* trackLeft  = new QLabel(tr("Left-aligned") + QStringLiteral(":"), this);
+    auto* TrackRight = new QLabel(tr("Right-aligned") + QStringLiteral(":"), this);
+
     trackLayout->addWidget(trackRowHeight, 0, 0);
     trackLayout->addWidget(m_trackRowHeight, 0, 1);
-    trackLayout->addWidget(m_trackLeftText, 1, 0, 1, 3);
-    trackLayout->addWidget(m_trackRightText, 2, 0, 1, 3);
+    trackLayout->addWidget(trackLeft, 1, 0, 1, 3);
+    trackLayout->addWidget(m_trackLeftText, 2, 0, 1, 3);
+    trackLayout->addWidget(TrackRight, 3, 0, 1, 3);
+    trackLayout->addWidget(m_trackRightText, 4, 0, 1, 3);
 
     trackLayout->setColumnStretch(2, 1);
     trackLayout->setRowStretch(trackLayout->rowCount(), 1);

--- a/src/gui/settings/playlist/playlistpresetspage.cpp
+++ b/src/gui/settings/playlist/playlistpresetspage.cpp
@@ -38,71 +38,8 @@
 #include <QPushButton>
 #include <QSpinBox>
 #include <QTabWidget>
+#include <QTextEdit>
 #include <QVBoxLayout>
-
-namespace {
-void setupInputBox(const Fooyin::TextBlock& preset, Fooyin::CustomisableInput* input)
-{
-    input->setText(preset.script);
-    input->setFont(preset.font);
-    input->setColour(preset.colour);
-
-    Fooyin::CustomisableInput::State state;
-    if(preset.colourChanged) {
-        state |= Fooyin::CustomisableInput::ColourChanged;
-    }
-    if(preset.fontChanged) {
-        state |= Fooyin::CustomisableInput::FontChanged;
-    }
-
-    input->setState(state);
-}
-
-void updateTextBlock(const Fooyin::CustomisableInput* input, Fooyin::TextBlock& textBlock)
-{
-    textBlock.script = input->text();
-    textBlock.font   = input->font();
-    textBlock.colour = input->colour();
-
-    auto state = input->state();
-
-    textBlock.fontChanged   = state & Fooyin::CustomisableInput::FontChanged;
-    textBlock.colourChanged = state & Fooyin::CustomisableInput::ColourChanged;
-}
-
-void updateTextBlocks(const Fooyin::ExpandableInputList& presetInputs, Fooyin::TextBlockList& textBlocks)
-{
-    textBlocks.clear();
-
-    for(const auto& input : presetInputs) {
-        if(!input->text().isEmpty()) {
-            if(auto* presetInput = qobject_cast<Fooyin::CustomisableInput*>(input)) {
-                Fooyin::TextBlock block;
-                updateTextBlock(presetInput, block);
-                textBlocks.emplace_back(block);
-            }
-        }
-    }
-}
-
-void createPresetInputs(const Fooyin::TextBlockList& blocks, Fooyin::ExpandableInputBox* box, QWidget* parent)
-{
-    auto createInput = [box, parent](const Fooyin::TextBlock& block) {
-        auto* input = new Fooyin::CustomisableInput(parent);
-        setupInputBox(block, input);
-        box->addInput(input);
-    };
-
-    if(blocks.empty()) {
-        createInput({});
-    }
-    else {
-        for(const auto& block : blocks) {
-            createInput(block);
-        }
-    }
-}
-} // namespace
 
 namespace Fooyin {
 class ExpandableGroupBox : public ExpandableInput
@@ -114,10 +51,8 @@ public:
         : ExpandableInput{ExpandableInput::CustomWidget, parent}
         , m_groupBox{new QGroupBox(this)}
         , m_rowHeight{new QSpinBox(this)}
-        , m_leftBox{new ExpandableInputBox(tr("Left-aligned text") + QStringLiteral(":"), ExpandableInput::CustomWidget,
-                                           this)}
-        , m_rightBox{new ExpandableInputBox(tr("Right-aligned text") + QStringLiteral(":"),
-                                            ExpandableInput::CustomWidget, this)}
+        , m_leftScript{new QTextEdit(tr("Left-aligned text") + QStringLiteral(":"), this)}
+        , m_rightScript{new QTextEdit(tr("Right-aligned text") + QStringLiteral(":"), this)}
     {
         auto* layout = new QVBoxLayout(this);
         layout->setContentsMargins(0, 0, 0, 0);
@@ -127,37 +62,34 @@ public:
 
         m_rowHeight->setValue(rowHeight);
 
-        m_leftBox->setInputWidget([](QWidget* widget) { return new CustomisableInput(widget); });
-        m_rightBox->setInputWidget([](QWidget* widget) { return new CustomisableInput(widget); });
-
         auto* rowHeightLabel = new QLabel(tr("Row height") + QStringLiteral(":"), this);
 
         groupLayout->addWidget(rowHeightLabel, 0, 0);
         groupLayout->addWidget(m_rowHeight, 0, 1);
-        groupLayout->addWidget(m_leftBox, 1, 0, 1, 3);
-        groupLayout->addWidget(m_rightBox, 2, 0, 1, 3);
+        groupLayout->addWidget(m_leftScript, 1, 0, 1, 3);
+        groupLayout->addWidget(m_rightScript, 2, 0, 1, 3);
 
         groupLayout->setColumnStretch(2, 1);
     }
 
-    void addLeftInput(const TextBlock& preset)
+    void setLeftScript(const QString& script)
     {
-        addInput(preset, m_leftBox);
+        m_leftScript->setPlainText(script);
     }
 
-    void addRightInput(const TextBlock& preset)
+    void setRightScript(const QString& script)
     {
-        addInput(preset, m_rightBox);
+        m_rightScript->setPlainText(script);
     }
 
-    ExpandableInputList leftBlocks() const
+    QString leftScript() const
     {
-        return m_leftBox->blocks();
+        return m_leftScript->toPlainText();
     }
 
-    ExpandableInputList rightBlocks() const
+    QString rightScript() const
     {
-        return m_rightBox->blocks();
+        return m_rightScript->toPlainText();
     }
 
     int rowHeight() const
@@ -170,35 +102,15 @@ public:
         ExpandableInput::setReadOnly(readOnly);
 
         m_rowHeight->setReadOnly(readOnly);
-        m_leftBox->setReadOnly(readOnly);
-        m_rightBox->setReadOnly(readOnly);
+        m_leftScript->setReadOnly(readOnly);
+        m_rightScript->setReadOnly(readOnly);
     }
 
 private:
-    void addInput(const TextBlock& preset, ExpandableInputBox* box)
-    {
-        auto* block = new CustomisableInput(this);
-        block->setReadOnly(readOnly());
-        block->setText(preset.script);
-        block->setFont(preset.font);
-        block->setColour(preset.colour);
-
-        CustomisableInput::State state;
-        if(preset.colourChanged) {
-            state |= CustomisableInput::ColourChanged;
-        }
-        if(preset.fontChanged) {
-            state |= CustomisableInput::FontChanged;
-        }
-        block->setState(state);
-
-        box->addInput(block);
-    }
-
     QGroupBox* m_groupBox;
     QSpinBox* m_rowHeight;
-    ExpandableInputBox* m_leftBox;
-    ExpandableInputBox* m_rightBox;
+    QTextEdit* m_leftScript;
+    QTextEdit* m_rightScript;
 };
 
 void createGroupPresetInputs(const SubheaderRow& subheader, ExpandableInputBox* box, QWidget* parent)
@@ -210,23 +122,8 @@ void createGroupPresetInputs(const SubheaderRow& subheader, ExpandableInputBox* 
     auto* input = new ExpandableGroupBox(subheader.rowHeight, parent);
     box->addInput(input);
 
-    if(subheader.leftText.empty()) {
-        input->addLeftInput({});
-    }
-    else {
-        for(const auto& block : subheader.leftText) {
-            input->addLeftInput(block);
-        }
-    }
-
-    if(subheader.rightText.empty()) {
-        input->addRightInput({});
-    }
-    else {
-        for(const auto& block : subheader.rightText) {
-            input->addRightInput(block);
-        }
-    }
+    input->setLeftScript(subheader.leftText.script);
+    input->setRightScript(subheader.rightText.script);
 }
 
 void updateGroupTextBlocks(const ExpandableInputList& presetInputs, SubheaderRows& textBlocks)
@@ -237,12 +134,9 @@ void updateGroupTextBlocks(const ExpandableInputList& presetInputs, SubheaderRow
         if(auto* presetInput = qobject_cast<ExpandableGroupBox*>(input)) {
             SubheaderRow block;
 
-            auto leftBlocks  = presetInput->leftBlocks();
-            auto rightBlocks = presetInput->rightBlocks();
-
-            updateTextBlocks(leftBlocks, block.leftText);
-            updateTextBlocks(rightBlocks, block.rightText);
-            block.rowHeight = presetInput->rowHeight();
+            block.leftText.script  = presetInput->leftScript();
+            block.rightText.script = presetInput->rightScript();
+            block.rowHeight        = presetInput->rowHeight();
 
             textBlocks.emplace_back(block);
         }
@@ -279,16 +173,16 @@ private:
     QComboBox* m_presetBox;
     QTabWidget* m_presetTabs;
 
-    ExpandableInputBox* m_headerTitle;
-    ExpandableInputBox* m_headerSubtitle;
-    ExpandableInputBox* m_headerSideText;
-    ExpandableInputBox* m_headerInfo;
+    QTextEdit* m_headerTitle;
+    QTextEdit* m_headerSubtitle;
+    QTextEdit* m_headerSideText;
+    QTextEdit* m_headerInfo;
     QSpinBox* m_headerRowHeight;
 
     ExpandableInputBox* m_subHeaders;
 
-    ExpandableInputBox* m_trackLeftText;
-    ExpandableInputBox* m_trackRightText;
+    QTextEdit* m_trackLeftText;
+    QTextEdit* m_trackRightText;
     QSpinBox* m_trackRowHeight;
 
     QCheckBox* m_showCover;
@@ -306,7 +200,13 @@ PlaylistPresetsPageWidget::PlaylistPresetsPageWidget(SettingsManager* settings)
     , m_presetRegistry{settings}
     , m_presetBox{new QComboBox(this)}
     , m_presetTabs{new QTabWidget(this)}
+    , m_headerTitle{new QTextEdit(tr("Title") + QStringLiteral(":"), this)}
+    , m_headerSubtitle{new QTextEdit(tr("Subtitle") + QStringLiteral(":"), this)}
+    , m_headerSideText{new QTextEdit(tr("Side text") + QStringLiteral(":"), this)}
+    , m_headerInfo{new QTextEdit(tr("Info") + QStringLiteral(":"), this)}
     , m_headerRowHeight{new QSpinBox(this)}
+    , m_trackLeftText{new QTextEdit(tr("Left-aligned text") + QStringLiteral(":"), this)}
+    , m_trackRightText{new QTextEdit(tr("Right-aligned text") + QStringLiteral(":"), this)}
     , m_trackRowHeight{new QSpinBox(this)}
     , m_showCover{new QCheckBox(tr("Show Cover"), this)}
     , m_simpleHeader{new QCheckBox(tr("Simple Header"), this)}
@@ -330,18 +230,6 @@ PlaylistPresetsPageWidget::PlaylistPresetsPageWidget(SettingsManager* settings)
     auto* headerWidget = new QWidget();
     auto* headerLayout = new QGridLayout(headerWidget);
 
-    const auto inputAttributes = ExpandableInput::CustomWidget;
-
-    m_headerTitle    = new ExpandableInputBox(tr("Title") + QStringLiteral(":"), inputAttributes, this);
-    m_headerSubtitle = new ExpandableInputBox(tr("Subtitle") + QStringLiteral(":"), inputAttributes, this);
-    m_headerSideText = new ExpandableInputBox(tr("Side text") + QStringLiteral(":"), inputAttributes, this);
-    m_headerInfo     = new ExpandableInputBox(tr("Info") + QStringLiteral(":"), inputAttributes, this);
-
-    m_headerTitle->setInputWidget([](QWidget* parent) { return new CustomisableInput(parent); });
-    m_headerSubtitle->setInputWidget([](QWidget* parent) { return new CustomisableInput(parent); });
-    m_headerSideText->setInputWidget([](QWidget* parent) { return new CustomisableInput(parent); });
-    m_headerInfo->setInputWidget([](QWidget* parent) { return new CustomisableInput(parent); });
-
     auto* headerRowHeight = new QLabel(tr("Row height") + QStringLiteral(":"), this);
 
     headerLayout->addWidget(headerRowHeight, 0, 0);
@@ -361,12 +249,10 @@ PlaylistPresetsPageWidget::PlaylistPresetsPageWidget(SettingsManager* settings)
     auto* subheaderWidget = new QWidget();
     auto* subheaderLayout = new QGridLayout(subheaderWidget);
 
-    m_subHeaders = new ExpandableInputBox(tr("Subheaders") + QStringLiteral(":"), inputAttributes, this);
+    m_subHeaders = new ExpandableInputBox(tr("Subheaders") + QStringLiteral(":"), ExpandableInput::CustomWidget, this);
     m_subHeaders->setInputWidget([](QWidget* parent) {
         const SubheaderRow subheader;
         auto* groupBox = new ExpandableGroupBox(subheader.rowHeight, parent);
-        groupBox->addLeftInput({});
-        groupBox->addRightInput({});
         return groupBox;
     });
 
@@ -380,11 +266,6 @@ PlaylistPresetsPageWidget::PlaylistPresetsPageWidget(SettingsManager* settings)
     subheaderLayout->setRowStretch(subheaderLayout->rowCount(), 1);
 
     auto* trackRowHeight = new QLabel(tr("Row height") + QStringLiteral(":"), this);
-
-    m_trackLeftText = new ExpandableInputBox(tr("Left-aligned text") + QStringLiteral(":"), inputAttributes, this);
-    m_trackLeftText->setInputWidget([](QWidget* parent) { return new CustomisableInput(parent); });
-    m_trackRightText = new ExpandableInputBox(tr("Right-aligned text") + QStringLiteral(":"), inputAttributes, this);
-    m_trackRightText->setInputWidget([](QWidget* parent) { return new CustomisableInput(parent); });
 
     trackLayout->addWidget(trackRowHeight, 0, 0);
     trackLayout->addWidget(m_trackRowHeight, 0, 1);
@@ -495,10 +376,10 @@ void PlaylistPresetsPageWidget::updatePreset()
         return;
     }
 
-    updateTextBlocks(m_headerTitle->blocks(), preset.header.title);
-    updateTextBlocks(m_headerSubtitle->blocks(), preset.header.subtitle);
-    updateTextBlocks(m_headerSideText->blocks(), preset.header.sideText);
-    updateTextBlocks(m_headerInfo->blocks(), preset.header.info);
+    preset.header.title.script    = m_headerTitle->toPlainText();
+    preset.header.subtitle.script = m_headerSubtitle->toPlainText();
+    preset.header.sideText.script = m_headerSideText->toPlainText();
+    preset.header.info.script     = m_headerInfo->toPlainText();
 
     preset.header.rowHeight = m_headerRowHeight->value();
     preset.header.simple    = m_simpleHeader->isChecked();
@@ -506,9 +387,9 @@ void PlaylistPresetsPageWidget::updatePreset()
 
     updateGroupTextBlocks(m_subHeaders->blocks(), preset.subHeaders);
 
-    updateTextBlocks(m_trackLeftText->blocks(), preset.track.leftText);
-    updateTextBlocks(m_trackRightText->blocks(), preset.track.rightText);
-    preset.track.rowHeight = m_trackRowHeight->value();
+    preset.track.leftText.script  = m_trackLeftText->toPlainText();
+    preset.track.rightText.script = m_trackRightText->toPlainText();
+    preset.track.rowHeight        = m_trackRowHeight->value();
 
     m_presetRegistry.changeItem(preset);
 }
@@ -552,10 +433,10 @@ void PlaylistPresetsPageWidget::setupPreset(const PlaylistPreset& preset)
     m_headerSideText->setReadOnly(preset.isDefault);
     m_headerInfo->setReadOnly(preset.isDefault);
 
-    createPresetInputs(preset.header.title, m_headerTitle, this);
-    createPresetInputs(preset.header.subtitle, m_headerSubtitle, this);
-    createPresetInputs(preset.header.sideText, m_headerSideText, this);
-    createPresetInputs(preset.header.info, m_headerInfo, this);
+    m_headerTitle->setPlainText(preset.header.title.script);
+    m_headerSubtitle->setPlainText(preset.header.subtitle.script);
+    m_headerSideText->setPlainText(preset.header.sideText.script);
+    m_headerInfo->setPlainText(preset.header.info.script);
 
     m_headerRowHeight->setValue(preset.header.rowHeight);
     m_headerRowHeight->setReadOnly(preset.isDefault);
@@ -576,21 +457,15 @@ void PlaylistPresetsPageWidget::setupPreset(const PlaylistPreset& preset)
     m_trackLeftText->setReadOnly(preset.isDefault);
     m_trackRightText->setReadOnly(preset.isDefault);
 
-    createPresetInputs(preset.track.leftText, m_trackLeftText, this);
-    createPresetInputs(preset.track.rightText, m_trackRightText, this);
+    m_trackLeftText->setPlainText(preset.track.leftText.script);
+    m_trackRightText->setPlainText(preset.track.rightText.script);
     m_trackRowHeight->setValue(preset.track.rowHeight);
     m_trackRowHeight->setReadOnly(preset.isDefault);
 }
 
 void PlaylistPresetsPageWidget::clearBlocks()
 {
-    m_headerTitle->clearBlocks();
-    m_headerSubtitle->clearBlocks();
-    m_headerSideText->clearBlocks();
-    m_headerInfo->clearBlocks();
     m_subHeaders->clearBlocks();
-    m_trackLeftText->clearBlocks();
-    m_trackRightText->clearBlocks();
 }
 
 PlaylistPresetsPage::PlaylistPresetsPage(SettingsManager* settings)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,18 +3,20 @@ enable_testing(true)
 include(GoogleTest)
 
 function(fooyin_add_test name)
-add_executable(${name} ${ARGN} testutils.cpp)
+    add_executable(${name} ${ARGN} testutils.cpp)
     fooyin_set_rpath(${name} ${LIB_INSTALL_DIR})
     target_link_libraries(
             ${name}
             PRIVATE Fooyin::Core
                     Fooyin::CorePrivate
+                    Fooyin::Gui
                     GTest::gtest_main
     )
     gtest_discover_tests(${name})
 endfunction()
 
 fooyin_add_test(test_scriptparser scriptparsertest.cpp)
+fooyin_add_test(test_scriptformatter scriptformattertest.cpp)
 
 qt_add_resources(TEST_SOURCES data/audio.qrc)
 add_library(fooyin_test_data ${TEST_SOURCES})

--- a/tests/scriptformattertest.cpp
+++ b/tests/scriptformattertest.cpp
@@ -1,0 +1,43 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <gui/scripting/scriptformatter.h>
+#include <gui/scripting/scriptformatterregistry.h>
+
+#include <gtest/gtest.h>
+
+namespace Fooyin::Testing {
+class ScriptFormatterTest : public ::testing::Test
+{
+protected:
+    ScriptFormatter m_formattter;
+};
+
+TEST_F(ScriptFormatterTest, NoFormat)
+{
+    const auto result = m_formattter.evaluate(QStringLiteral("I am a test."));
+    EXPECT_EQ(1, result.size());
+}
+
+TEST_F(ScriptFormatterTest, Bold)
+{
+    const auto result = m_formattter.evaluate(QStringLiteral("<b>I</b> am a test."));
+    EXPECT_EQ(2, result.size());
+}
+} // namespace Fooyin::Testing


### PR DESCRIPTION
Brings formatting support to FooScript using tags such as ``<b>text</b>``. The closing tag is optional, but if not used, everything up to the end of the string will be formatted. Some tags require options to be passed like: ``<size=14>text``. This support greatly simplifies customising playlist presets, and will open up an even deeper level of customisation down the line. 

The alternative is to use a QTextDocument in the playlist delegate to draw rich text, but this was found to be significantly detrimental to performance. The performance impact of tags in FooScript is negligible, though it does come with a small memory increase depending on the playlist size and formatting options used. This could be reduced/eliminated by caching the fonts and colours.

This also changes how the script scanner/lexer works. Instead of reading token by token, it tokenises the entire script at setup. This allows parsers to 'peek' ahead, and is required by the formatter in order to properly process tags.
