### PR TITLE
Add CUE support

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -13,6 +13,7 @@ The following libraries are required:
 * [TagLib](https://taglib.org) (1.11.1+)
 * [FFmpeg](https://ffmpeg.org) (4.4+)
 * [ALSA](https://alsa-project.org)
+* [ICU](https://icu.unicode.org/)
 
 The following libraries are optional, but will add extra audio outputs:
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -27,7 +27,7 @@ Platform-specific requirements are listed below.
 sudo apt update
 sudo apt install \
     g++ git cmake pkg-config ninja-build libglu1-mesa-dev libxkbcommon-dev \
-    libasound2-dev libtag1-dev \
+    libasound2-dev libtag1-dev libicu-dev libpipewire-0.3-dev\
     qt6-base-dev libqt6svg6-dev qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools \
     libavcodec-dev libavformat-dev libavutil-dev libavdevice-dev
 ```
@@ -37,9 +37,19 @@ sudo apt install \
 ```
 sudo pacman -Syu
 sudo pacman -S --needed \
-    gcc git cmake pkgconf ninja alsa-lib \
-    qt6-base qt6-svg qt6-tools \
-    kdsingleapplication taglib ffmpeg
+    gcc git cmake pkgconf ninja alsa-lib pipewire icu ffmpeg
+    qt6-base qt6-svg qt6-tools kdsingleapplication taglib
+```
+
+### Fedora
+
+```
+sudo dnf update
+sudo dnf install \
+cmake ninja-build glib2-devel libxkbcommon-x11-devel libxkbcommon-devel \
+alsa-lib-devel qt6-qtbase-devel qt6-qtsvg-devel qt6-qttools-devel 
+libavcodec-free-devel libavformat-free-devel libavutil-free-devel \
+taglib-devel kdsingleapplication-qt6-devel libicu-devel pipewire-devel
 ```
 
 ## Building

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ set_package_properties(Qt6Concurrent PROPERTIES TYPE REQUIRED)
 set_package_properties(Qt6Network PROPERTIES TYPE REQUIRED)
 set_package_properties(Qt6Svg PROPERTIES TYPE REQUIRED)
 
+find_package(ICU COMPONENTS uc i18n REQUIRED)
 find_package(Taglib REQUIRED taglib>=1.12)
 find_package(
     FFmpeg REQUIRED

--- a/ci/archlinux-depends.sh
+++ b/ci/archlinux-depends.sh
@@ -4,6 +4,16 @@ source ci/setup.sh
 
 $SUDO pacman -Syyu --noconfirm
 $SUDO pacman -S --noconfirm --needed \
-       gcc cmake pkgconf ninja alsa-lib \
-       qt6-base qt6-svg qt6-tools \
-       kdsingleapplication taglib ffmpeg
+       gcc \
+       cmake \
+       pkgconf \
+       ninja \
+       alsa-lib \
+       icu \
+       qt6-base \
+       qt6-svg \
+       qt6-tools \
+       kdsingleapplication \
+       taglib \
+       ffmpeg \
+       pipewire

--- a/ci/fedora-depends.sh
+++ b/ci/fedora-depends.sh
@@ -6,8 +6,10 @@ dnf -y --allowerasing install \
      rpmdevtools \
      tar \
      desktop-file-utils \
-     cmake ninja-build \
+     cmake \
+     ninja-build \
      glib2-devel \
+     libicu-devel \
      libxkbcommon-x11-devel \
      libxkbcommon-devel \
      alsa-lib-devel \

--- a/ci/ubuntu-depends.sh
+++ b/ci/ubuntu-depends.sh
@@ -6,7 +6,26 @@ echo 'debconf debconf/frontend select Noninteractive' | $SUDO debconf-set-select
 
 $SUDO apt-get update -qq
 $SUDO apt-get install -y \
-        g++ git cmake pkg-config ninja-build debhelper lsb-release libglu1-mesa-dev libxkbcommon-dev dpkg-dev dh-make \
-        libasound2-dev libpipewire-0.3-dev libtag1-dev \
-        qt6-base-dev libqt6svg6-dev qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools \
-        libavcodec-dev libavformat-dev libavutil-dev
+        g++ \
+        git \
+        cmake \
+        pkg-config \
+        ninja-build \
+        debhelper \
+        lsb-release \
+        libicu-dev \
+        libglu1-mesa-dev \
+        libxkbcommon-dev \
+        dpkg-dev \
+        dh-make \
+        libasound2-dev \
+        libpipewire-0.3-dev \
+        libtag1-dev \
+        qt6-base-dev \
+        libqt6svg6-dev \
+        qt6-tools-dev \
+        qt6-tools-dev-tools \
+        qt6-l10n-tools \
+        libavcodec-dev \
+        libavformat-dev \
+        libavutil-dev

--- a/cmake/FooyinPackaging.cmake
+++ b/cmake/FooyinPackaging.cmake
@@ -37,6 +37,7 @@ set(CPACK_DEBIAN_PACKAGE_DEPENDS
         libqt6svg6 (>= 6.2.0),
         qt6-qpa-plugins,
         libasound2,
+        libicu70,
         libtag1v5,
         ffmpeg (>= 7:4.4),
         pipewire"

--- a/data/dbschema.xml
+++ b/data/dbschema.xml
@@ -104,4 +104,57 @@
             ALTER TABLE Tracks ADD COLUMN BitDepth INTEGER DEFAULT -1;
         </sql>
     </revision>
+    <revision version="6" foreignKeys="1">
+        <description>
+            Remove unique constraint on FilePath. Add unique index on FilePath and Offset. Add CuePath.
+        </description>
+        <sql>
+            CREATE TABLE NewTracks (
+                TrackID INTEGER PRIMARY KEY AUTOINCREMENT,
+                FilePath TEXT NOT NULL,
+                Title TEXT,
+                TrackNumber INTEGER,
+                TrackTotal INTEGER,
+                Artists TEXT,
+                AlbumArtist TEXT,
+                Album TEXT,
+                DiscNumber INTEGER,
+                DiscTotal INTEGER,
+                Date TEXT,
+                Composer TEXT,
+                Performer TEXT,
+                Genres TEXT,
+                Comment TEXT,
+                CuePath TEXT,
+                Offset INTEGER DEFAULT 0,
+                Duration INTEGER DEFAULT 0,
+                FileSize INTEGER DEFAULT 0,
+                BitRate INTEGER DEFAULT 0,
+                SampleRate INTEGER DEFAULT 0,
+                Channels INTEGER DEFAULT 0,
+                BitDepth INTEGER DEFAULT -1,
+                ExtraTags BLOB,
+                Type INTEGER DEFAULT 0,
+                ModifiedDate INTEGER,
+                LibraryID INTEGER DEFAULT -1,
+                TrackHash TEXT
+            );
+
+            INSERT INTO NewTracks (
+                TrackID, FilePath, Title, TrackNumber, TrackTotal, Artists, AlbumArtist, Album, DiscNumber,
+                DiscTotal, Date, Composer, Performer, Genres, Comment, Duration, FileSize, BitRate, SampleRate,
+                ExtraTags, Type, ModifiedDate, LibraryID, TrackHash
+            )
+            SELECT
+                TrackID, FilePath, Title, TrackNumber, TrackTotal, Artists, AlbumArtist, Album, DiscNumber,
+                DiscTotal, Date, Composer, Performer, Genres, Comment, Duration, FileSize, BitRate, SampleRate,
+                ExtraTags, Type, ModifiedDate, LibraryID, TrackHash
+            FROM Tracks;
+
+            DROP TABLE Tracks;
+            ALTER TABLE NewTracks RENAME TO Tracks;
+
+            CREATE UNIQUE INDEX IF NOT EXISTS UniqueTrack ON Tracks(FilePath, Offset);
+        </sql>
+    </revision>
 </schema>

--- a/include/core/library/musiclibrary.h
+++ b/include/core/library/musiclibrary.h
@@ -29,7 +29,8 @@ namespace Fooyin {
 struct LibraryInfo;
 
 /*!
- * There are two types of scan request:
+ * There are three types of scan request:
+ * - Files: Scans a list of files; emits tracksScanned when finished.
  * - Tracks: Scans a TrackList; emits tracksScanned when finished.
  * - Library: Scans an entire library; emits tracksAdded, tracksUpdated, tracksDeleted.
  * In-progress requests can be cancelled early using cancel().
@@ -38,7 +39,8 @@ struct ScanRequest
 {
     enum Type : uint8_t
     {
-        Tracks = 0,
+        Files = 0,
+        Tracks,
         Library,
     };
 
@@ -86,6 +88,12 @@ public:
      * @note tracks will be considered unmanaged (not associated with an added library)
      */
     virtual ScanRequest scanTracks(const TrackList& tracks) = 0;
+    /*!
+     * Scans the @p files for tracks and adds to library.
+     * @returns a ScanRequest representing a queued scan operation.
+     * @note tracks will be considered unmanaged (not associated with an added library)
+     */
+    virtual ScanRequest scanFiles(const QList<QUrl>& files) = 0;
 
     /** Returns all tracks for all libraries */
     [[nodiscard]] virtual TrackList tracks() const = 0;

--- a/include/core/playlist/playlistparser.h
+++ b/include/core/playlist/playlistparser.h
@@ -31,6 +31,6 @@ class FYCORE_EXPORT PlaylistParser
 public:
     virtual ~PlaylistParser() = default;
 
-    virtual TrackList read(const QString& file) = 0;
+    virtual TrackList readPlaylist(const QString& file) = 0;
 };
 } // namespace Fooyin

--- a/include/core/playlist/playlistparser.h
+++ b/include/core/playlist/playlistparser.h
@@ -1,0 +1,36 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "fycore_export.h"
+
+#include <core/trackfwd.h>
+
+class QString;
+
+namespace Fooyin {
+class FYCORE_EXPORT PlaylistParser
+{
+public:
+    virtual ~PlaylistParser() = default;
+
+    virtual TrackList read(const QString& file) = 0;
+};
+} // namespace Fooyin

--- a/include/core/track.h
+++ b/include/core/track.h
@@ -37,7 +37,7 @@ public:
     {
         size_t operator()(const Track& track) const
         {
-            return qHash(track.filepath());
+            return qHash(track.uniqueFilepath());
         }
     };
 
@@ -91,6 +91,7 @@ public:
     [[nodiscard]] Type type() const;
     [[nodiscard]] QString typeString() const;
     [[nodiscard]] QString filepath() const;
+    [[nodiscard]] QString uniqueFilepath() const;
     [[nodiscard]] QString relativePath() const;
     [[nodiscard]] QString filename() const;
     [[nodiscard]] QString path() const;
@@ -112,12 +113,14 @@ public:
     [[nodiscard]] QString genre() const;
     [[nodiscard]] QString composer() const;
     [[nodiscard]] QString performer() const;
-    [[nodiscard]] uint64_t duration() const;
     [[nodiscard]] QString comment() const;
     [[nodiscard]] QString date() const;
     [[nodiscard]] int year() const;
     [[nodiscard]] float rating() const;
     [[nodiscard]] int ratingStars() const;
+
+    [[nodiscard]] bool hasCue() const;
+    [[nodiscard]] QString cuePath() const;
 
     [[nodiscard]] bool hasExtraTag(const QString& tag) const;
     [[nodiscard]] QStringList extraTag(const QString& tag) const;
@@ -125,6 +128,8 @@ public:
     [[nodiscard]] QStringList removedTags() const;
     [[nodiscard]] QByteArray serialiseExtrasTags() const;
 
+    [[nodiscard]] uint64_t offset() const;
+    [[nodiscard]] uint64_t duration() const;
     [[nodiscard]] uint64_t fileSize() const;
     [[nodiscard]] int bitrate() const;
     [[nodiscard]] int sampleRate() const;
@@ -159,7 +164,6 @@ public:
     void setGenres(const QStringList& genres);
     void setComposer(const QString& composer);
     void setPerformer(const QString& performer);
-    void setDuration(uint64_t duration);
     void setComment(const QString& comment);
     void setDate(const QString& date);
     void setYear(int year);
@@ -168,12 +172,16 @@ public:
 
     [[nodiscard]] QString metaValue(const QString& name) const;
 
+    void setCuePath(const QString& path);
+
     void addExtraTag(const QString& tag, const QString& value);
     void removeExtraTag(const QString& tag);
     void replaceExtraTag(const QString& tag, const QString& value);
     void clearExtraTags();
     void storeExtraTags(const QByteArray& json);
 
+    void setOffset(uint64_t offset);
+    void setDuration(uint64_t duration);
     void setFileSize(uint64_t fileSize);
     void setBitrate(int rate);
     void setSampleRate(int rate);

--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -47,6 +47,7 @@ FYUTILS_EXPORT QString appendShortcut(const QString& str, const QKeySequence& sh
 FYUTILS_EXPORT uint64_t currentDateToInt();
 FYUTILS_EXPORT QString formatTimeMs(uint64_t time);
 FYUTILS_EXPORT QString capitalise(const QString& str);
+FYUTILS_EXPORT QByteArray detectEncoding(const QByteArray& content);
 
 FYUTILS_EXPORT QPixmap scalePixmap(const QPixmap& image, const QSize& size, double dpr, bool upscale = false);
 FYUTILS_EXPORT QPixmap scalePixmap(const QPixmap& image, int width, double dpr, bool upscale = false);

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SOURCES
     ${CMAKE_SOURCE_DIR}/include/core/player/playerdefs.h
     ${CMAKE_SOURCE_DIR}/include/core/playlist/playlist.h
     ${CMAKE_SOURCE_DIR}/include/core/playlist/playlisthandler.h
+    ${CMAKE_SOURCE_DIR}/include/core/playlist/playlistparser.h
     ${CMAKE_SOURCE_DIR}/include/core/plugins/coreplugin.h
     ${CMAKE_SOURCE_DIR}/include/core/plugins/coreplugincontext.h
     ${CMAKE_SOURCE_DIR}/include/core/plugins/plugin.h
@@ -93,6 +94,8 @@ set(SOURCES
     player/playercontroller.cpp
     playlist/playlist.cpp
     playlist/playlisthandler.cpp
+    playlist/parsers/cueparser.cpp
+    playlist/parsers/cueparser.h
     plugins/plugininfo.cpp
     plugins/plugininfo.h
     plugins/pluginmanager.cpp

--- a/src/core/database/database.cpp
+++ b/src/core/database/database.cpp
@@ -28,7 +28,7 @@
 
 #include <QFileInfo>
 
-const auto CurrentSchemaVersion = 5;
+const auto CurrentSchemaVersion = 6;
 
 namespace {
 Fooyin::DbConnection::DbParams dbConnectionParams()

--- a/src/core/database/trackdatabase.cpp
+++ b/src/core/database/trackdatabase.cpp
@@ -48,6 +48,8 @@ QString fetchTrackColumns()
                                                   "Performer,"
                                                   "Genres,"
                                                   "Comment,"
+                                                  "CuePath,"
+                                                  "Offset,"
                                                   "Duration,"
                                                   "FileSize,"
                                                   "BitRate,"
@@ -84,15 +86,17 @@ BindingsMap trackBindings(const Fooyin::Track& track)
             {QStringLiteral(":performer"), track.performer()},
             {QStringLiteral(":genres"), track.genres()},
             {QStringLiteral(":comment"), track.comment()},
-            {QStringLiteral(":duration"), QVariant::fromValue(track.duration())},
-            {QStringLiteral(":fileSize"), QVariant::fromValue(track.fileSize())},
+            {QStringLiteral(":cuePath"), track.cuePath()},
+            {QStringLiteral(":offset"), static_cast<quint64>(track.offset())},
+            {QStringLiteral(":duration"), static_cast<quint64>(track.duration())},
+            {QStringLiteral(":fileSize"), static_cast<quint64>(track.fileSize())},
             {QStringLiteral(":bitRate"), track.bitrate()},
             {QStringLiteral(":sampleRate"), track.sampleRate()},
             {QStringLiteral(":channels"), track.channels()},
             {QStringLiteral(":bitDepth"), track.bitDepth()},
             {QStringLiteral(":extraTags"), track.serialiseExtrasTags()},
             {QStringLiteral(":type"), static_cast<int>(track.type())},
-            {QStringLiteral(":modifiedDate"), QVariant::fromValue(track.modifiedTime())},
+            {QStringLiteral(":modifiedDate"), static_cast<quint64>(track.modifiedTime())},
             {QStringLiteral(":trackHash"), track.hash()},
             {QStringLiteral(":libraryID"), track.libraryId()}};
 }
@@ -117,22 +121,24 @@ Fooyin::Track readToTrack(const Fooyin::DbQuery& q)
     track.setPerformer(q.value(13).toString());
     track.setGenres(q.value(14).toStringList());
     track.setComment(q.value(15).toString());
-    track.setDuration(q.value(16).toULongLong());
-    track.setFileSize(q.value(17).toInt());
-    track.setBitrate(q.value(18).toInt());
-    track.setSampleRate(q.value(19).toInt());
-    track.setChannels(q.value(20).toInt());
-    track.setBitDepth(q.value(21).toInt());
-    track.storeExtraTags(q.value(22).toByteArray());
-    track.setType(static_cast<Fooyin::Track::Type>(q.value(23).toInt()));
-    track.setModifiedTime(q.value(24).toULongLong());
-    track.setLibraryId(q.value(25).toInt());
-    track.setHash(q.value(26).toString());
-    track.setAddedTime(q.value(27).toULongLong());
-    track.setFirstPlayed(q.value(28).toULongLong());
-    track.setLastPlayed(q.value(29).toULongLong());
-    track.setPlayCount(q.value(30).toInt());
-    track.setRating(q.value(31).toFloat());
+    track.setCuePath(q.value(16).toString());
+    track.setOffset(q.value(17).toULongLong());
+    track.setDuration(q.value(18).toULongLong());
+    track.setFileSize(q.value(19).toInt());
+    track.setBitrate(q.value(20).toInt());
+    track.setSampleRate(q.value(21).toInt());
+    track.setChannels(q.value(22).toInt());
+    track.setBitDepth(q.value(23).toInt());
+    track.storeExtraTags(q.value(24).toByteArray());
+    track.setType(static_cast<Fooyin::Track::Type>(q.value(25).toInt()));
+    track.setModifiedTime(q.value(26).toULongLong());
+    track.setLibraryId(q.value(27).toInt());
+    track.setHash(q.value(28).toString());
+    track.setAddedTime(q.value(29).toULongLong());
+    track.setFirstPlayed(q.value(30).toULongLong());
+    track.setLastPlayed(q.value(31).toULongLong());
+    track.setPlayCount(q.value(32).toInt());
+    track.setRating(q.value(33).toFloat());
 
     track.generateHash();
     track.setIsEnabled(QFileInfo::exists(track.filepath()));
@@ -280,6 +286,8 @@ bool TrackDatabase::updateTrack(const Track& track)
                                           "Performer = :performer,"
                                           "Genres = :genres,"
                                           "Comment = :comment,"
+                                          "CuePath = :cuePath,"
+                                          "Offset = :offset,"
                                           "Duration = :duration,"
                                           "FileSize = :fileSize,"
                                           "BitRate = :bitRate,"
@@ -435,6 +443,8 @@ void TrackDatabase::insertViews(const QSqlDatabase& db)
                                           "Tracks.Performer,"
                                           "Tracks.Genres,"
                                           "Tracks.Comment,"
+                                          "Tracks.CuePath,"
+                                          "Tracks.Offset,"
                                           "Tracks.Duration,"
                                           "Tracks.FileSize,"
                                           "Tracks.BitRate,"
@@ -494,6 +504,8 @@ bool TrackDatabase::insertTrack(Track& track) const
                                           "Performer,"
                                           "Genres,"
                                           "Comment,"
+                                          "CuePath,"
+                                          "Offset,"
                                           "Duration,"
                                           "FileSize,"
                                           "BitRate,"
@@ -521,6 +533,8 @@ bool TrackDatabase::insertTrack(Track& track) const
                                           ":performer,"
                                           ":genres,"
                                           ":comment,"
+                                          ":cuePath,"
+                                          ":offset,"
                                           ":duration,"
                                           ":fileSize,"
                                           ":bitRate,"

--- a/src/core/engine/audiorenderer.cpp
+++ b/src/core/engine/audiorenderer.cpp
@@ -128,9 +128,12 @@ struct AudioRenderer::Private
     {
         isRunning = false;
         writeTimer->stop();
-        pauseOutput(true);
+
         updateOutputVolume(0.0);
+
+        audioOutput->drain();
         emit self->paused();
+        pauseOutput(true);
     }
 
     void updateOutputVolume(double newVolume)
@@ -316,9 +319,8 @@ void AudioRenderer::pause(bool paused, int fadeLength)
             p->pause();
             return;
         }
-        else {
-            p->volumeChange = -(p->volume / p->fadeSteps);
-        }
+
+        p->volumeChange = -(p->volume / p->fadeSteps);
     }
     else {
         p->pauseOutput(false);
@@ -408,11 +410,6 @@ void AudioRenderer::timerEvent(QTimerEvent* event)
     }
 
     if(p->volumeChange < 0.0) {
-        if(p->writeTimer->isActive() && p->audioOutput->currentState().queuedSamples > 0) {
-            p->audioOutput->drain();
-            p->writeTimer->stop();
-            return;
-        }
         // Faded out
         p->pause();
     }

--- a/src/core/library/libraryscanner.cpp
+++ b/src/core/library/libraryscanner.cpp
@@ -295,7 +295,7 @@ struct LibraryScanner::Private
 
         if(existingCues.contains(cue)) {
             if(existingCues.at(cue) != lastModified || !onlyModified) {
-                const TrackList cueTracks = cueParser->read(cue);
+                const TrackList cueTracks = cueParser->readPlaylist(cue);
                 for(const Track& cueTrack : cueTracks) {
                     Track track{cueTrack};
                     setTrackProps(track);
@@ -313,7 +313,7 @@ struct LibraryScanner::Private
                 }
             }
             else {
-                const TrackList cueTracks = cueParser->read(cue);
+                const TrackList cueTracks = cueParser->readPlaylist(cue);
                 for(const Track& cueTrack : cueTracks) {
                     Track track{cueTrack};
                     setTrackProps(track);
@@ -654,7 +654,7 @@ void LibraryScanner::scanFiles(const TrackList& libraryTracks, const QList<QUrl>
         }
 
         for(const auto& cue : cues) {
-            const TrackList cueTracks = p->cueParser->read(cue);
+            const TrackList cueTracks = p->cueParser->readPlaylist(cue);
             for(const Track& cueTrack : cueTracks) {
                 Track track{cueTrack};
                 track.generateHash();

--- a/src/core/library/libraryscanner.cpp
+++ b/src/core/library/libraryscanner.cpp
@@ -19,25 +19,159 @@
 
 #include "libraryscanner.h"
 
-#include "database/database.h"
 #include "database/trackdatabase.h"
 #include "internalcoresettings.h"
 #include "library/libraryinfo.h"
 #include "librarywatcher.h"
+#include "playlist/parsers/cueparser.h"
 #include "tagging/tagreader.h"
 
+#include <core/playlist/playlistparser.h>
 #include <core/track.h>
+#include <utils/database/dbconnectionhandler.h>
+#include <utils/database/dbconnectionpool.h>
 #include <utils/fileutils.h>
 #include <utils/settings/settingsmanager.h>
 
 #include <QDir>
 #include <QFileSystemWatcher>
+#include <QRegularExpression>
 
 #include <ranges>
+#include <stack>
 
 constexpr auto BatchSize = 250;
 
 namespace {
+struct LibraryDirectory
+{
+    QString directory;
+    QStringList files;
+    QStringList cues;
+};
+using LibraryDirectories = std::vector<LibraryDirectory>;
+
+bool hasMatchingExtension(const QString& file, const QStringList& extensions)
+{
+    if(file.isEmpty()) {
+        return false;
+    }
+
+    return std::ranges::any_of(extensions, [&file](const QString& wildcard) {
+        const QRegularExpression re{QRegularExpression::wildcardToRegularExpression(wildcard)};
+        const QRegularExpressionMatch match = re.match(file);
+        return match.hasMatch();
+    });
+}
+
+std::optional<QString> findMatchingCue(const QFileInfo& file)
+{
+    static const QStringList cueExtensions{QStringLiteral("*.cue")};
+
+    const QDir dir           = file.absoluteDir();
+    const QFileInfoList cues = dir.entryInfoList(cueExtensions, QDir::Files);
+
+    for(const auto& cue : cues) {
+        if(cue.completeBaseName() == file.completeBaseName() || cue.fileName().contains(file.fileName())) {
+            return cue.absoluteFilePath();
+        }
+    }
+
+    return {};
+}
+
+LibraryDirectories getDirectories(const QString& baseDirectory)
+{
+    LibraryDirectories dirs;
+
+    std::stack<QDir> stack;
+    stack.emplace(baseDirectory);
+
+    static const QStringList fileExtensions = Fooyin::Track::supportedFileExtensions();
+    static const QStringList cueExtensions{QStringLiteral("*.cue")};
+
+    while(!stack.empty()) {
+        QDir dir = stack.top();
+        stack.pop();
+
+        const QFileInfo info{dir.absolutePath()};
+        QStringList files;
+        QStringList cues;
+
+        if(info.isDir()) {
+            const QFileInfoList subDirs = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+            for(const auto& subDir : subDirs) {
+                stack.emplace(subDir.absoluteFilePath());
+            }
+            const QFileInfoList foundFiles = dir.entryInfoList(fileExtensions, QDir::Files);
+            for(const auto& file : foundFiles) {
+                files.append(file.absoluteFilePath());
+            }
+            const QFileInfoList foundCues = dir.entryInfoList(cueExtensions, QDir::Files);
+            for(const auto& file : foundCues) {
+                cues.append(file.absoluteFilePath());
+            }
+
+            dirs.emplace_back(dir.absolutePath(), files, cues);
+        }
+        else {
+            dir.cdUp();
+            if(hasMatchingExtension(info.fileName(), fileExtensions)) {
+                files.append(info.absoluteFilePath());
+                if(const auto cue = findMatchingCue(info)) {
+                    cues.append(cue.value());
+                }
+            }
+            else if(hasMatchingExtension(info.fileName(), cueExtensions)) {
+                cues.append(info.absoluteFilePath());
+            }
+
+            dirs.emplace_back(dir.absolutePath(), files, cues);
+        }
+    }
+
+    return dirs;
+}
+
+LibraryDirectories getDirectories(const QList<QUrl>& urls)
+{
+    std::unordered_map<QString, LibraryDirectory> processedDirs;
+
+    static const QStringList fileExtensions = Fooyin::Track::supportedFileExtensions();
+    static const QStringList cueExtensions{QStringLiteral("*.cue")};
+
+    for(const QUrl& url : urls | std::views::reverse) {
+        const QFileInfo file{url.toLocalFile()};
+        const auto dir = file.absolutePath();
+
+        if(processedDirs.contains(dir)) {
+            auto& libDir = processedDirs.at(dir);
+            if(hasMatchingExtension(file.fileName(), fileExtensions)) {
+                libDir.files.append(file.absoluteFilePath());
+            }
+            else if(!libDir.cues.contains(file.absoluteFilePath())
+                    && hasMatchingExtension(file.fileName(), cueExtensions)) {
+                libDir.cues.append(file.absoluteFilePath());
+            }
+        }
+        else {
+            const auto libDirs = getDirectories(file.absoluteFilePath());
+            for(const auto& libDir : libDirs) {
+                processedDirs.emplace(libDir.directory, libDir);
+            }
+        }
+    }
+
+    LibraryDirectories dirs;
+    dirs.reserve(processedDirs.size());
+
+    for(const auto& [_, dir] : processedDirs) {
+        dirs.emplace_back(dir);
+    }
+
+    return dirs;
+}
+
 Fooyin::Track matchMissingTrack(const Fooyin::TrackFieldMap& missingFiles, const Fooyin::TrackFieldMap& missingHashes,
                                 Fooyin::Track& track)
 {
@@ -68,6 +202,17 @@ struct LibraryScanner::Private
 
     LibraryInfo currentLibrary;
     TrackDatabase trackDatabase;
+    std::unique_ptr<PlaylistParser> cueParser;
+
+    TrackList tracksToStore;
+    TrackList tracksToUpdate;
+
+    TrackFieldMap trackPaths;
+    TrackFieldMap missingFiles;
+    TrackFieldMap missingHashes;
+    std::unordered_map<QString, uint64_t> existingCues;
+    std::unordered_map<QString, TrackList> missingCueTracks;
+    std::set<QString> cueFilesScanned;
 
     int tracksProcessed{0};
     double totalTracks{0};
@@ -79,7 +224,20 @@ struct LibraryScanner::Private
         : self{self_}
         , dbPool{std::move(dbPool_)}
         , settings{settings_}
+        , cueParser{std::make_unique<CueParser>()}
     { }
+
+    void cleanupScan()
+    {
+        tracksToStore.clear();
+        tracksToUpdate.clear();
+        trackPaths.clear();
+        missingFiles.clear();
+        missingHashes.clear();
+        existingCues.clear();
+        missingCueTracks.clear();
+        cueFilesScanned.clear();
+    }
 
     void addWatcher(const Fooyin::LibraryInfo& library)
     {
@@ -116,19 +274,136 @@ struct LibraryScanner::Private
         trackDatabase.storeTracks(tracks);
     }
 
+    void readCue(const QString& cue, const QDir& baseDir, bool onlyModified)
+    {
+        const QFileInfo info{cue};
+        const QDateTime lastModifiedTime{info.lastModified()};
+        uint64_t lastModified{0};
+
+        if(lastModifiedTime.isValid()) {
+            lastModified = static_cast<uint64_t>(lastModifiedTime.toMSecsSinceEpoch());
+        }
+
+        auto setTrackProps = [this, &baseDir](Track& track) {
+            if(currentLibrary.id >= 0) {
+                track.setLibraryId(currentLibrary.id);
+                track.setRelativePath(baseDir.relativeFilePath(track.filepath()));
+            }
+            track.generateHash();
+            track.setIsEnabled(true);
+        };
+
+        if(existingCues.contains(cue)) {
+            if(existingCues.at(cue) != lastModified || !onlyModified) {
+                const TrackList cueTracks = cueParser->read(cue);
+                for(const Track& cueTrack : cueTracks) {
+                    Track track{cueTrack};
+                    setTrackProps(track);
+                    tracksToUpdate.push_back(track);
+                    cueFilesScanned.emplace(track.filepath());
+                }
+            }
+        }
+        else {
+            if(missingCueTracks.contains(info.fileName())) {
+                TrackList refoundCueTracks = missingCueTracks.at(cue);
+                for(Track& track : refoundCueTracks) {
+                    track.setCuePath(cue);
+                    tracksToUpdate.push_back(track);
+                }
+            }
+            else {
+                const TrackList cueTracks = cueParser->read(cue);
+                for(const Track& cueTrack : cueTracks) {
+                    Track track{cueTrack};
+                    setTrackProps(track);
+                    tracksToStore.push_back(track);
+                    cueFilesScanned.emplace(track.filepath());
+                }
+            }
+        }
+    }
+
+    void readFile(const QString& file, const QDir& baseDir, bool onlyModified)
+    {
+        if(!self->mayRun()) {
+            return;
+        }
+
+        if(cueFilesScanned.contains(file)) {
+            return;
+        }
+
+        const QFileInfo info{file};
+        const QDateTime lastModifiedTime{info.lastModified()};
+        uint64_t lastModified{0};
+
+        if(lastModifiedTime.isValid()) {
+            lastModified = static_cast<uint64_t>(lastModifiedTime.toMSecsSinceEpoch());
+        }
+
+        auto setTrackProps = [this, &file, &baseDir](Track& track) {
+            track.setFilePath(file);
+            if(currentLibrary.id >= 0) {
+                track.setLibraryId(currentLibrary.id);
+                track.setRelativePath(baseDir.relativeFilePath(file));
+            }
+            track.setIsEnabled(true);
+        };
+
+        if(trackPaths.contains(file)) {
+            const Track& libraryTrack = trackPaths.at(file);
+
+            if(!libraryTrack.isEnabled() || libraryTrack.libraryId() != currentLibrary.id
+               || libraryTrack.modifiedTime() != lastModified || !onlyModified) {
+                Track changedTrack{libraryTrack};
+                if(Tagging::readMetaData(changedTrack)) {
+                    setTrackProps(changedTrack);
+
+                    tracksToUpdate.push_back(changedTrack);
+                    missingHashes.erase(changedTrack.hash());
+                    missingFiles.erase(changedTrack.filename());
+                }
+            }
+        }
+        else {
+            Track track{file};
+
+            if(Tagging::readMetaData(track)) {
+                Track refoundTrack = matchMissingTrack(missingFiles, missingHashes, track);
+
+                if(refoundTrack.isInLibrary() || refoundTrack.isInDatabase()) {
+                    missingHashes.erase(refoundTrack.hash());
+                    missingFiles.erase(refoundTrack.filename());
+
+                    setTrackProps(refoundTrack);
+                    tracksToUpdate.push_back(refoundTrack);
+                }
+                else {
+                    setTrackProps(track);
+                    tracksToStore.push_back(track);
+                }
+
+                if(tracksToStore.size() >= BatchSize) {
+                    storeTracks(tracksToStore);
+                    emit self->scanUpdate({.addedTracks = tracksToStore, .updatedTracks = {}});
+                    tracksToStore.clear();
+                }
+            }
+        }
+    }
+
     bool getAndSaveAllTracks(const QString& path, const TrackList& tracks, bool onlyModified)
     {
-        const QDir dir{path};
-
-        TrackList tracksToStore;
-        TrackList tracksToUpdate;
-
-        TrackFieldMap trackPaths;
-        TrackFieldMap missingFiles;
-        TrackFieldMap missingHashes;
-
         for(const Track& track : tracks) {
-            trackPaths.emplace(track.filepath(), track);
+            trackPaths.emplace(track.uniqueFilepath(), track);
+
+            if(track.hasCue()) {
+                existingCues.emplace(track.cuePath(), track.modifiedTime());
+                if(!QFileInfo::exists(track.cuePath())) {
+                    missingCueTracks[track.cuePath()].emplace_back(track);
+                }
+            }
 
             if(!QFileInfo::exists(track.filepath())) {
                 missingFiles.emplace(track.filename(), track);
@@ -136,76 +411,38 @@ struct LibraryScanner::Private
             }
         }
 
-        const QStringList files = Utils::File::getFilesInDirRecursive(dir, Track::supportedFileExtensions());
+        const QDir baseDir{path};
+        const auto dirs = getDirectories(path);
 
         tracksProcessed = 0;
-        totalTracks     = static_cast<double>(files.size());
-        currentProgress = -1;
+        totalTracks     = static_cast<double>(
+            std::accumulate(dirs.cbegin(), dirs.cend(), 0, [](int sum, const LibraryDirectory& dir) {
+                return sum + static_cast<int>(dir.files.size()) + static_cast<int>(dir.cues.size());
+            }));
+        currentProgress = 0;
 
-        for(const auto& filepath : files) {
-            if(!self->mayRun()) {
-                return false;
-            }
-
-            ++tracksProcessed;
-
-            const QFileInfo info{filepath};
-            const QDateTime lastModifiedTime{info.lastModified()};
-            uint64_t lastModified{0};
-
-            if(lastModifiedTime.isValid()) {
-                lastModified = static_cast<uint64_t>(lastModifiedTime.toMSecsSinceEpoch());
-            }
-
-            auto setTrackProps = [this, &filepath, &dir](Track& track) {
-                track.setFilePath(filepath);
-                track.setLibraryId(currentLibrary.id);
-                track.setRelativePath(dir.relativeFilePath(filepath));
-                track.setIsEnabled(true);
-            };
-
-            if(trackPaths.contains(filepath)) {
-                const Track& libraryTrack = trackPaths.at(filepath);
-
-                if(!libraryTrack.isEnabled() || libraryTrack.libraryId() != currentLibrary.id
-                   || libraryTrack.modifiedTime() != lastModified || !onlyModified) {
-                    Track changedTrack{libraryTrack};
-                    if(Tagging::readMetaData(changedTrack)) {
-                        setTrackProps(changedTrack);
-
-                        tracksToUpdate.push_back(changedTrack);
-                        missingHashes.erase(changedTrack.hash());
-                        missingFiles.erase(changedTrack.filename());
-                    }
+        for(const auto& [_, files, cues] : dirs) {
+            for(const auto& cue : cues) {
+                if(!self->mayRun()) {
+                    return false;
                 }
+
+                readCue(cue, baseDir, onlyModified);
+
+                ++tracksProcessed;
+                reportProgress();
             }
-            else {
-                Track track{filepath};
 
-                if(Tagging::readMetaData(track)) {
-                    Track refoundTrack = matchMissingTrack(missingFiles, missingHashes, track);
-
-                    if(refoundTrack.isInLibrary() || refoundTrack.isInDatabase()) {
-                        missingHashes.erase(refoundTrack.hash());
-                        missingFiles.erase(refoundTrack.filename());
-
-                        setTrackProps(refoundTrack);
-                        tracksToUpdate.push_back(refoundTrack);
-                    }
-                    else {
-                        setTrackProps(track);
-                        tracksToStore.push_back(track);
-                    }
-
-                    if(tracksToStore.size() >= BatchSize) {
-                        storeTracks(tracksToStore);
-                        emit self->scanUpdate({.addedTracks = tracksToStore, .updatedTracks = {}});
-                        tracksToStore.clear();
-                    }
+            for(const auto& file : files) {
+                if(!self->mayRun()) {
+                    return false;
                 }
-            }
 
-            reportProgress();
+                readFile(file, baseDir, onlyModified);
+
+                ++tracksProcessed;
+                reportProgress();
+            }
         }
 
         for(auto& track : missingFiles | std::views::values) {
@@ -285,7 +522,6 @@ void LibraryScanner::scanLibrary(const LibraryInfo& library, const TrackList& tr
     setState(Running);
 
     p->currentLibrary = library;
-
     p->changeLibraryStatus(LibraryInfo::Status::Scanning);
 
     if(p->currentLibrary.id >= 0 && QFileInfo::exists(p->currentLibrary.path)) {
@@ -293,6 +529,7 @@ void LibraryScanner::scanLibrary(const LibraryInfo& library, const TrackList& tr
             p->addWatcher(library);
         }
         p->getAndSaveAllTracks(library.path, tracks, onlyModified);
+        p->cleanupScan();
     }
 
     if(state() == Paused) {
@@ -316,6 +553,7 @@ void LibraryScanner::scanLibraryDirectory(const LibraryInfo& library, const QStr
     p->changeLibraryStatus(LibraryInfo::Status::Scanning);
 
     p->getAndSaveAllTracks(dir, tracks, true);
+    p->cleanupScan();
 
     if(state() == Paused) {
         p->changeLibraryStatus(LibraryInfo::Status::Pending);
@@ -369,6 +607,85 @@ void LibraryScanner::scanTracks(const TrackList& libraryTracks, const TrackList&
         }
 
         p->reportProgress();
+    }
+
+    p->storeTracks(tracksToStore);
+
+    std::ranges::copy(tracksToStore, std::back_inserter(tracksScanned));
+
+    emit scannedTracks(tracksScanned);
+
+    handleFinished();
+}
+
+void LibraryScanner::scanFiles(const TrackList& libraryTracks, const QList<QUrl>& urls)
+{
+    setState(Running);
+
+    TrackList tracksScanned;
+    TrackList tracksToStore;
+
+    std::unordered_map<QString, Track> trackMap;
+    std::ranges::transform(libraryTracks, std::inserter(trackMap, trackMap.end()),
+                           [](const Track& track) { return std::make_pair(track.uniqueFilepath(), track); });
+
+    p->tracksProcessed = 0;
+    p->currentProgress = 0;
+
+    const auto handleFinished = [this]() {
+        if(state() != Paused) {
+            setState(Idle);
+            emit finished();
+        }
+    };
+
+    const LibraryDirectories dirs = getDirectories(urls);
+
+    p->totalTracks
+        = static_cast<double>(std::accumulate(dirs.cbegin(), dirs.cend(), 0, [](int sum, const LibraryDirectory& dir) {
+              return sum + static_cast<int>(dir.files.size()) + static_cast<int>(dir.cues.size());
+          }));
+    std::set<QString> cueFilesScanned;
+
+    for(const auto& [_, files, cues] : dirs) {
+        if(!mayRun()) {
+            handleFinished();
+            return;
+        }
+
+        for(const auto& cue : cues) {
+            const TrackList cueTracks = p->cueParser->read(cue);
+            for(const Track& cueTrack : cueTracks) {
+                Track track{cueTrack};
+                track.generateHash();
+                const auto trackKey = track.uniqueFilepath();
+                if(trackMap.contains(trackKey)) {
+                    tracksScanned.push_back(trackMap.at(trackKey));
+                }
+                else {
+                    tracksToStore.push_back(track);
+                }
+                cueFilesScanned.emplace(track.filepath());
+            }
+
+            ++p->tracksProcessed;
+            p->reportProgress();
+        }
+
+        for(const auto& file : files) {
+            if(!cueFilesScanned.contains(file)) {
+                Track track{file};
+                if(trackMap.contains(track.uniqueFilepath())) {
+                    tracksScanned.push_back(trackMap.at(track.uniqueFilepath()));
+                }
+                else if(Tagging::readMetaData(track)) {
+                    tracksToStore.push_back(track);
+                }
+            }
+
+            ++p->tracksProcessed;
+            p->reportProgress();
+        }
     }
 
     p->storeTracks(tracksToStore);

--- a/src/core/library/libraryscanner.h
+++ b/src/core/library/libraryscanner.h
@@ -58,6 +58,7 @@ public slots:
     void scanLibrary(const LibraryInfo& library, const TrackList& tracks, bool onlyModified);
     void scanLibraryDirectory(const LibraryInfo& library, const QString& dir, const TrackList& tracks);
     void scanTracks(const TrackList& libraryTracks, const TrackList& tracks);
+    void scanFiles(const TrackList& libraryTracks, const QList<QUrl>& urls);
 
 private:
     struct Private;

--- a/src/core/library/librarythreadhandler.h
+++ b/src/core/library/librarythreadhandler.h
@@ -48,6 +48,7 @@ public:
     ScanRequest refreshLibrary(const LibraryInfo& library);
     ScanRequest scanLibrary(const LibraryInfo& library);
     ScanRequest scanTracks(const TrackList& tracks);
+    ScanRequest scanFiles(const QList<QUrl>& files);
 
     void saveUpdatedTracks(const TrackList& tracks);
     void saveUpdatedTrackStats(const TrackList& track);

--- a/src/core/library/unifiedmusiclibrary.cpp
+++ b/src/core/library/unifiedmusiclibrary.cpp
@@ -92,6 +92,7 @@ struct UnifiedMusicLibrary::Private
 
             resortTracks(tracks).then(self, [this, sortedTracks](const TrackList& sortedLibraryTracks) {
                 tracks = sortedLibraryTracks;
+
                 emit self->tracksAdded(sortedTracks);
             });
         });
@@ -292,6 +293,11 @@ ScanRequest UnifiedMusicLibrary::rescan(const LibraryInfo& library)
 ScanRequest UnifiedMusicLibrary::scanTracks(const TrackList& tracks)
 {
     return p->threadHandler.scanTracks(tracks);
+}
+
+ScanRequest UnifiedMusicLibrary::scanFiles(const QList<QUrl>& files)
+{
+    return p->threadHandler.scanFiles(files);
 }
 
 bool UnifiedMusicLibrary::hasLibrary() const

--- a/src/core/library/unifiedmusiclibrary.h
+++ b/src/core/library/unifiedmusiclibrary.h
@@ -43,6 +43,7 @@ public:
     ScanRequest refresh(const LibraryInfo& library) override;
     ScanRequest rescan(const LibraryInfo& library) override;
     ScanRequest scanTracks(const TrackList& tracks) override;
+    ScanRequest scanFiles(const QList<QUrl>& files) override;
 
     [[nodiscard]] bool hasLibrary() const override;
     [[nodiscard]] bool isEmpty() const override;

--- a/src/core/playlist/parsers/cueparser.cpp
+++ b/src/core/playlist/parsers/cueparser.cpp
@@ -139,7 +139,7 @@ void finaliseTrack(const CueSheet& cue, Fooyin::Track& track)
 } // namespace
 
 namespace Fooyin {
-TrackList CueParser::read(const QString& file)
+TrackList CueParser::readPlaylist(const QString& file)
 {
     TrackList tracks;
 

--- a/src/core/playlist/parsers/cueparser.cpp
+++ b/src/core/playlist/parsers/cueparser.cpp
@@ -1,0 +1,265 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "cueparser.h"
+
+#include "tagging/tagreader.h"
+#include "utils/utils.h"
+
+#include <core/track.h>
+
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QRegularExpression>
+
+constexpr auto CueLineRegex    = R"lit((\S+)\s+(?:"([^"]+)"|(\S+))\s*(?:"([^"]+)"|(\S+))?)lit";
+constexpr auto TrackIndexRegex = R"lit((\d{1,3}):(\d{2}):(\d{2}))lit";
+
+namespace {
+struct CueSheet
+{
+    QString cuePath;
+    QString type;
+    QString albumArtist;
+    QString album;
+    QString composer;
+    QString genre;
+    QString date;
+    QString comment;
+    int disc{-1};
+};
+
+QStringList splitCueLine(const QString& line)
+{
+    static const QRegularExpression lineRegex{QLatin1String{CueLineRegex}};
+    const QRegularExpressionMatch match = lineRegex.match(line);
+    if(!match.hasMatch()) {
+        return {};
+    }
+
+    const QStringList capturedTexts = match.capturedTexts().mid(1);
+
+    QStringList result;
+    result.reserve(capturedTexts.size() - 1);
+
+    for(const QString& text : capturedTexts) {
+        if(!text.isEmpty() && text != line) {
+            result.append(text);
+        }
+    }
+
+    return result;
+};
+
+void readRemLine(const QStringList& lineParts, CueSheet& sheet)
+{
+    if(lineParts.size() < 2) {
+        return;
+    }
+
+    const QString& field = lineParts.at(0);
+    const QString& value = lineParts.at(1);
+
+    if(field.compare(u"DATE", Qt::CaseInsensitive) == 0) {
+        sheet.date = value;
+    }
+    else if(field.compare(u"DISCNUMBER", Qt::CaseInsensitive) == 0) {
+        if(const int disc = lineParts.at(2).toInt(); disc > 0) {
+            sheet.disc = disc;
+        }
+    }
+    else if(field.compare(u"GENRE", Qt::CaseInsensitive) == 0) {
+        sheet.genre = value;
+    }
+    else if(field.compare(u"COMMENT", Qt::CaseInsensitive) == 0) {
+        sheet.comment = value;
+    }
+}
+
+std::optional<uint64_t> msfToMs(const QString& index)
+{
+    static const QRegularExpression indexRegex{QLatin1String{TrackIndexRegex}};
+    const QRegularExpressionMatch match = indexRegex.match(index);
+    if(!match.hasMatch()) {
+        return {};
+    }
+
+    const QStringList parts = match.capturedTexts().mid(1);
+
+    const int minutes = parts.at(0).toInt();
+    const int seconds = parts.at(1).toInt();
+    const int frames  = parts.at(2).toInt();
+
+    return ((minutes * 60 + seconds) * 1000) + frames * 1000 / 75;
+}
+
+void finaliseTrack(const CueSheet& cue, Fooyin::Track& track)
+{
+    track.setCuePath(cue.cuePath);
+
+    if(track.albumArtists().empty()) {
+        track.setAlbumArtists({cue.albumArtist});
+    }
+    if(track.album().isEmpty()) {
+        track.setAlbum(cue.album);
+    }
+    if(track.genres().empty()) {
+        track.setGenres({cue.genre});
+    }
+    if(track.date().isEmpty()) {
+        track.setDate(cue.date);
+    }
+    if(track.discNumber() <= 0) {
+        track.setDiscNumber(cue.disc);
+    }
+    if(track.comment().isEmpty()) {
+        track.setComment(cue.comment);
+    }
+    if(track.composer().isEmpty()) {
+        track.setComposer(cue.composer);
+    }
+}
+} // namespace
+
+namespace Fooyin {
+TrackList CueParser::read(const QString& file)
+{
+    TrackList tracks;
+
+    QFile cueFile{file};
+
+    if(!cueFile.open(QIODevice::ReadOnly)) {
+        qWarning() << "Can't open cue file" << file;
+        return {};
+    }
+
+    QDir dir{file};
+    dir.cdUp();
+
+    CueSheet sheet;
+    sheet.cuePath = file;
+    Track track;
+    QString trackPath;
+
+    QTextStream in(&cueFile);
+
+    const QByteArray data = cueFile.peek(1024);
+    auto encoding         = QStringConverter::encodingForData(data);
+    if(encoding) {
+        in.setEncoding(encoding.value());
+    }
+    else {
+        const auto encodingName = Utils::detectEncoding(data);
+        if(!encodingName.isEmpty()) {
+            encoding = QStringConverter::encodingForName(encodingName.constData());
+            if(encoding) {
+                in.setEncoding(encoding.value());
+            }
+        }
+    }
+
+    while(!in.atEnd()) {
+        const QStringList parts = splitCueLine(in.readLine().trimmed());
+        if(parts.size() < 2) {
+            continue;
+        }
+
+        const QString& field = parts.at(0);
+        const QString& value = parts.at(1);
+
+        if(field.compare(u"PERFORMER", Qt::CaseInsensitive) == 0) {
+            if(track.isValid() && track.artists().empty()) {
+                track.setArtists({value});
+            }
+            else {
+                sheet.albumArtist = value;
+            }
+        }
+        else if(field.compare(u"TITLE", Qt::CaseInsensitive) == 0) {
+            if(track.isValid() && track.title().isEmpty()) {
+                track.setTitle(value);
+            }
+            else {
+                sheet.album = value;
+            }
+        }
+        else if(field.compare(u"COMPOSER", Qt::CaseInsensitive) == 0
+                || field.compare(u"SONGWRITER", Qt::CaseInsensitive) == 0) {
+            if(track.isValid() && track.composer().isEmpty()) {
+                track.setComposer(value);
+            }
+            else {
+                sheet.composer = value;
+            }
+        }
+        else if(field.compare(u"FILE", Qt::CaseInsensitive) == 0) {
+            trackPath = QDir::isAbsolutePath(value) ? value : dir.absoluteFilePath(value);
+            if(parts.size() > 2) {
+                sheet.type = parts.at(2);
+            }
+        }
+        else if(field.compare(u"REM", Qt::CaseInsensitive) == 0) {
+            readRemLine(parts.sliced(1), sheet);
+        }
+        else if(field.compare(u"TRACK", Qt::CaseInsensitive) == 0) {
+            if(QFile::exists(trackPath)) {
+                if(track.isValid()) {
+                    finaliseTrack(sheet, track);
+                    tracks.emplace_back(track);
+                }
+
+                track = Track{trackPath};
+                Tagging::readMetaData(track);
+                if(const int trackNum = parts.at(1).toInt(); trackNum > 0) {
+                    track.setTrackNumber(trackNum);
+                }
+            }
+        }
+        else if(field.compare(u"INDEX", Qt::CaseInsensitive) == 0) {
+            if(value == u"01" && parts.size() > 2) {
+                if(const auto start = msfToMs(parts.at(2))) {
+                    track.setOffset(start.value());
+
+                    if(const auto count = tracks.size(); count > 0) {
+                        Track& prevTrack = tracks.at(count - 1);
+                        prevTrack.setDuration(track.offset() - prevTrack.offset());
+                    }
+                }
+            }
+        }
+
+        // TODO: Implement a binary file decoder
+        if(sheet.type == u"BINARY") {
+            qInfo() << "[CUE] Unsupported file type:" << sheet.type;
+            return {};
+        }
+    }
+
+    if(track.isValid() && QFile::exists(trackPath)) {
+        finaliseTrack(sheet, track);
+        if(track.duration() > 0) {
+            track.setDuration(track.duration() - track.offset());
+        }
+        tracks.emplace_back(track);
+    }
+
+    return tracks;
+}
+} // namespace Fooyin

--- a/src/core/playlist/parsers/cueparser.h
+++ b/src/core/playlist/parsers/cueparser.h
@@ -1,0 +1,30 @@
+/*
+ * Fooyin
+ * Copyright © 2024, Luke Taylor <LukeT1@proton.me>
+ *
+ * Fooyin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Fooyin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Fooyin.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <core/playlist/playlistparser.h>
+
+namespace Fooyin {
+class CueParser : public PlaylistParser
+{
+public:
+    TrackList read(const QString& file) override;
+};
+} // namespace Fooyin

--- a/src/core/playlist/parsers/cueparser.h
+++ b/src/core/playlist/parsers/cueparser.h
@@ -25,6 +25,6 @@ namespace Fooyin {
 class CueParser : public PlaylistParser
 {
 public:
-    TrackList read(const QString& file) override;
+    TrackList readPlaylist(const QString& file) override;
 };
 } // namespace Fooyin

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -60,7 +60,6 @@ struct Track::Private : public QSharedData
     QStringList removedTags;
 
     QString cuePath;
-    uint64_t cueIndex{0};
 
     uint64_t offset{0};
     uint64_t duration{0};

--- a/src/core/track.cpp
+++ b/src/core/track.cpp
@@ -53,13 +53,17 @@ struct Track::Private : public QSharedData
     QStringList genres;
     QString composer;
     QString performer;
-    uint64_t duration{0};
     QString comment;
     QString date;
     int year{-1};
     ExtraTags extraTags;
     QStringList removedTags;
 
+    QString cuePath;
+    uint64_t cueIndex{0};
+
+    uint64_t offset{0};
+    uint64_t duration{0};
     uint64_t filesize{0};
     int bitrate{0};
     int sampleRate{0};
@@ -90,12 +94,12 @@ Track::Track(const QString& filepath)
 
 bool Track::operator==(const Track& other) const
 {
-    return filepath() == other.filepath() && hash() == other.hash();
+    return filepath() == other.filepath() && offset() == other.offset() && hash() == other.hash();
 }
 
 bool Track::operator!=(const Track& other) const
 {
-    return filepath() != other.filepath() && hash() != other.hash();
+    return !(*this == other);
 }
 
 Track::~Track()                             = default;
@@ -225,6 +229,17 @@ QString Track::filepath() const
     return p->filepath;
 }
 
+QString Track::uniqueFilepath() const
+{
+    QString path{p->filepath};
+
+    if(hasCue()) {
+        path.append(QString::number(p->offset));
+    }
+
+    return path;
+}
+
 QString Track::relativePath() const
 {
     return p->relativePath;
@@ -337,11 +352,6 @@ QString Track::performer() const
     return p->performer;
 }
 
-uint64_t Track::duration() const
-{
-    return p->duration;
-}
-
 QString Track::comment() const
 {
     return p->comment;
@@ -365,6 +375,16 @@ float Track::rating() const
 int Track::ratingStars() const
 {
     return static_cast<int>(std::floor(p->rating * MaxStarCount));
+}
+
+bool Track::hasCue() const
+{
+    return !p->cuePath.isEmpty();
+}
+
+QString Track::cuePath() const
+{
+    return p->cuePath;
 }
 
 bool Track::hasExtraTag(const QString& tag) const
@@ -403,6 +423,16 @@ QByteArray Track::serialiseExtrasTags() const
     stream << p->extraTags;
 
     return out;
+}
+
+uint64_t Track::offset() const
+{
+    return p->offset;
+}
+
+uint64_t Track::duration() const
+{
+    return p->duration;
 }
 
 uint64_t Track::fileSize() const
@@ -597,11 +627,6 @@ void Track::setPerformer(const QString& performer)
     p->performer = performer;
 }
 
-void Track::setDuration(uint64_t duration)
-{
-    p->duration = duration;
-}
-
 void Track::setComment(const QString& comment)
 {
     p->comment = comment;
@@ -679,6 +704,11 @@ QString Track::metaValue(const QString& name) const
     return extraTag(name).join(u"\037");
 }
 
+void Track::setCuePath(const QString& path)
+{
+    p->cuePath = path;
+}
+
 void Track::addExtraTag(const QString& tag, const QString& value)
 {
     if(tag.isEmpty() || value.isEmpty()) {
@@ -725,6 +755,16 @@ void Track::storeExtraTags(const QByteArray& tags)
     stream.setVersion(QDataStream::Qt_6_0);
 
     stream >> p->extraTags;
+}
+
+void Track::setOffset(uint64_t offset)
+{
+    p->offset = offset;
+}
+
+void Track::setDuration(uint64_t duration)
+{
+    p->duration = duration;
 }
 
 void Track::setFileSize(uint64_t fileSize)
@@ -832,7 +872,7 @@ QStringList Track::supportedMimeTypes()
 
 size_t qHash(const Track& track)
 {
-    return qHash(track.filepath());
+    return qHash(track.uniqueFilepath());
 }
 } // namespace Fooyin
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -115,4 +115,10 @@ target_link_libraries(
            Qt6::Widgets
            Qt6::Sql
            Qt6::Concurrent
+           ${ICU_LIBRARY_DIRS}
+)
+
+target_include_directories(
+    fooyin_utils
+    PUBLIC ${ICU_INCLUDE_DIRS}
 )

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -169,6 +169,27 @@ QString capitalise(const QString& str)
     return parts.join(u' ');
 }
 
+QByteArray detectEncoding(const QByteArray& content)
+{
+    QByteArray encoding;
+    UErrorCode status{U_ZERO_ERROR};
+
+    UCharsetDetector* csd = ucsdet_open(&status);
+    ucsdet_setText(csd, content.constData(), static_cast<int32_t>(content.length()), &status);
+
+    const UCharsetMatch* ucm = ucsdet_detect(csd, &status);
+    if(U_SUCCESS(status) && ucm) {
+        const char* cname = ucsdet_getName(ucm, &status);
+        if(U_SUCCESS(status)) {
+            encoding = QByteArray{cname};
+        }
+    }
+
+    ucsdet_close(csd);
+
+    return encoding;
+}
+
 QPixmap scalePixmap(const QPixmap& image, const QSize& size, double dpr, bool upscale)
 {
     const QSize scaledSize(static_cast<int>(size.width() * dpr), static_cast<int>(size.height() * dpr));

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -29,6 +29,8 @@
 #include <QTime>
 #include <QWidget>
 
+#include <unicode/ucsdet.h>
+
 namespace Fooyin::Utils {
 int randomNumber(int min, int max)
 {


### PR DESCRIPTION
Adds support for reading CUE files. An offset property has been added to identify a track's position in a multi-track file. Further changes were also required in the DB, as such files will have the same file path. 

ICU is now a required dependency as it's used to correctly identify the encoding of many non-UTF files which QStringConverter doesn't support.