### PR TITLE
Add natural sorting for tracks and filters

### DIFF
--- a/src/core/library/tracksort.cpp
+++ b/src/core/library/tracksort.cpp
@@ -24,6 +24,8 @@
 
 #include <ranges>
 
+#include <QCollator>
+
 namespace {
 Fooyin::ParsedScript parseScript(const QString& sort)
 {
@@ -53,8 +55,13 @@ TrackList calcSortFields(const ParsedScript& sortScript, const TrackList& tracks
 TrackList sortTracks(const TrackList& tracks, Qt::SortOrder order)
 {
     TrackList sortedTracks{tracks};
-    std::ranges::sort(sortedTracks, [order](const Track& lhs, const Track& rhs) {
-        const auto cmp = QString::localeAwareCompare(lhs.sort(), rhs.sort());
+
+    QCollator collator;
+    collator.setNumericMode(true);
+
+    std::ranges::sort(sortedTracks, [order, collator](const Track& lhs, const Track& rhs) {
+        const auto cmp = collator.compare(lhs.sort(), rhs.sort());
+
         if(cmp == 0) {
             return false;
         }


### PR DESCRIPTION
Firstly I'd like to say I've been looking for a music player for Linux like this one for years, so thanks for your work!

At the moment, Fooyin uses ASCII-order sorting for the library, as is also the case for most other players I've used. For a music player, I believe natural sorting should be used instead. The core argument for this goes [pretty far back,](https://blog.codinghorror.com/sorting-for-humans-natural-sort-order/) but in our case, consider the current sorting of some Bach works with their commonly used Opus number:

```
BWV 1
BWV 10
BWV 100
...
```
Using `QCollator` instead, the player will use a natural sort more similar to the behavior of foobar2000:

```
BWV 1
BWV 2
BWV 3
...
```
---
I am a C programmer by trade so there might be some bad code here.