### PR TITLE
[gui] Forward scrolling on volume button to slider

### DIFF
--- a/src/gui/controls/volumecontrol.cpp
+++ b/src/gui/controls/volumecontrol.cpp
@@ -31,6 +31,7 @@
 #include <utils/settings/settingsmanager.h>
 #include <utils/utils.h>
 
+#include <QApplication>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QToolButton>
@@ -160,6 +161,11 @@ QString VolumeControl::name() const
 QString VolumeControl::layoutName() const
 {
     return QStringLiteral("VolumeControls");
+}
+
+void VolumeControl::wheelEvent(QWheelEvent* event)
+{
+    QApplication::sendEvent(p->volumeSlider, event);
 }
 } // namespace Fooyin
 

--- a/src/gui/controls/volumecontrol.h
+++ b/src/gui/controls/volumecontrol.h
@@ -21,6 +21,8 @@
 
 #include <gui/fywidget.h>
 
+#include <QWheelEvent>
+
 namespace Fooyin {
 class ActionManager;
 class SettingsManager;
@@ -35,6 +37,8 @@ public:
 
     QString name() const override;
     QString layoutName() const override;
+
+    void wheelEvent(QWheelEvent* event) override;
 
 private:
     struct Private;


### PR DESCRIPTION
This means that the icon can be scrolled on directly, rather than having to move to the slider.

Forwarding the event means that scrolling behaves identically as on the slider directly.

