### PR TITLE
[gui] EditableLayout: Remove margins

### DIFF
--- a/src/gui/editablelayout.cpp
+++ b/src/gui/editablelayout.cpp
@@ -197,7 +197,7 @@ struct EditableLayout::Private
         , editingContext{new WidgetContext(self, Context{"Fooyin.LayoutEditing"}, self)}
         , layoutHistory{new QUndoStack(self)}
     {
-        box->setContentsMargins(5, 5, 5, 5);
+        box->setContentsMargins(0, 0, 0, 0);
         box->addWidget(root);
 
         widgetProvider->setCommandStack(layoutHistory);


### PR DESCRIPTION
This improves appearance with the KDE Breeze theme:

![image](https://github.com/ludouzi/fooyin/assets/107320647/8e733584-d1e9-4c25-a119-800083b768db)

Of note, there is no longer empty space at the bottom and to the left of the artwork, which was previously present.

There is less spacing besides buttons such as those on the top toolbar, but if this was intentional to space them out, they should probably come with margins as they don't space at all against their containers (i.e. they are right against the splitter).